### PR TITLE
swqos: fix ping task lifecycle and clone/drop safety

### DIFF
--- a/src/swqos/astralane.rs
+++ b/src/swqos/astralane.rs
@@ -25,6 +25,7 @@ pub struct AstralaneClient {
     pub http_client: Client,
     pub ping_handle: Arc<tokio::sync::Mutex<Option<JoinHandle<()>>>>,
     pub stop_ping: Arc<AtomicBool>,
+    lifecycle_guard: Arc<()>,
 }
 
 #[async_trait::async_trait]
@@ -71,23 +72,22 @@ impl AstralaneClient {
             http_client,
             ping_handle: Arc::new(tokio::sync::Mutex::new(None)),
             stop_ping: Arc::new(AtomicBool::new(false)),
+            lifecycle_guard: Arc::new(()),
         };
         
-        // Start ping task
-        let client_clone = client.clone();
-        tokio::spawn(async move {
-            client_clone.start_ping_task().await;
-        });
+        // Start ping task without cloning self (to avoid Drop side effects on clone).
+        client.spawn_ping_task();
         
         client
     }
 
     /// Start periodic ping task to keep connections active
-    async fn start_ping_task(&self) {
+    fn spawn_ping_task(&self) {
         let endpoint = self.endpoint.clone();
         let auth_token = self.auth_token.clone();
         let http_client = self.http_client.clone();
         let stop_ping = self.stop_ping.clone();
+        let ping_handle = self.ping_handle.clone();
         
         let handle = tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(60)); // Ping every 60 seconds
@@ -106,15 +106,14 @@ impl AstralaneClient {
                 }
             }
         });
-        
-        // Update ping_handle - use Mutex to safely update
-        {
-            let mut ping_guard = self.ping_handle.lock().await;
+
+        tokio::spawn(async move {
+            let mut ping_guard = ping_handle.lock().await;
             if let Some(old_handle) = ping_guard.as_ref() {
                 old_handle.abort();
             }
             *ping_guard = Some(handle);
-        }
+        });
     }
 
     /// Send ping request to /gethealth endpoint
@@ -209,18 +208,18 @@ impl AstralaneClient {
 
 impl Drop for AstralaneClient {
     fn drop(&mut self) {
+        // Only the last clone should stop the shared ping task.
+        if Arc::strong_count(&self.lifecycle_guard) != 1 {
+            return;
+        }
+
         // Ensure ping task stops when client is destroyed
         self.stop_ping.store(true, Ordering::Relaxed);
-        
-        // Try to stop ping task immediately
-        // Use tokio::spawn to avoid blocking Drop
-        let ping_handle = self.ping_handle.clone();
-        tokio::spawn(async move {
-            let mut ping_guard = ping_handle.lock().await;
-            if let Some(handle) = ping_guard.as_ref() {
+
+        if let Ok(mut ping_guard) = self.ping_handle.try_lock() {
+            if let Some(handle) = ping_guard.take() {
                 handle.abort();
             }
-            *ping_guard = None;
-        });
+        }
     }
 }

--- a/src/swqos/blockrazor.rs
+++ b/src/swqos/blockrazor.rs
@@ -25,6 +25,7 @@ pub struct BlockRazorClient {
     pub http_client: Client,
     pub ping_handle: Arc<tokio::sync::Mutex<Option<JoinHandle<()>>>>,
     pub stop_ping: Arc<AtomicBool>,
+    lifecycle_guard: Arc<()>,
 }
 
 #[async_trait::async_trait]
@@ -71,23 +72,22 @@ impl BlockRazorClient {
             http_client,
             ping_handle: Arc::new(tokio::sync::Mutex::new(None)),
             stop_ping: Arc::new(AtomicBool::new(false)),
+            lifecycle_guard: Arc::new(()),
         };
         
-        // Start ping task
-        let client_clone = client.clone();
-        tokio::spawn(async move {
-            client_clone.start_ping_task().await;
-        });
+        // Start ping task without cloning self (to avoid Drop side effects on clone).
+        client.spawn_ping_task();
         
         client
     }
 
     /// Start periodic ping task to keep connections active
-    async fn start_ping_task(&self) {
+    fn spawn_ping_task(&self) {
         let endpoint = self.endpoint.clone();
         let auth_token = self.auth_token.clone();
         let http_client = self.http_client.clone();
         let stop_ping = self.stop_ping.clone();
+        let ping_handle = self.ping_handle.clone();
         
         let handle = tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(60)); // Ping every 60 seconds
@@ -105,15 +105,14 @@ impl BlockRazorClient {
                 }
             }
         });
