### PR TITLE
feat(swqos): add Lunar Lander provider with binary HTTP and QUIC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ arc-swap = "1.7"
 sha2 = "0.10"
 tonic-prost = "0.14.2"
 quinn = { version = "0.11", default-features = false, features = ["rustls"] }
+lunar-lander-quic-client = "0.1"
 rcgen = "0.13"
 uuid = "1.11"
 

--- a/src/constants/swqos.rs
+++ b/src/constants/swqos.rs
@@ -369,6 +369,47 @@ pub const SWQOS_ENDPOINTS_HELIUS: [&str; 8] = [
     "https://sender.helius-rpc.com/fast",
 ];
 
+/// Lunar Lander (HelloMoon) tip accounts.
+/// Apply for API key: https://docs.hellomoon.io/reference/lunar-lander
+pub const LUNARLANDER_TIP_ACCOUNTS: &[Pubkey] = &[
+    pubkey!("moon17L6BgxXRX5uHKudAmqVF96xia9h8ygcmG2sL3F"),
+    pubkey!("moon26Sek222Md7ZydcAGxoKG832DK36CkLrS3PQY4c"),
+    pubkey!("moon7fwyajcVstMoBnVy7UBcTx87SBtNoGGAaH2Cb8V"),
+    pubkey!("moonBtH9HvLHjLqi9ivyrMVKgFUsSfrz9BwQ9khhn1u"),
+    pubkey!("moonCJg8476LNFLptX1qrK8PdRsA1HD1R6XWyu9MB93"),
+    pubkey!("moonF2sz7qwAtdETnrgxNbjonnhGGjd6r4W4UC9284s"),
+    pubkey!("moonKfftMiGSak3cezvhEqvkPSzwrmQxQHXuspC96yj"),
+    pubkey!("moonQBUKBpkifLcTd78bfxxt4PYLwmJ5admLW6cBBs8"),
+    pubkey!("moonXwpKwoVkMegt5Bc776cSW793X1irL5hHV1vJ3JA"),
+    pubkey!("moonZ6u9E2fgk6eWd82621eLPHt9zuJuYECXAYjMY1C"),
+];
+
+/// Lunar Lander HTTP endpoints. Binary tx via POST /send-bin with x-api-key header.
+/// Region order: NewYork, Frankfurt, Amsterdam, SLC, Tokyo, London, LosAngeles, Default.
+pub const SWQOS_ENDPOINTS_LUNARLANDER: [&str; 8] = [
+    "http://nyc-1.prod.lunar-lander.hellomoon.io",
+    "http://fra-1.prod.lunar-lander.hellomoon.io",
+    "http://ams-1.prod.lunar-lander.hellomoon.io",
+    "http://ash-2.prod.lunar-lander.hellomoon.io", // SLC → Ashburn
+    "http://tyo-1.prod.lunar-lander.hellomoon.io",
+    "http://fra-1.prod.lunar-lander.hellomoon.io", // London → Frankfurt
+    "http://nyc-1.prod.lunar-lander.hellomoon.io", // LA → NYC
+    "http://nyc-1.prod.lunar-lander.hellomoon.io", // Default → NYC
+];
+
+/// Lunar Lander QUIC endpoints (direct, port 16888). Auth via client cert CN = API key.
+/// ALPN: b"lunar-lander-tpu". Fire-and-forget unidirectional streams.
+pub const SWQOS_ENDPOINTS_LUNARLANDER_QUIC: [&str; 8] = [
+    "nyc-1.prod.lunar-lander.hellomoon.io:16888",
+    "fra-1.prod.lunar-lander.hellomoon.io:16888",
+    "ams-1.prod.lunar-lander.hellomoon.io:16888",
+    "ash-2.prod.lunar-lander.hellomoon.io:16888", // SLC → Ashburn
+    "tyo-1.prod.lunar-lander.hellomoon.io:16888",
+    "fra-1.prod.lunar-lander.hellomoon.io:16888", // London → Frankfurt
+    "nyc-1.prod.lunar-lander.hellomoon.io:16888", // LA → NYC
+    "nyc-1.prod.lunar-lander.hellomoon.io:16888", // Default → NYC
+];
+
 pub const SWQOS_MIN_TIP_DEFAULT: f64 = 0.00001; // 其它SWQOS默认最低小费
 pub const SWQOS_MIN_TIP_JITO: f64 = 0.00001;
 pub const SWQOS_MIN_TIP_NEXTBLOCK: f64 = 0.001;
