### PR TITLE
fix: correct instruction index in calculate_size function

### DIFF
--- a/src/trading/core/execution.rs
+++ b/src/trading/core/execution.rs
@@ -106,10 +106,10 @@ impl InstructionProcessor {
     pub fn calculate_size(instructions: &[Instruction]) -> usize {
         let mut total_size = 0;
 
-        for instr in instructions {
+        for (i, instr) in instructions.iter().enumerate() {
             // 预取下一条指令
             unsafe {
-                if let Some(next_instr) = instructions.get(total_size + 1) {
+                if let Some(next_instr) = instructions.get(i + 1) {
                     BranchOptimizer::prefetch_read_data(next_instr);
                 }
             }


### PR DESCRIPTION
## Summary

This PR includes the following changes:

1. **fix: correct instruction index in calculate_size function** (7c5a8b0)
   - Corrected instruction index in calculate_size function

2. **docs: update README to use TradingClient instead of SolanaTrade** (aa0a452)  
   - Updated README to use TradingClient instead of SolanaTrade

3. **docs: Update README examples to use DexParamEnum API and add new TradeBuyParams fields** (5982f51)
   - Updated README examples to use DexParamEnum API
   - Added new fields to TradeBuyParams struct

## Changes Made
- Fixed instruction index calculation bug
- Updated documentation to reflect current API usage
- Added new fields to TradeBuyParams struct