### PR TITLE
docs: fix README example imports so the SWQoS and trading snippets compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ For detailed information about all trading parameters, see the [Trading Paramete
 
 ```rust
 use sol_trade_sdk::{
-    AccountPolicy, BuyAmount, DexType, SimpleBuyParams, TradeTokenType,
+    AccountPolicy, BuyAmount, trading::factory::DexType, SimpleBuyParams, TradeTokenType,
     trading::core::params::DexParamEnum,
 };
 
@@ -381,7 +381,7 @@ client.buy_simple(buy_params).await?;
 Astralane supports **Binary** HTTP (`/irisb`), **Plain** HTTP (`/iris`), and **QUIC** (`host:7000`, or `:9000` when global `mev_protection` is true). Pass `Some(AstralaneTransport::Plain)`, `Some(AstralaneTransport::Quic)`, or use `None` / omit for **Binary** (default). Global `mev_protection` adds `mev-protect=true` on HTTP or selects QUIC port 9000.
 
 ```rust
-use sol_trade_sdk::{SwqosConfig, SwqosRegion, AstralaneTransport};
+use sol_trade_sdk::{swqos::{SwqosConfig, SwqosRegion}, AstralaneTransport};
 
 let swqos_configs: Vec<SwqosConfig> = vec![
     SwqosConfig::Default(rpc_url.clone()),


### PR DESCRIPTION
While going through the README examples I noticed two of them import types from the crate root that are only exported from their modules, so copying the snippets into a project fails to compile with `E0432` (unresolved import).

The SWQoS example imports `SwqosConfig` and `SwqosRegion` from `sol_trade_sdk` directly, but `src/lib.rs` only re-exports `AstralaneTransport` and `SwqosTransport` from `swqos`. Both types are defined in the `swqos` module (`src/swqos/mod.rs`), so this imports them as `swqos::{SwqosConfig, SwqosRegion}`.

The trading example imports `DexType` from the crate root, but it is defined in `trading::factory` (`src/trading/factory.rs`) and is not re-exported at the root. This qualifies it as `trading::factory::DexType`, which also matches how the same import block already pulls in `trading::core::params::DexParamEnum`.

`AstralaneTransport` is left as-is since it is exported at the crate root. Docs-only change, no code touched.