@@ -387,3 +428,4 @@ pub const SWQOS_MIN_TIP_SPEEDLANDING: f64 = 0.001; // Speedlanding requires mini
 pub const SWQOS_MIN_TIP_HELIUS: f64 = 0.0002;
 /// Helius Sender with swqos_only: minimum 0.000005 SOL (much lower tip allowed).
 pub const SWQOS_MIN_TIP_HELIUS_SWQOS_ONLY: f64 = 0.000005;
+pub const SWQOS_MIN_TIP_LUNARLANDER: f64 = 0.001;

--- a/src/swqos/lunarlander.rs
+++ b/src/swqos/lunarlander.rs
@@ -1,0 +1,290 @@
+use crate::swqos::common::{default_http_client_builder, poll_transaction_confirmation};
+use rand::seq::IndexedRandom;
+use reqwest::Client;
+use std::{sync::Arc, time::Instant};
+
+use crate::swqos::SwqosClientTrait;
+use crate::swqos::{SwqosType, TradeType};
+use anyhow::Result;
+use bincode::serialize as bincode_serialize;
+use solana_sdk::transaction::VersionedTransaction;
+use std::time::Duration;
+
+use crate::{common::SolanaRpcClient, constants::swqos::LUNARLANDER_TIP_ACCOUNTS};
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use tokio::task::JoinHandle;
+
+use lunar_lander_quic_client::LunarLanderQuicClient;
+use tokio::sync::Mutex;
+
+#[derive(Clone)]
+pub enum LunarLanderBackend {
+    Http {
+        endpoint: String,
+        auth_token: String,
+        http_client: Client,
+        ping_handle: Arc<tokio::sync::Mutex<Option<JoinHandle<()>>>>,
+        stop_ping: Arc<AtomicBool>,
+    },
+    Quic(Arc<Mutex<LunarLanderQuicClient>>),
+}
+
+#[derive(Clone)]
+pub struct LunarLanderClient {
+    pub rpc_client: Arc<SolanaRpcClient>,
+    backend: LunarLanderBackend,
+}
+
+#[async_trait::async_trait]
+impl SwqosClientTrait for LunarLanderClient {
+    async fn send_transaction(
+        &self,
+        trade_type: TradeType,
+        transaction: &VersionedTransaction,
+        wait_confirmation: bool,
+    ) -> Result<()> {
+        self.send_transaction_impl(trade_type, transaction, wait_confirmation).await
+    }
+
+    async fn send_transactions(
+        &self,
+        trade_type: TradeType,
+        transactions: &Vec<VersionedTransaction>,
+        wait_confirmation: bool,
+    ) -> Result<()> {
+        for transaction in transactions {
+            self.send_transaction_impl(trade_type, transaction, wait_confirmation).await?;
+        }
+        Ok(())
+    }
+
+    fn get_tip_account(&self) -> Result<String> {
+        let tip_account = *LUNARLANDER_TIP_ACCOUNTS
+            .choose(&mut rand::rng())
+            .or_else(|| LUNARLANDER_TIP_ACCOUNTS.first())
+            .unwrap();
+        Ok(tip_account.to_string())
+    }
+
+    fn get_swqos_type(&self) -> SwqosType {
+        SwqosType::LunarLander
+    }
+}
+
+impl LunarLanderClient {
+    /// Create an HTTP binary client (POST /send-bin with bincode body).
+    pub fn new(rpc_url: String, endpoint: String, auth_token: String) -> Self {
+        let rpc_client = SolanaRpcClient::new(rpc_url);
+        let http_client = default_http_client_builder().build().unwrap();
+        let ping_handle = Arc::new(tokio::sync::Mutex::new(None));
+        let stop_ping = Arc::new(AtomicBool::new(false));
+
+        let client = Self {
+            rpc_client: Arc::new(rpc_client),
+            backend: LunarLanderBackend::Http {
+                endpoint,
+                auth_token,
+                http_client,
+                ping_handle,
+                stop_ping,
+            },
+        };
+        let client_clone = client.clone();
+        tokio::spawn(async move {
+            client_clone.start_ping_task().await;
+        });
+        client
+    }
+
+    /// Create a QUIC client (port 16888, cert CN = api_key, fire-and-forget unidirectional streams).
+    pub async fn new_quic(rpc_url: String, quic_endpoint: &str, api_key: String) -> Result<Self> {
+        let rpc_client = SolanaRpcClient::new(rpc_url);
+        let quic_client = LunarLanderQuicClient::connect(quic_endpoint, &api_key).await?;
+        Ok(Self {
+            rpc_client: Arc::new(rpc_client),
+            backend: LunarLanderBackend::Quic(Arc::new(Mutex::new(quic_client))),
+        })
+    }
+
+    async fn start_ping_task(&self) {
+        match &self.backend {
+            LunarLanderBackend::Http {
+                endpoint,
+                auth_token,
+                http_client,
+                ping_handle,
+                stop_ping,
+            } => {
+                let endpoint = endpoint.clone();
+                let auth_token = auth_token.clone();
+                let http_client = http_client.clone();
+                let ping_handle = ping_handle.clone();
+                let stop_ping = stop_ping.clone();
+                let handle = tokio::spawn(async move {
+                    // Immediate first ping to warm connection
+                    let _ = Self::send_ping_request(&http_client, &endpoint, &auth_token).await;
+                    let mut interval = tokio::time::interval(Duration::from_secs(30));
+                    loop {
+                        interval.tick().await;
+                        if stop_ping.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        if let Err(e) =
+                            Self::send_ping_request(&http_client, &endpoint, &auth_token).await
+                        {
+                            if crate::common::sdk_log::sdk_log_enabled() {
+                                eprintln!("LunarLander ping request failed: {}", e);
+                            }
+                        }
+                    }
+                });
+                let mut guard = ping_handle.lock().await;
+                if let Some(old) = guard.as_ref() {
+                    old.abort();
+                }
+                *guard = Some(handle);
+            }
+            LunarLanderBackend::Quic(_) => {}
+        }
+    }
+
+    /// GET {endpoint}/ping for HTTP keepalive.
+    async fn send_ping_request(
+        http_client: &Client,
+        endpoint: &str,
+        auth_token: &str,
+    ) -> Result<()> {
+        let url = format!("{}/ping", endpoint);
+        let response = http_client
+            .get(&url)
+            .header("x-api-key", auth_token)
+            .timeout(Duration::from_millis(1500))
+            .send()
+            .await?;
+        let _ = response.bytes().await;
+        Ok(())
+    }
+
+    async fn send_transaction_impl(
+        &self,
+        trade_type: TradeType,
+        transaction: &VersionedTransaction,
+        wait_confirmation: bool,
+    ) -> Result<()> {
+        let start_time = Instant::now();
+        let signature = transaction.signatures[0];
+        let body_bytes = bincode_serialize(transaction)
+            .map_err(|e| anyhow::anyhow!("LunarLander binary serialize failed: {}", e))?;
+
+        match &self.backend {
+            LunarLanderBackend::Http { endpoint, auth_token, http_client, .. } => {
+                let url = format!("{}/send-bin", endpoint);
+                let response = http_client
+                    .post(&url)
+                    .header("x-api-key", auth_token)
+                    .header("Content-Type", "application/octet-stream")
+                    .body(body_bytes)
+                    .send()
+                    .await?;
+                let status = response.status();
+                let _ = response.bytes().await;
+                if status.is_success() {
+                    if crate::common::sdk_log::sdk_log_enabled() {
+                        crate::common::sdk_log::log_swqos_submitted(
+                            "LunarLander",
+                            trade_type,
+                            start_time.elapsed(),
+                        );
+                    }
+                } else {
+                    if crate::common::sdk_log::sdk_log_enabled() {
+                        crate::common::sdk_log::log_swqos_submission_failed(
+                            "LunarLander",
+                            trade_type,
+                            start_time.elapsed(),
+                            format!("status {}", status),
+                        );
+                    }
+                    return Err(anyhow::anyhow!("LunarLander sendTransaction failed: {}", status));
+                }
+            }
+            LunarLanderBackend::Quic(quic) => {
+                let send_result = {
+                    let client = quic.lock().await;
+                    client.send_transaction(&body_bytes).await
+                };
+                if let Err(e) = send_result {
+                    // Attempt reconnect on failure
+                    let mut client = quic.lock().await;
+                    if let Err(re) = client.reconnect().await {
+                        if crate::common::sdk_log::sdk_log_enabled() {
+                            crate::common::sdk_log::log_swqos_submission_failed(
+                                "LunarLander",
+                                trade_type,
+                                start_time.elapsed(),
+                                format!("QUIC send failed: {}, reconnect failed: {}", e, re),
+                            );
+                        }
+                    }
+                    return Err(anyhow::anyhow!("LunarLander QUIC send failed: {}", e));
+                }
+                if crate::common::sdk_log::sdk_log_enabled() {
+                    crate::common::sdk_log::log_swqos_submitted(
+                        "LunarLander",
+                        trade_type,
+                        start_time.elapsed(),
+                    );
+                }
+            }
+        }
+
+        let start_time = Instant::now();
+        match poll_transaction_confirmation(&self.rpc_client, signature, wait_confirmation).await {
+            Ok(_) => (),
+            Err(e) => {
+                if crate::common::sdk_log::sdk_log_enabled() {
+                    println!(" signature: {:?}", signature);
+                    println!(
+                        " [{:width$}] {} confirmation failed: {:?}",
+                        "LunarLander",
+                        trade_type,
+                        start_time.elapsed(),
+                        width = crate::common::sdk_log::SWQOS_LABEL_WIDTH
+                    );
+                }
+                return Err(e);
+            }
+        }
+        if wait_confirmation && crate::common::sdk_log::sdk_log_enabled() {
+            println!(" signature: {:?}", signature);
+            println!(
+                " [{:width$}] {} confirmed: {:?}",
+                "LunarLander",
+                trade_type,
+                start_time.elapsed(),
+                width = crate::common::sdk_log::SWQOS_LABEL_WIDTH
+            );
+        }
+        Ok(())
+    }
+}
+
+impl Drop for LunarLanderClient {
+    fn drop(&mut self) {
+        match &self.backend {
+            LunarLanderBackend::Http { stop_ping, ping_handle, .. } => {
+                stop_ping.store(true, Ordering::Relaxed);
+                let ping_handle = ping_handle.clone();
+                tokio::spawn(async move {
+                    let mut guard = ping_handle.lock().await;
+                    if let Some(handle) = guard.as_ref() {
+                        handle.abort();
+                    }
+                    *guard = None;
+                });
+            }
+            LunarLanderBackend::Quic(_) => {}
+        }
+    }
+}

