### PR TITLE
feat(swqos): default Lunar Lander to QUIC

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,13 +161,13 @@ let swqos_configs: Vec<SwqosConfig> = vec![
     // Astralane: 4th param = AstralaneTransport — Binary (default), Plain (/iris), or Quic
     SwqosConfig::Astralane("your_astralane_api_key".to_string(), SwqosRegion::Frankfurt, None, None), // Binary HTTP /irisb
     SwqosConfig::SpeedLanding("your api_token".to_string(), SwqosRegion::Frankfurt, None),
-    // Lunar Lander: 4th param None = binary HTTP; Some(SwqosTransport::Quic) = QUIC
+    // Lunar Lander: 4th param None = QUIC (default); Some(SwqosTransport::Http) = binary HTTP
     SwqosConfig::LunarLander("your_hellomoon_api_key".to_string(), SwqosRegion::Frankfurt, None, None),
     SwqosConfig::LunarLander(
         "your_hellomoon_api_key".to_string(),
         SwqosRegion::Frankfurt,
         None,
-        Some(SwqosTransport::Quic),
+        Some(SwqosTransport::Http),
     ),
 ];
 // Create TradeConfig instance

--- a/README_CN.md
+++ b/README_CN.md
@@ -161,13 +161,13 @@ let swqos_configs: Vec<SwqosConfig> = vec![
     // Astralane：第4个参数为 AstralaneTransport — Binary（默认）、Plain（/iris）或 Quic
     SwqosConfig::Astralane("your_astralane_api_key".to_string(), SwqosRegion::Frankfurt, None, None), // Binary /irisb
     SwqosConfig::SpeedLanding("your api_token".to_string(), SwqosRegion::Frankfurt, None),
-    // Lunar Lander：第4个参数 None 为 binary HTTP；Some(SwqosTransport::Quic) 为 QUIC
+    // Lunar Lander：第4个参数 None 为 QUIC（默认）；Some(SwqosTransport::Http) 为 binary HTTP
     SwqosConfig::LunarLander("your_hellomoon_api_key".to_string(), SwqosRegion::Frankfurt, None, None),
     SwqosConfig::LunarLander(
         "your_hellomoon_api_key".to_string(),
         SwqosRegion::Frankfurt,
         None,
-        Some(SwqosTransport::Quic),
+        Some(SwqosTransport::Http),
     ),
 ];
 // 创建 TradeConfig 实例

--- a/src/swqos/mod.rs
+++ b/src/swqos/mod.rs
@@ -277,8 +277,8 @@ pub enum SwqosConfig {
     Helius(String, SwqosRegion, Option<String>, Option<bool>),
     /// Solami(api_key, region, custom_url)
     Solami(String, SwqosRegion, Option<String>),
-    /// Lunar Lander (HelloMoon): binary tx via HTTP POST /send-bin or QUIC (port 16888).
-    /// (api_key, region, custom_url, transport). transport=None => HTTP; Some(Quic) => QUIC.
+    /// Lunar Lander (HelloMoon): binary tx via QUIC (port 16888) or HTTP POST /send-bin.
+    /// (api_key, region, custom_url, transport). transport=None => QUIC; Some(Http) => HTTP.
     /// Minimum tip: 0.001 SOL. Apply for API key: https://docs.hellomoon.io/reference/lunar-lander
     LunarLander(String, SwqosRegion, Option<String>, Option<SwqosTransport>),
 }
@@ -367,7 +367,7 @@ impl SwqosConfig {
                 }
             }
             SwqosType::LunarLander => {
-                let use_quic = transport.map_or(false, |t| t == SwqosTransport::Quic);
+                let use_quic = transport.unwrap_or(SwqosTransport::Quic) == SwqosTransport::Quic;
                 if use_quic {
                     SWQOS_ENDPOINTS_LUNARLANDER_QUIC[region as usize].to_string()
                 } else {
@@ -548,7 +548,7 @@ impl SwqosConfig {
                 Ok(Arc::new(solami_client))
             }
             SwqosConfig::LunarLander(api_key, region, url, transport) => {
-                let use_quic = transport.map_or(false, |t| t == SwqosTransport::Quic);
+                let use_quic = transport.unwrap_or(SwqosTransport::Quic) == SwqosTransport::Quic;
                 if use_quic {
                     let quic_endpoint = url.unwrap_or_else(|| {
                         SWQOS_ENDPOINTS_LUNARLANDER_QUIC[region as usize].to_string()
@@ -574,5 +574,36 @@ impl SwqosConfig {
                 Ok(Arc::new(rpc_client))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lunarlander_defaults_to_quic_endpoint() {
+        let endpoint = SwqosConfig::get_endpoint_with_transport(
+            SwqosType::LunarLander,
+            SwqosRegion::Frankfurt,
+            None,
+            None,
+            false,
+        );
+
+        assert_eq!(endpoint, SWQOS_ENDPOINTS_LUNARLANDER_QUIC[SwqosRegion::Frankfurt as usize]);
+    }
+
+    #[test]
+    fn lunarlander_http_transport_uses_binary_http_endpoint() {
+        let endpoint = SwqosConfig::get_endpoint_with_transport(
+            SwqosType::LunarLander,
+            SwqosRegion::Frankfurt,
+            None,
+            Some(SwqosTransport::Http),
+            false,
+        );
+
+        assert_eq!(endpoint, SWQOS_ENDPOINTS_LUNARLANDER[SwqosRegion::Frankfurt as usize]);
     }
 }


### PR DESCRIPTION
## Summary

- use QUIC when the Lunar Lander transport is omitted
- retain explicit binary HTTP support with `Some(SwqosTransport::Http)`
- update English and Chinese configuration examples
- add endpoint-selection regression tests

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --lib` (135 passed, 0 failed, 2 ignored)