### PR TITLE
feat(swqos): add HelloMoon Lunar Lander provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 4. **Raydium CPMM Trading**: Support for Raydium CPMM (Concentrated Pool Market Maker) trading operations
 5. **Raydium AMM V4 Trading**: Support for Raydium AMM V4 (Automated Market Maker) trading operations
 6. **Meteora DAMM V2 Trading**: Support for Meteora DAMM V2 (Dynamic AMM) trading operations
-7. **Multiple MEV Protection**: Support for Jito, Nextblock, ZeroSlot, Temporal, Bloxroute, FlashBlock, BlockRazor, Node1, Astralane and other services
+7. **Multiple MEV Protection**: Support for Jito, Nextblock, ZeroSlot, Temporal, Bloxroute, FlashBlock, BlockRazor, Node1, Astralane, LunarLander and other services
 8. **Concurrent Trading**: Send transactions using multiple MEV services simultaneously; the fastest succeeds while others fail
 9. **Unified Trading Interface**: Use unified trading protocol enums for trading operations
 10. **Middleware System**: Support for custom instruction middleware to modify, add, or remove instructions before transaction execution
@@ -122,6 +122,7 @@ let swqos_configs: Vec<SwqosConfig> = vec![
     SwqosConfig::Bloxroute("your api_token".to_string(), SwqosRegion::Frankfurt, None),
     // Astralane: HTTP (4th param None) or QUIC (Some(SwqosTransport::Quic)); same API key
     SwqosConfig::Astralane("your_astralane_api_key".to_string(), SwqosRegion::Frankfurt, None, None), // HTTP
+    SwqosConfig::LunarLander("your_hellomoon_api_key".to_string(), SwqosRegion::Frankfurt, None),
     SwqosConfig::Astralane(
         "your_astralane_api_key".to_string(),
         SwqosRegion::Frankfurt,
@@ -351,6 +352,7 @@ You can apply for a key through the official website: [Community Website](https:
 - **BlockRazor**: High-speed transaction execution with API key authentication
 - **Node1**: High-speed transaction execution with API key authentication 
 - **Astralane**: Blockchain network acceleration (supports HTTP and QUIC; see [Astralane QUIC](#astralane-quic-low-latency) above)
+- **LunarLander**: HelloMoon transaction landing service (minimum tip: 0.001 SOL)
 
 ## 📁 Project Structure
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -69,7 +69,7 @@
 4. **Raydium CPMM 交易**: 支持 Raydium CPMM (Concentrated Pool Market Maker) 的交易操作
 5. **Raydium AMM V4 交易**: 支持 Raydium AMM V4 (Automated Market Maker) 的交易操作
 6. **Meteora DAMM V2 交易**: 支持 Meteora DAMM V2 (Dynamic AMM) 的交易操作
-7. **多种 MEV 保护**: 支持 Jito、Nextblock、ZeroSlot、Temporal、Bloxroute、FlashBlock、BlockRazor、Node1、Astralane 等服务
+7. **多种 MEV 保护**: 支持 Jito、Nextblock、ZeroSlot、Temporal、Bloxroute、FlashBlock、BlockRazor、Node1、Astralane、LunarLander 等服务
 8. **并发交易**: 同时使用多个 MEV 服务发送交易，最快的成功，其他失败
 9. **统一交易接口**: 使用统一的交易协议枚举进行交易操作
 10. **中间件系统**: 支持自定义指令中间件，可在交易执行前对指令进行修改、添加或移除
@@ -122,6 +122,7 @@ let swqos_configs: Vec<SwqosConfig> = vec![
     SwqosConfig::Bloxroute("your api_token".to_string(), SwqosRegion::Frankfurt, None),
     // Astralane：第4个参数 None 为 HTTP，Some(SwqosTransport::Quic) 为 QUIC；同一 API key
     SwqosConfig::Astralane("your_astralane_api_key".to_string(), SwqosRegion::Frankfurt, None, None), // HTTP
+    SwqosConfig::LunarLander("your_hellomoon_api_key".to_string(), SwqosRegion::Frankfurt, None),
     SwqosConfig::Astralane(
         "your_astralane_api_key".to_string(),
         SwqosRegion::Frankfurt,
@@ -350,6 +351,7 @@ SDK 不会在每次卖出时通过 RPC 拉取 creator_vault（以避免延迟）
 - **BlockRazor**: 高速交易执行，支持 API 密钥认证
 - **Node1**: 高速交易执行，支持 API 密钥认证
 - **Astralane**: 区块链网络加速（支持 HTTP 与 QUIC，见上方 [Astralane QUIC](#astralane-quic低延迟)）
+- **LunarLander**: HelloMoon 交易着陆服务（最低小费：0.001 SOL）
 
 ## 📁 项目结构
 

--- a/src/constants/swqos.rs
+++ b/src/constants/swqos.rs
@@ -155,6 +155,20 @@ pub const SPEEDLANDING_TIP_ACCOUNTS: &[Pubkey] = &[
     pubkey!("speede8xCcUq2Tiv1efXeTuE3k9TDNq8TnGKaKSc6J4"),
 ];
 
+// LunarLander (HelloMoon) tip accounts
+pub const LUNARLANDER_TIP_ACCOUNTS: &[Pubkey] = &[
+    pubkey!("moon17L6BgxXRX5uHKudAmqVF96xia9h8ygcmG2sL3F"),
+    pubkey!("moon26Sek222Md7ZydcAGxoKG832DK36CkLrS3PQY4c"),
+    pubkey!("moon7fwyajcVstMoBnVy7UBcTx87SBtNoGGAaH2Cb8V"),
+    pubkey!("moonBtH9HvLHjLqi9ivyrMVKgFUsSfrz9BwQ9khhn1u"),
+    pubkey!("moonCJg8476LNFLptX1qrK8PdRsA1HD1R6XWyu9MB93"),
+    pubkey!("moonF2sz7qwAtdETnrgxNbjonnhGGjd6r4W4UC9284s"),
+    pubkey!("moonKfftMiGSak3cezvhEqvkPSzwrmQxQHXuspC96yj"),
+    pubkey!("moonQBUKBpkifLcTd78bfxxt4PYLwmJ5admLW6cBBs8"),
+    pubkey!("moonXwpKwoVkMegt5Bc776cSW793X1irL5hHV1vJ3JA"),
+    pubkey!("moonZ6u9E2fgk6eWd82621eLPHt9zuJuYECXAYjMY1C"),
+];
+
 // NewYork,
 // Frankfurt,
 // Amsterdam,
@@ -314,6 +328,19 @@ pub const SWQOS_ENDPOINTS_SPEEDLANDING: [&str; 8] = [
     "fra.speedlanding.trade:17778",
 ];
 
+/// HelloMoon Lunar Lander: JSON-RPC sendTransaction, auth via ?api-key= query param.
+/// Region order: NewYork(NYC), Frankfurt, Amsterdam, SLC(Ashburn), Tokyo, London(→Frankfurt), LosAngeles(→NYC), Default(geolocated).
+pub const SWQOS_ENDPOINTS_LUNARLANDER: [&str; 8] = [
+    "http://nyc.lunar-lander.hellomoon.io/send",       // NewYork
+    "http://fra.lunar-lander.hellomoon.io/send",       // Frankfurt
+    "http://ams.lunar-lander.hellomoon.io/send",       // Amsterdam
+    "http://ash.lunar-lander.hellomoon.io/send",       // SLC (closest: Ashburn)
+    "http://tyo.lunar-lander.hellomoon.io/send",       // Tokyo
+    "http://fra.lunar-lander.hellomoon.io/send",       // London (fallback to Frankfurt)
+    "http://nyc.lunar-lander.hellomoon.io/send",       // LosAngeles (fallback to NYC)
+    "http://lunar-lander.hellomoon.io/send",           // Default (geolocated)
+];
+
 /// Helius Sender: POST /fast, dual routing to validators and Jito. API key optional (custom TPS only).
 /// Region order: NewYork(EWR), Frankfurt, Amsterdam, SLC, Tokyo, London, LosAngeles(SG), Default(Global).
 pub const SWQOS_ENDPOINTS_HELIUS: [&str; 8] = [
@@ -343,5 +370,6 @@ pub const SWQOS_MIN_TIP_SOYAS: f64 = 0.001; // Soyas requires minimum 0.001 SOL 
 pub const SWQOS_MIN_TIP_SPEEDLANDING: f64 = 0.001; // Speedlanding requires minimum 0.001 SOL tip
 /// Helius Sender: 0.0002 SOL when not swqos_only; use SWQOS_MIN_TIP_HELIUS_SWQOS_ONLY when swqos_only=true.
 pub const SWQOS_MIN_TIP_HELIUS: f64 = 0.0002;
+pub const SWQOS_MIN_TIP_LUNARLANDER: f64 = 0.001; // LunarLander 最低小费 0.001 SOL
 /// Helius Sender with swqos_only: minimum 0.000005 SOL (much lower tip allowed).
 pub const SWQOS_MIN_TIP_HELIUS_SWQOS_ONLY: f64 = 0.000005;

--- a/src/swqos/lunarlander.rs
+++ b/src/swqos/lunarlander.rs
@@ -1,0 +1,209 @@
+//! HelloMoon Lunar Lander SWQOS client.
+//!
+//! High-performance transaction landing service with keep-alive ping.
+//! Auth via `?api-key=` query parameter. Minimum tip: 0.001 SOL.
+
+use crate::swqos::common::{default_http_client_builder, poll_transaction_confirmation, serialize_transaction_and_encode};
+use rand::seq::IndexedRandom;
+use reqwest::Client;
+use serde_json::json;
+use std::{sync::Arc, time::Instant};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use std::time::Duration;
+use solana_transaction_status::UiTransactionEncoding;
+
+use anyhow::Result;
+use solana_sdk::transaction::VersionedTransaction;
+use crate::swqos::{SwqosType, TradeType};
+use crate::swqos::SwqosClientTrait;
+
+use crate::{common::SolanaRpcClient, constants::swqos::LUNARLANDER_TIP_ACCOUNTS};
+
+
+#[derive(Clone)]
+pub struct LunarLanderClient {
+    pub endpoint: String,
+    pub api_key: String,
+    pub rpc_client: Arc<SolanaRpcClient>,
+    pub http_client: Client,
+    stop_ping: Arc<AtomicBool>,
+}
+
+#[async_trait::async_trait]
+impl SwqosClientTrait for LunarLanderClient {
+    async fn send_transaction(&self, trade_type: TradeType, transaction: &VersionedTransaction, wait_confirmation: bool) -> Result<()> {
+        self.send_transaction(trade_type, transaction, wait_confirmation).await
+    }
+
+    async fn send_transactions(&self, trade_type: TradeType, transactions: &Vec<VersionedTransaction>, wait_confirmation: bool) -> Result<()> {
+        self.send_transactions(trade_type, transactions, wait_confirmation).await
+    }
+
+    fn get_tip_account(&self) -> Result<String> {
+        let tip_account = *LUNARLANDER_TIP_ACCOUNTS.choose(&mut rand::rng()).or_else(|| LUNARLANDER_TIP_ACCOUNTS.first()).unwrap();
+        Ok(tip_account.to_string())
+    }
+
+    fn get_swqos_type(&self) -> SwqosType {
+        SwqosType::LunarLander
+    }
+}
+
+impl LunarLanderClient {
+    /// Derive the ping URL from the send endpoint by replacing the last path segment.
+    fn ping_url(endpoint: &str, api_key: &str) -> String {
+        // Find the last '/' that is part of the path (after "://")
+        let scheme_end = endpoint.find("://").map(|i| i + 3).unwrap_or(0);
+        let base = endpoint[scheme_end..].rfind('/')
+            .map(|i| &endpoint[..scheme_end + i])
+            .unwrap_or(endpoint);
+        format!("{}/ping?api-key={}", base, api_key)
+    }
+
+    /// Derive the send URL with the API key query parameter.
+    fn send_url(endpoint: &str, api_key: &str) -> String {
+        let separator = if endpoint.contains('?') { '&' } else { '?' };
+        format!("{}{}api-key={}", endpoint, separator, api_key)
+    }
+
+    pub fn new(rpc_url: String, endpoint: String, api_key: String) -> Self {
+        let rpc_client = SolanaRpcClient::new(rpc_url);
+        let http_client = default_http_client_builder().build().unwrap();
+
+        let stop_ping = Arc::new(AtomicBool::new(false));
+
+        let client = Self {
+            rpc_client: Arc::new(rpc_client),
+            endpoint: endpoint.clone(),
+            api_key: api_key.clone(),
+            http_client: http_client.clone(),
+            stop_ping: stop_ping.clone(),
+        };
+
+        // Start ping task
+        let client_clone = client.clone();
+        tokio::spawn(async move {
+            client_clone.start_ping_task().await;
+        });
+
+        client
+    }
+
+    /// Start periodic ping task to keep connections active.
+    /// GET /ping every 30s on the same TCP connection (recommended 30-45s by HelloMoon).
+    async fn start_ping_task(&self) {
+        let ping_url = Self::ping_url(&self.endpoint, &self.api_key);
+        let http_client = self.http_client.clone();
+        let stop_ping = self.stop_ping.clone();
+
+        tokio::spawn(async move {
+            // Immediate first ping to warm connection and reduce first-submit cold start latency
+            if let Ok(resp) = http_client.get(&ping_url).timeout(Duration::from_millis(1500)).send().await {
+                let status = resp.status();
+                let _ = resp.bytes().await;
+                if !status.is_success() && crate::common::sdk_log::sdk_log_enabled() {
+                    eprintln!(" [lunarlander] ping failed with status: {}", status);
+                }
+            }
+            let mut interval = tokio::time::interval(Duration::from_secs(30));
+            loop {
+                interval.tick().await;
+                if stop_ping.load(Ordering::Relaxed) {
+                    break;
+                }
+                match http_client.get(&ping_url).timeout(Duration::from_millis(1500)).send().await {
+                    Ok(response) => {
+                        let status = response.status();
+                        let _ = response.bytes().await;
+                        if !status.is_success() && crate::common::sdk_log::sdk_log_enabled() {
+                            eprintln!(" [lunarlander] ping failed with status: {}", status);
+                        }
+                    }
+                    Err(e) => {
+                        if crate::common::sdk_log::sdk_log_enabled() {
+                            eprintln!(" [lunarlander] ping request error: {:?}", e);
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    pub async fn send_transaction(&self, trade_type: TradeType, transaction: &VersionedTransaction, wait_confirmation: bool) -> Result<()> {
+        let start_time = Instant::now();
+        let (content, signature) = serialize_transaction_and_encode(transaction, UiTransactionEncoding::Base64)?;
+
+        let request_body = serde_json::to_string(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "sendTransaction",
+            "params": [
+                content,
+                { "encoding": "base64" }
+            ]
+        }))?;
+
+        let url = Self::send_url(&self.endpoint, &self.api_key);
+
+        let response_text = self.http_client.post(&url)
+            .body(request_body)
+            .header("Content-Type", "application/json")
+            .header("Connection", "keep-alive")
+            .header("Keep-Alive", "timeout=30, max=1000")
+            .send()
+            .await?
+            .text()
+            .await?;
+
+        // Parse response
+        if let Ok(response_json) = serde_json::from_str::<serde_json::Value>(&response_text) {
+            if crate::common::sdk_log::sdk_log_enabled() {
+                if response_json.get("result").is_some() {
+                    println!(" [lunarlander] {} submitted: {:?}", trade_type, start_time.elapsed());
+                } else if let Some(error) = response_json.get("error") {
+                    eprintln!(" [lunarlander] {} submission failed: {:?}", trade_type, error);
+                }
+            }
+        } else if crate::common::sdk_log::sdk_log_enabled() {
+            eprintln!(" [lunarlander] {} submission failed: {:?}", trade_type, response_text);
+        }
+
+        let start_time: Instant = Instant::now();
+        match poll_transaction_confirmation(&self.rpc_client, signature, wait_confirmation).await {
+            Ok(_) => (),
+            Err(e) => {
+                if crate::common::sdk_log::sdk_log_enabled() {
+                    println!(" signature: {:?}", signature);
+                    println!(" [lunarlander] {} confirmation failed: {:?}", trade_type, start_time.elapsed());
+                }
+                return Err(e);
+            },
+        }
+        if wait_confirmation && crate::common::sdk_log::sdk_log_enabled() {
+            println!(" signature: {:?}", signature);
+            println!(" [lunarlander] {} confirmed: {:?}", trade_type, start_time.elapsed());
+        }
+
+        Ok(())
+    }
+
+    pub async fn send_transactions(&self, trade_type: TradeType, transactions: &Vec<VersionedTransaction>, wait_confirmation: bool) -> Result<()> {
+        for transaction in transactions {
+            self.send_transaction(trade_type, transaction, wait_confirmation).await?;
+        }
+        Ok(())
+    }
+
+    /// Stop the ping task
+    pub fn stop_ping_task(&self) {
+        self.stop_ping.store(true, Ordering::Relaxed);
+    }
+}
+
+impl Drop for LunarLanderClient {
+    fn drop(&mut self) {
+        // Stop ping task when client is dropped
+        self.stop_ping.store(true, Ordering::Relaxed);
+    }
+}

--- a/src/swqos/lunarlander.rs
+++ b/src/swqos/lunarlander.rs
@@ -207,3 +207,74 @@ impl Drop for LunarLanderClient {
         self.stop_ping.store(true, Ordering::Relaxed);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ping_url_default_endpoint() {
+        let url = LunarLanderClient::ping_url(
+            "http://nyc.lunar-lander.hellomoon.io/send",
+            "test-key",
+        );
+        assert_eq!(url, "http://nyc.lunar-lander.hellomoon.io/ping?api-key=test-key");
+    }
+
+    #[test]
+    fn test_ping_url_geolocated_endpoint() {
+        let url = LunarLanderClient::ping_url(
+            "http://lunar-lander.hellomoon.io/send",
+            "test-key",
+        );
+        assert_eq!(url, "http://lunar-lander.hellomoon.io/ping?api-key=test-key");
+    }
+
+    #[test]
+    fn test_ping_url_custom_with_nested_path() {
+        let url = LunarLanderClient::ping_url(
+            "http://proxy.example.com/v2/lunar/send",
+            "key123",
+        );
+        assert_eq!(url, "http://proxy.example.com/v2/lunar/ping?api-key=key123");
+    }
+
+    #[test]
+    fn test_ping_url_custom_pathless() {
+        // Custom URL with no path — should append /ping to the host
+        let url = LunarLanderClient::ping_url(
+            "http://proxy.example.com",
+            "key123",
+        );
+        assert_eq!(url, "http://proxy.example.com/ping?api-key=key123");
+    }
+
+    #[test]
+    fn test_send_url_simple() {
+        let url = LunarLanderClient::send_url(
+            "http://nyc.lunar-lander.hellomoon.io/send",
+            "test-key",
+        );
+        assert_eq!(url, "http://nyc.lunar-lander.hellomoon.io/send?api-key=test-key");
+    }
+
+    #[test]
+    fn test_send_url_existing_query_params() {
+        let url = LunarLanderClient::send_url(
+            "http://proxy.example.com/send?foo=bar",
+            "test-key",
+        );
+        assert_eq!(url, "http://proxy.example.com/send?foo=bar&api-key=test-key");
+    }
+
+    #[test]
+    fn test_tip_account_is_valid() {
+        // Verify the tip accounts array is non-empty and accounts parse as pubkeys
+        assert!(!LUNARLANDER_TIP_ACCOUNTS.is_empty());
+        for account in LUNARLANDER_TIP_ACCOUNTS {
+            // If these were invalid, the pubkey! macro would fail at compile time,
+            // but verify they are 32 bytes
+            assert_eq!(account.to_bytes().len(), 32);
+        }
+    }
+}

--- a/src/swqos/mod.rs
+++ b/src/swqos/mod.rs
@@ -16,6 +16,7 @@ pub mod lightspeed;
 pub mod soyas;
 pub mod speedlanding;
 pub mod helius;
+pub mod lunarlander;
 
 use std::sync::Arc;
 
@@ -57,6 +58,8 @@ use crate::{
         SWQOS_MIN_TIP_SOYAS,
         SWQOS_MIN_TIP_SPEEDLANDING,
         SWQOS_MIN_TIP_HELIUS,
+        SWQOS_ENDPOINTS_LUNARLANDER,
+        SWQOS_MIN_TIP_LUNARLANDER,
     },
     swqos::{
         bloxroute::BloxrouteClient,
@@ -74,6 +77,7 @@ use crate::{
         soyas::SoyasClient,
         speedlanding::SpeedlandingClient,
         helius::HeliusClient,
+        lunarlander::LunarLanderClient,
     }
 };
 
@@ -134,6 +138,7 @@ pub enum SwqosType {
     Soyas,
     Speedlanding,
     Helius,
+    LunarLander,
     Default,
 }
 
@@ -154,6 +159,7 @@ impl SwqosType {
             Self::Soyas,
             Self::Speedlanding,
             Self::Helius,
+            Self::LunarLander,
             Self::Default,
         ]
     }
@@ -185,6 +191,7 @@ pub trait SwqosClientTrait {
             SwqosType::Soyas => SWQOS_MIN_TIP_SOYAS,
             SwqosType::Speedlanding => SWQOS_MIN_TIP_SPEEDLANDING,
             SwqosType::Helius => SWQOS_MIN_TIP_HELIUS,
+            SwqosType::LunarLander => SWQOS_MIN_TIP_LUNARLANDER,
             SwqosType::Default => SWQOS_MIN_TIP_DEFAULT,
         }
     }
@@ -237,6 +244,9 @@ pub enum SwqosConfig {
     /// Helius Sender: dual routing to validators and Jito. API key optional (custom TPS only).
     /// (api_key, region, custom_url, swqos_only). swqos_only: None => false (min tip 0.0002 SOL); Some(true) => SWQOS-only (min tip 0.000005 SOL, much lower).
     Helius(String, SwqosRegion, Option<String>, Option<bool>),
+    /// LunarLander(api_key, region, custom_url) - HelloMoon Lunar Lander
+    /// Minimum tip: 0.001 SOL
+    LunarLander(String, SwqosRegion, Option<String>),
 }
 
 impl SwqosConfig {
@@ -257,6 +267,7 @@ impl SwqosConfig {
             SwqosConfig::Soyas(_, _, _) => SwqosType::Soyas,
             SwqosConfig::Speedlanding(_, _, _) => SwqosType::Speedlanding,
             SwqosConfig::Helius(_, _, _, _) => SwqosType::Helius,
+            SwqosConfig::LunarLander(_, _, _) => SwqosType::LunarLander,
         }
     }
 
@@ -285,6 +296,7 @@ impl SwqosConfig {
             SwqosType::Soyas => SWQOS_ENDPOINTS_SOYAS[region as usize].to_string(),
             SwqosType::Speedlanding => SWQOS_ENDPOINTS_SPEEDLANDING[region as usize].to_string(),
             SwqosType::Helius => SWQOS_ENDPOINTS_HELIUS[region as usize].to_string(),
+            SwqosType::LunarLander => SWQOS_ENDPOINTS_LUNARLANDER[region as usize].to_string(),
             SwqosType::Default => "".to_string(),
         }
     }
@@ -428,6 +440,15 @@ impl SwqosConfig {
                     swqos_only,
                 );
                 Ok(Arc::new(helius_client))
+            },
+            SwqosConfig::LunarLander(api_key, region, url) => {
+                let endpoint = SwqosConfig::get_endpoint(SwqosType::LunarLander, region, url);
+                let lunarlander_client = LunarLanderClient::new(
+                    rpc_url.clone(),
+                    endpoint.to_string(),
+                    api_key
+                );
+                Ok(Arc::new(lunarlander_client))
             },
             SwqosConfig::Default(endpoint) => {
                 let rpc = SolanaRpcClient::new_with_commitment(


### PR DESCRIPTION
## Summary

- Add HelloMoon Lunar Lander as a new SWQOS transaction landing service
- Supports 6 regional endpoints (NYC, Frankfurt, Amsterdam, Ashburn, Tokyo, geolocated) with fallback mappings for London/LA/SLC
- Auth via `?api-key=` query parameter, JSON-RPC `sendTransaction` with base64 encoding
- Background keep-alive ping task every 30s (per HelloMoon docs) with proper `AtomicBool` stop signal
- Minimum tip: 0.001 SOL (10 `moon*`-prefixed tip accounts)
- 7 unit tests covering URL derivation edge cases and tip account validity

### Files changed

- `src/swqos/lunarlander.rs` — New `LunarLanderClient` implementation (modeled on Stellium/BlockRazor patterns)
- `src/swqos/mod.rs` — `SwqosType::LunarLander`, `SwqosConfig::LunarLander`, all match arms wired
- `src/constants/swqos.rs` — Tip accounts, regional endpoints, min tip constant
- `README.md` / `README_CN.md` — Added to supported services list, usage example, provider description

### Usage

```rust
SwqosConfig::LunarLander(
    "your_hellomoon_api_key".to_string(),
    SwqosRegion::Frankfurt,
    None, // or Some("custom_url")
),
```

## Test plan

- [x] Unit tests for `ping_url` derivation (default, geolocated, nested path, pathless custom URL)
- [x] Unit tests for `send_url` (simple, existing query params)
- [x] Unit test for tip account validity
- [x] `cargo check` passes with no new warnings
- [x] Full test suite — no regressions
- [ ] End-to-end test with HelloMoon API key and funded wallet (requires live environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)