--- a/src/swqos/mod.rs
+++ b/src/swqos/mod.rs
@@ -7,6 +7,7 @@ pub mod flashblock;
 pub mod helius;
 pub mod jito;
 pub mod lightspeed;
+pub mod lunarlander;
 pub mod nextblock;
 pub mod node1;
 pub mod node1_quic;
@@ -31,12 +32,13 @@ use crate::{
     constants::swqos::{
         SWQOS_ENDPOINTS_ASTRALANE, SWQOS_ENDPOINTS_ASTRALANE_QUIC, SWQOS_ENDPOINTS_BLOCKRAZOR,
         SWQOS_ENDPOINTS_BLOCKRAZOR_GRPC, SWQOS_ENDPOINTS_BLOX, SWQOS_ENDPOINTS_FLASHBLOCK,
-        SWQOS_ENDPOINTS_HELIUS, SWQOS_ENDPOINTS_JITO, SWQOS_ENDPOINTS_NEXTBLOCK,
-        SWQOS_ENDPOINTS_NODE1, SWQOS_ENDPOINTS_NODE1_QUIC, SWQOS_ENDPOINTS_SOYAS,
-        SWQOS_ENDPOINTS_SPEEDLANDING, SWQOS_ENDPOINTS_STELLIUM, SWQOS_ENDPOINTS_TEMPORAL,
-        SWQOS_ENDPOINTS_ZERO_SLOT, SWQOS_MIN_TIP_ASTRALANE, SWQOS_MIN_TIP_BLOCKRAZOR,
-        SWQOS_MIN_TIP_BLOXROUTE, SWQOS_MIN_TIP_DEFAULT, SWQOS_MIN_TIP_FLASHBLOCK,
-        SWQOS_MIN_TIP_HELIUS, SWQOS_MIN_TIP_JITO, SWQOS_MIN_TIP_LIGHTSPEED,
+        SWQOS_ENDPOINTS_HELIUS, SWQOS_ENDPOINTS_JITO, SWQOS_ENDPOINTS_LUNARLANDER,
+        SWQOS_ENDPOINTS_LUNARLANDER_QUIC, SWQOS_ENDPOINTS_NEXTBLOCK, SWQOS_ENDPOINTS_NODE1,
+        SWQOS_ENDPOINTS_NODE1_QUIC, SWQOS_ENDPOINTS_SOYAS, SWQOS_ENDPOINTS_SPEEDLANDING,
+        SWQOS_ENDPOINTS_STELLIUM, SWQOS_ENDPOINTS_TEMPORAL, SWQOS_ENDPOINTS_ZERO_SLOT,
+        SWQOS_MIN_TIP_ASTRALANE, SWQOS_MIN_TIP_BLOCKRAZOR, SWQOS_MIN_TIP_BLOXROUTE,
+        SWQOS_MIN_TIP_DEFAULT, SWQOS_MIN_TIP_FLASHBLOCK, SWQOS_MIN_TIP_HELIUS,
+        SWQOS_MIN_TIP_JITO, SWQOS_MIN_TIP_LIGHTSPEED, SWQOS_MIN_TIP_LUNARLANDER,
         SWQOS_MIN_TIP_NEXTBLOCK, SWQOS_MIN_TIP_NODE1, SWQOS_MIN_TIP_SOYAS,
         SWQOS_MIN_TIP_SPEEDLANDING, SWQOS_MIN_TIP_STELLIUM, SWQOS_MIN_TIP_TEMPORAL,
         SWQOS_MIN_TIP_ZERO_SLOT,
@@ -44,10 +46,10 @@ use crate::{
     swqos::{
         astralane::AstralaneClient, blockrazor::BlockRazorClient, bloxroute::BloxrouteClient,
         flashblock::FlashBlockClient, helius::HeliusClient, jito::JitoClient,
-        lightspeed::LightspeedClient, nextblock::NextBlockClient, node1::Node1Client,
-        node1_quic::Node1QuicClient, solana_rpc::SolRpcClient, soyas::SoyasClient,
-        speedlanding::SpeedlandingClient, stellium::StelliumClient, temporal::TemporalClient,
-        zeroslot::ZeroSlotClient,
+        lightspeed::LightspeedClient, lunarlander::LunarLanderClient,
+        nextblock::NextBlockClient, node1::Node1Client, node1_quic::Node1QuicClient,
+        solana_rpc::SolRpcClient, soyas::SoyasClient, speedlanding::SpeedlandingClient,
+        stellium::StelliumClient, temporal::TemporalClient, zeroslot::ZeroSlotClient,
     },
 };
 
@@ -111,6 +113,7 @@ pub enum SwqosType {
     Soyas,
     Speedlanding,
     Helius,
+    LunarLander,
     Default,
 }
 
@@ -133,6 +136,7 @@ impl SwqosType {
             Self::Soyas => "Soyas",
             Self::Speedlanding => "Speedlanding",
             Self::Helius => "Helius",
+            Self::LunarLander => "LunarLander",
             Self::Default => "Default",
         }
     }
@@ -153,6 +157,7 @@ impl SwqosType {
             Self::Soyas,
             Self::Speedlanding,
             Self::Helius,
+            Self::LunarLander,
             Self::Default,
         ]
     }
