### PR TITLE
fix: cli_trading example missing {:?} format for Vec<Signature>

### DIFF
--- a/examples/cli_trading/src/main.rs
+++ b/examples/cli_trading/src/main.rs
@@ -1090,7 +1090,7 @@ async fn handle_sell_pumpswap(
     match client.sell(sell_params).await {
         Ok((_, signature, _)) => {
             println!("   ✅ Successfully sold tokens from PumpSwap!");
-            println!("   ✅ Transaction Signature: {}", signature);
+            println!("   ✅ Transaction Signature: {:?}", signature);  
         }
         Err(e) => {
             println!("   ❌ Failed to sell tokens from PumpSwap: {}", e);


### PR DESCRIPTION
In `examples/cli_trading/src/main.rs` line 1093, the print statement uses `{}` but `signature` is now `Vec<Signature>` which doesn't implement `Display`.

Error:
error[E0277]: Vec<Signature> doesn't implement std::fmt::Display

  Fix: Change `{}` to `{:?}`

  // Before
  println!("   ✅ Transaction Signature: {}", signature);

  // After
  println!("   ✅ Transaction Signature: {:?}", signature);

This was likely missed when updating the sell return type from single Signature to Vec.