### PR TITLE
feat: use global BloxRoute endpoint as default

### DIFF
--- a/src/constants/swqos.rs
+++ b/src/constants/swqos.rs
@@ -184,7 +184,7 @@ pub const SWQOS_ENDPOINTS_BLOX: [&str; 8] = [
     "https://tokyo.solana.dex.blxrbdn.com",
     "https://uk.solana.dex.blxrbdn.com",
     "https://la.solana.dex.blxrbdn.com",
-    "https://germany.solana.dex.blxrbdn.com",
+    "https://global.solana.dex.blxrbdn.com",
 ];
 
 pub const SWQOS_ENDPOINTS_NODE1: [&str; 8] = [


### PR DESCRIPTION
## Summary

Change the default BloxRoute endpoint from `germany.solana.dex.blxrbdn.com` to `global.solana.dex.blxrbdn.com` for better routing.

## Changes

- Updated `SWQOS_ENDPOINTS_BLOX[7]` (Default region) from germany to global endpoint