@@ -194,6 +199,7 @@ pub trait SwqosClientTrait {
             SwqosType::Soyas => SWQOS_MIN_TIP_SOYAS,
             SwqosType::Speedlanding => SWQOS_MIN_TIP_SPEEDLANDING,
             SwqosType::Helius => SWQOS_MIN_TIP_HELIUS,
+            SwqosType::LunarLander => SWQOS_MIN_TIP_LUNARLANDER,
             SwqosType::Default => SWQOS_MIN_TIP_DEFAULT,
         }
     }
@@ -246,6 +252,10 @@ pub enum SwqosConfig {
     /// Helius Sender: dual routing to validators and Jito. API key optional (custom TPS only).
     /// (api_key, region, custom_url, swqos_only). swqos_only: None => false (min tip 0.0002 SOL); Some(true) => SWQOS-only (min tip 0.000005 SOL, much lower).
     Helius(String, SwqosRegion, Option<String>, Option<bool>),
+    /// Lunar Lander (HelloMoon): binary tx via HTTP POST /send-bin or QUIC (port 16888).
+    /// (api_key, region, custom_url, transport). transport=None => HTTP; Some(Quic) => QUIC.
+    /// Minimum tip: 0.001 SOL. Apply for API key: https://docs.hellomoon.io/reference/lunar-lander
+    LunarLander(String, SwqosRegion, Option<String>, Option<SwqosTransport>),
 }
 
 impl SwqosConfig {
@@ -266,6 +276,7 @@ impl SwqosConfig {
             SwqosConfig::Soyas(_, _, _) => SwqosType::Soyas,
             SwqosConfig::Speedlanding(_, _, _) => SwqosType::Speedlanding,
             SwqosConfig::Helius(_, _, _, _) => SwqosType::Helius,
+            SwqosConfig::LunarLander(_, _, _, _) => SwqosType::LunarLander,
         }
     }
 