-        
-        // Update ping_handle - use Mutex to safely update
-        {
-            let mut ping_guard = self.ping_handle.lock().await;
+
+        tokio::spawn(async move {
+            let mut ping_guard = ping_handle.lock().await;
             if let Some(old_handle) = ping_guard.as_ref() {
                 old_handle.abort();
             }
             *ping_guard = Some(handle);
-        }
+        });
     }
 
     /// Send ping request to /health endpoint
@@ -211,18 +210,18 @@ impl BlockRazorClient {
 
 impl Drop for BlockRazorClient {
     fn drop(&mut self) {
+        // Only the last clone should stop the shared ping task.
+        if Arc::strong_count(&self.lifecycle_guard) != 1 {
+            return;
+        }
+
         // Ensure ping task stops when client is destroyed
         self.stop_ping.store(true, Ordering::Relaxed);
-        
-        // Try to stop ping task immediately
-        // Use tokio::spawn to avoid blocking Drop
-        let ping_handle = self.ping_handle.clone();
-        tokio::spawn(async move {
-            let mut ping_guard = ping_handle.lock().await;
-            if let Some(handle) = ping_guard.as_ref() {
+
+        if let Ok(mut ping_guard) = self.ping_handle.try_lock() {
+            if let Some(handle) = ping_guard.take() {
                 handle.abort();
             }
-            *ping_guard = None;
-        });
+        }
     }
 }

--- a/src/swqos/temporal.rs
+++ b/src/swqos/temporal.rs
@@ -40,6 +40,7 @@ pub struct TemporalClient {
     pub http_client: Client,
     pub ping_handle: Arc<tokio::sync::Mutex<Option<JoinHandle<()>>>>,
     pub stop_ping: Arc<AtomicBool>,
+    lifecycle_guard: Arc<()>,
 }
 
 #[async_trait::async_trait]
@@ -97,23 +98,22 @@ impl TemporalClient {
             http_client,
             ping_handle: Arc::new(tokio::sync::Mutex::new(None)),
             stop_ping: Arc::new(AtomicBool::new(false)),
+            lifecycle_guard: Arc::new(()),
         };
         
-        // Start ping task
-        let client_clone = client.clone();
-        tokio::spawn(async move {
-            client_clone.start_ping_task().await;
-        });
+        // Start ping task without cloning self (to avoid Drop side effects on clone).
+        client.spawn_ping_task();
         
         client
     }
 
     /// Start periodic ping task to keep connections active
-    async fn start_ping_task(&self) {
+    fn spawn_ping_task(&self) {
         let endpoint = self.endpoint.clone();
         let auth_token = self.auth_token.clone();
         let http_client = self.http_client.clone();
         let stop_ping = self.stop_ping.clone();
+        let ping_handle = self.ping_handle.clone();
         
         let handle = tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(60)); // Ping every 60 seconds
@@ -131,15 +131,14 @@ impl TemporalClient {
                 }
             }
         });
-        
-        // Update ping_handle - use Mutex to safely update
-        {
-            let mut ping_guard = self.ping_handle.lock().await;
+
+        tokio::spawn(async move {
+            let mut ping_guard = ping_handle.lock().await;
             if let Some(old_handle) = ping_guard.as_ref() {
                 old_handle.abort();
             }
             *ping_guard = Some(handle);
-        }
+        });
     }
 
     /// Send ping request to /ping endpoint