@@ -294,6 +305,7 @@ impl SwqosConfig {
             SwqosType::Soyas => SWQOS_ENDPOINTS_SOYAS[region as usize].to_string(),
             SwqosType::Speedlanding => SWQOS_ENDPOINTS_SPEEDLANDING[region as usize].to_string(),
             SwqosType::Helius => SWQOS_ENDPOINTS_HELIUS[region as usize].to_string(),
+            SwqosType::LunarLander => SWQOS_ENDPOINTS_LUNARLANDER[region as usize].to_string(),
             SwqosType::Default => "".to_string(),
         }
     }
@@ -332,6 +344,14 @@ impl SwqosConfig {
                     SWQOS_ENDPOINTS_ASTRALANE_QUIC[region as usize].to_string()
                 } else {
                     SWQOS_ENDPOINTS_ASTRALANE[region as usize].to_string()
+                }
+            }
+            SwqosType::LunarLander => {
+                let use_quic = transport.map_or(false, |t| t == SwqosTransport::Quic);
+                if use_quic {
+                    SWQOS_ENDPOINTS_LUNARLANDER_QUIC[region as usize].to_string()
+                } else {
+                    SWQOS_ENDPOINTS_LUNARLANDER[region as usize].to_string()
                 }
             }
             _ => Self::get_endpoint(swqos_type, region, url),
@@ -459,6 +479,23 @@ impl SwqosConfig {
                 let helius_client =
                     HeliusClient::new(rpc_url.clone(), endpoint, api_key_opt, swqos_only);
                 Ok(Arc::new(helius_client))
+            }
+            SwqosConfig::LunarLander(api_key, region, url, transport) => {
+                let use_quic = transport.map_or(false, |t| t == SwqosTransport::Quic);
+                if use_quic {
+                    let quic_endpoint = url.unwrap_or_else(|| {
+                        SWQOS_ENDPOINTS_LUNARLANDER_QUIC[region as usize].to_string()
+                    });
+                    let lunarlander_client =
+                        LunarLanderClient::new_quic(rpc_url.clone(), &quic_endpoint, api_key)
+                            .await?;
+                    Ok(Arc::new(lunarlander_client))
+                } else {
+                    let endpoint = SwqosConfig::get_endpoint(SwqosType::LunarLander, region, url);
+                    let lunarlander_client =
+                        LunarLanderClient::new(rpc_url.clone(), endpoint, api_key);
+                    Ok(Arc::new(lunarlander_client))
+                }
             }
             SwqosConfig::Default(endpoint) => {
                 let rpc = SolanaRpcClient::new_with_commitment(endpoint, commitment);


### PR DESCRIPTION
## Summary

- Adds HelloMoon Lunar Lander as a SWQoS provider with dual transport support
- **HTTP binary mode**: POST `/send-bin` with bincode body, `x-api-key` header auth, 30s keepalive ping
- **QUIC mode** (opt-in): port 16888 via [`lunar-lander-quic-client`](https://crates.io/crates/lunar-lander-quic-client) crate, fire-and-forget unidirectional streams, auto-reconnect on failure
- Follows the Astralane dual-transport pattern: `SwqosConfig::LunarLander(api_key, region, custom_url, Option<SwqosTransport>)`
- 10 moon-prefix tip accounts, 0.001 SOL minimum tip
- Regional endpoints: NYC, Frankfurt, Amsterdam, Ashburn, Tokyo

## Usage

```rust
// HTTP binary (default)
SwqosConfig::LunarLander("your-api-key".into(), SwqosRegion::Frankfurt, None, None)

// QUIC (opt-in)
SwqosConfig::LunarLander("your-api-key".into(), SwqosRegion::Frankfurt, None, Some(SwqosTransport::Quic))
```

API keys: https://docs.hellomoon.io/reference/lunar-lander