@@ -231,18 +230,18 @@ impl TemporalClient {
 
 impl Drop for TemporalClient {
     fn drop(&mut self) {
+        // Only the last clone should stop the shared ping task.
+        if Arc::strong_count(&self.lifecycle_guard) != 1 {
+            return;
+        }
+
         // Ensure ping task stops when client is destroyed
         self.stop_ping.store(true, Ordering::Relaxed);
-        
-        // Try to stop ping task immediately
-        // Use tokio::spawn to avoid blocking Drop
-        let ping_handle = self.ping_handle.clone();
-        tokio::spawn(async move {
-            let mut ping_guard = ping_handle.lock().await;
-            if let Some(handle) = ping_guard.as_ref() {
+
+        if let Ok(mut ping_guard) = self.ping_handle.try_lock() {
+            if let Some(handle) = ping_guard.take() {
                 handle.abort();
             }
-            *ping_guard = None;
-        });
+        }
     }
 }


### PR DESCRIPTION
Context
-------
Several SWQoS clients were managing keep-alive ping tasks in a way that depended on clone/drop ordering. In practice this can cause timing jitter and inconsistent connection warmness around high-frequency submit paths.

Root cause
----------
1. Ping startup was using a temporary client clone plus async start_ping_task(). That temporary clone participates in shared state and can trigger Drop side effects when it is destroyed.
2. Drop cleanup was scheduled via tokio::spawn and relied on async mutex locking, which makes shutdown timing non-deterministic.
3. Because stop flag and task handle are shared, dropping a non-final clone could interfere with the active ping loop.
4. StelliumClient had a separate keep_alive_running model and did not follow the same handle-tracked lifecycle pattern used by the other SWQoS clients.

What changed
------------
Applied the same lifecycle model to TemporalClient, BlockRazorClient, AstralaneClient, and Node1Client:
- Added lifecycle_guard: Arc<()>.
- Replaced async start_ping_task(&self) with sync spawn_ping_task(&self).
- Started ping from new() via client.spawn_ping_task() without cloning self.
- Captured ping_handle and updated it in a spawned lock task, aborting the previous handle before replacement.
- Updated Drop to:
  - exit early unless this is the last clone (Arc::strong_count(&lifecycle_guard) == 1),
  - set stop flag,
  - abort current ping handle synchronously via try_lock() + take().

Aligned StelliumClient with the same model:
- Replaced keep_alive_running with:
  - ping_handle: Arc<tokio::sync::Mutex<Option<JoinHandle<()>>>>,
  - stop_ping: Arc<AtomicBool>,
  - lifecycle_guard: Arc<()>.
- Added JoinHandle import.
- Added spawn_ping_task() with handle-tracking and replacement semantics.
- Updated stop_ping_task() to set stop flag and abort current handle.
- Updated Drop with last-clone guard and synchronous handle abort.

Behavioral impact
-----------------
- Prevents premature ping shutdown when short-lived clones are dropped.
- Reduces race windows in ping task lifecycle management.
- Makes shutdown behavior deterministic and clone-safe.
- Avoids spawning async cleanup work from Drop for these clients.

Non-goals / scope
-----------------
- No changes to request payloads, endpoints, auth headers, tip account selection, or transaction send logic.
- No formatting-only refactors included.

Validation notes
----------------
- Commit contains only:
  - src/swqos/temporal.rs
  - src/swqos/blockrazor.rs
  - src/swqos/astralane.rs
  - src/swqos/node1.rs
  - src/swqos/stellium.rs
- Confirmed no remaining client_clone.start_ping_task pattern and no async start_ping_task function in these files.
- Full cargo check was not completed to green due environment OpenSSL header issue (openssl/opensslconf.h missing), unrelated to this functional diff.