### PR TITLE
fix(bonk): clamp slippage to MAX_SLIPPAGE_BASIS_POINTS

### DIFF
--- a/src/instruction/utils/bonk.rs
+++ b/src/instruction/utils/bonk.rs
@@ -1,6 +1,7 @@
 use crate::{
     common::SolanaRpcClient,
     instruction::utils::bonk_types::{pool_state_decode, PoolState},
+    utils::calc::common::clamp_slippage_basis_points_u128,
 };
 use anyhow::anyhow;
 use solana_sdk::pubkey::Pubkey;
@@ -105,9 +106,10 @@ pub fn get_amount_in(
     slippage_basis_points: u128,
 ) -> u64 {
     let amount_out_u128 = amount_out as u128;
+    let bps = clamp_slippage_basis_points_u128(slippage_basis_points);
 
     // Consider slippage, actual required output amount is higher
-    let amount_out_with_slippage = amount_out_u128 * 10000 / (10000 - slippage_basis_points);
+    let amount_out_with_slippage = amount_out_u128 * 10000 / (10000 - bps);
 
     let input_reserve = virtual_quote.checked_add(real_quote).unwrap();
     let output_reserve = virtual_base.checked_sub(real_base).unwrap();
@@ -137,6 +139,7 @@ pub fn get_amount_out(
     slippage_basis_points: u128,
 ) -> u64 {
     let amount_in_u128 = amount_in as u128;
+    let bps = clamp_slippage_basis_points_u128(slippage_basis_points);
     let protocol_fee = (amount_in_u128 * protocol_fee_rate / 10000) as u128;
     let platform_fee = (amount_in_u128 * platform_fee_rate / 10000) as u128;
     let share_fee = (amount_in_u128 * share_fee_rate / 10000) as u128;
@@ -153,7 +156,7 @@ pub fn get_amount_out(
     let denominator = input_reserve.checked_add(amount_in_net).unwrap();
     let mut amount_out = numerator.checked_div(denominator).unwrap();
 
-    amount_out = amount_out - (amount_out * slippage_basis_points) / 10000;
+    amount_out = amount_out - (amount_out * bps) / 10000;
     amount_out as u64
 }
 
@@ -194,4 +197,69 @@ pub fn get_creator_associated_account(creator: &Pubkey) -> Option<Pubkey> {
     let program_id: &Pubkey = &accounts::BONK;
     let pda: Option<(Pubkey, u8)> = Pubkey::try_find_program_address(seeds, program_id);
     pda.map(|pubkey| pubkey.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::calc::common::MAX_SLIPPAGE_BASIS_POINTS;
+
+    const VIRTUAL_BASE: u128 = 1_073_025_605_596_382;
+    const VIRTUAL_QUOTE: u128 = 30_000_852_951;
+
+    #[test]
+    fn get_amount_in_at_10000_bps_does_not_divide_by_zero() {
+        let amount = get_amount_in(
+            1_000_000,
+            accounts::PROTOCOL_FEE_RATE,
+            accounts::PLATFORM_FEE_RATE,
+            accounts::SHARE_FEE_RATE,
+            VIRTUAL_BASE,
+            VIRTUAL_QUOTE,
+            0,
+            0,
+            10_000,
+        );
+        let clamped = get_amount_in(
+            1_000_000,
+            accounts::PROTOCOL_FEE_RATE,
+            accounts::PLATFORM_FEE_RATE,
+            accounts::SHARE_FEE_RATE,
+            VIRTUAL_BASE,
+            VIRTUAL_QUOTE,
+            0,
+            0,
+            MAX_SLIPPAGE_BASIS_POINTS as u128,
+        );
+        assert_eq!(amount, clamped);
+        assert!(amount > 0);
+    }
+
+    #[test]
+    fn get_amount_out_at_10000_bps_does_not_zero_min_out() {
+        let amount = get_amount_out(
+            1_000_000,
+            accounts::PROTOCOL_FEE_RATE,
+            accounts::PLATFORM_FEE_RATE,
+            accounts::SHARE_FEE_RATE,
+            VIRTUAL_BASE,
+            VIRTUAL_QUOTE,
+            0,
+            0,
+            10_000,
+        );
+        let clamped = get_amount_out(
+            1_000_000,
+            accounts::PROTOCOL_FEE_RATE,
+            accounts::PLATFORM_FEE_RATE,
+            accounts::SHARE_FEE_RATE,
+            VIRTUAL_BASE,
+            VIRTUAL_QUOTE,
+            0,
+            0,
+            MAX_SLIPPAGE_BASIS_POINTS as u128,
+        );
+        assert_eq!(amount, clamped);
+        assert!(amount > 0);
+    }
 }

--- a/src/utils/calc/bonk.rs
+++ b/src/utils/calc/bonk.rs
@@ -1,5 +1,7 @@
 use crate::instruction::utils::bonk::accounts;
 
+use super::common::clamp_slippage_basis_points_u128;
+
 /// Calculates the amount of tokens to receive when buying with SOL
 ///
 /// This function implements the constant product formula (x * y = k) for token swaps,
@@ -12,7 +14,8 @@ use crate::instruction::utils::bonk::accounts;
 /// * `virtual_quote` - Virtual quote token (SOL) reserves
 /// * `real_base` - Real base token reserves
 /// * `real_quote` - Real quote token (SOL) reserves
-/// * `slippage_basis_points` - Maximum slippage tolerance in basis points (e.g., 100 = 1%)
+/// * `slippage_basis_points` - Maximum slippage tolerance in basis points (e.g., 100 = 1%).
+///   Clamped to [`MAX_SLIPPAGE_BASIS_POINTS`](super::common::MAX_SLIPPAGE_BASIS_POINTS) (9999 = 99.99%).
 ///
 /// # Returns
 ///
@@ -26,6 +29,7 @@ pub fn get_buy_token_amount_from_sol_amount(
     slippage_basis_points: u128,
 ) -> u64 {
     let amount_in_u128 = amount_in as u128;
+    let bps = clamp_slippage_basis_points_u128(slippage_basis_points);
 
     // Calculate various fees deducted from input amount
     let protocol_fee = (amount_in_u128 * accounts::PROTOCOL_FEE_RATE / 10000) as u128;
@@ -50,8 +54,8 @@ pub fn get_buy_token_amount_from_sol_amount(
     let denominator = input_reserve.checked_add(amount_in_net).unwrap();
     let mut amount_out = numerator.checked_div(denominator).unwrap();
 
-    // Apply slippage protection
-    amount_out = amount_out - (amount_out * slippage_basis_points) / 10000;
+    // Apply slippage protection (bps already clamped)
+    amount_out = amount_out - (amount_out * bps) / 10000;
     amount_out as u64
 }
 
@@ -67,7 +71,8 @@ pub fn get_buy_token_amount_from_sol_amount(
 /// * `virtual_quote` - Virtual quote token (SOL) reserves
 /// * `real_base` - Real base token reserves
 /// * `real_quote` - Real quote token (SOL) reserves
-/// * `slippage_basis_points` - Maximum slippage tolerance in basis points (e.g., 100 = 1%)
+/// * `slippage_basis_points` - Maximum slippage tolerance in basis points (e.g., 100 = 1%).
+///   Clamped to [`MAX_SLIPPAGE_BASIS_POINTS`](super::common::MAX_SLIPPAGE_BASIS_POINTS) (9999 = 99.99%).
 ///
 /// # Returns
 ///
@@ -81,6 +86,7 @@ pub fn get_sell_sol_amount_from_token_amount(
     slippage_basis_points: u128,
 ) -> u64 {
     let amount_in_u128 = amount_in as u128;
+    let bps = clamp_slippage_basis_points_u128(slippage_basis_points);
 
     // For sell operation, input_reserve is token reserves, output_reserve is SOL reserves
     let input_reserve = virtual_base.checked_sub(real_base).unwrap();
@@ -105,8 +111,107 @@ pub fn get_sell_sol_amount_from_token_amount(
         .checked_sub(share_fee)
         .unwrap();
 
-    // Apply slippage protection
-    let final_amount = sol_amount_net - (sol_amount_net * slippage_basis_points) / 10000;
+    // Apply slippage protection (bps already clamped)
+    let final_amount = sol_amount_net - (sol_amount_net * bps) / 10000;
 
     final_amount as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::common::MAX_SLIPPAGE_BASIS_POINTS;
+
+    // Matches defaults used by BonkParams::from_dev_trade
+    const VIRTUAL_BASE: u128 = 1_073_025_605_596_382;
+    const VIRTUAL_QUOTE: u128 = 30_000_852_951;
+
+    #[test]
+    fn buy_slippage_at_10000_bps_does_not_zero_min_out() {
+        let with_max = get_buy_token_amount_from_sol_amount(
+            1_000_000,
+            VIRTUAL_BASE,
+            VIRTUAL_QUOTE,
+            0,
+            0,
+            10_000,
+        );
+        let with_clamp_cap = get_buy_token_amount_from_sol_amount(
+            1_000_000,
+            VIRTUAL_BASE,
+            VIRTUAL_QUOTE,
+            0,
+            0,
+            MAX_SLIPPAGE_BASIS_POINTS as u128,
+        );
+        assert_eq!(with_max, with_clamp_cap);
+        assert!(with_max > 0);
+    }
+
+    #[test]
+    fn sell_slippage_above_10000_bps_does_not_underflow() {
+        let with_overflow = get_sell_sol_amount_from_token_amount(
+            1_000_000_000,
+            VIRTUAL_BASE,
+            VIRTUAL_QUOTE,
+            0,
+            0,
+            50_000,
+        );
+        let with_clamp_cap = get_sell_sol_amount_from_token_amount(
+            1_000_000_000,
+            VIRTUAL_BASE,
+            VIRTUAL_QUOTE,
+            0,
+            0,
+            MAX_SLIPPAGE_BASIS_POINTS as u128,
+        );
+        assert_eq!(with_overflow, with_clamp_cap);
+        assert!(with_overflow > 0);
+    }
+
+    #[test]
+    fn normal_slippage_matches_uncapped_formula() {
+        const BPS: u128 = 100;
+
+        let buy_no_slip = get_buy_token_amount_from_sol_amount(
+            1_000_000,
+            VIRTUAL_BASE,
+            VIRTUAL_QUOTE,
+            0,
+            0,
+            0,
+        );
+        let buy_with_slip = get_buy_token_amount_from_sol_amount(
+            1_000_000,
+            VIRTUAL_BASE,
+            VIRTUAL_QUOTE,
+            0,
+            0,
+            BPS,
+        );
+        let expected_buy = buy_no_slip - ((buy_no_slip as u128 * BPS) / 10_000) as u64;
+        assert_eq!(buy_with_slip, expected_buy);
+        assert!(buy_with_slip < buy_no_slip);
+
+        let sell_no_slip = get_sell_sol_amount_from_token_amount(
+            1_000_000_000,
+            VIRTUAL_BASE,
+            VIRTUAL_QUOTE,
+            0,
+            0,
+            0,
+        );
+        let sell_with_slip = get_sell_sol_amount_from_token_amount(
+            1_000_000_000,
+            VIRTUAL_BASE,
+            VIRTUAL_QUOTE,
+            0,
+            0,
+            BPS,
+        );
+        let expected_sell = sell_no_slip - ((sell_no_slip as u128 * BPS) / 10_000) as u64;
+        assert_eq!(sell_with_slip, expected_sell);
+        assert!(sell_with_slip < sell_no_slip);
+    }
 }

--- a/src/utils/calc/common.rs
+++ b/src/utils/calc/common.rs
@@ -48,6 +48,26 @@ pub const fn ceil_div(a: u128, b: u128) -> u128 {
 /// This prevents the wrap amount from doubling when slippage is 100%
 pub const MAX_SLIPPAGE_BASIS_POINTS: u64 = 9999;
 
+/// Clamp slippage so 100% (10000 bps) cannot zero min-out, underflow, or divide by zero.
+#[inline(always)]
+pub const fn clamp_slippage_basis_points(basis_points: u64) -> u64 {
+    if basis_points > MAX_SLIPPAGE_BASIS_POINTS {
+        MAX_SLIPPAGE_BASIS_POINTS
+    } else {
+        basis_points
+    }
+}
+
+/// `u128` variant for Bonk helpers that take slippage as `u128`.
+#[inline(always)]
+pub const fn clamp_slippage_basis_points_u128(basis_points: u128) -> u128 {
+    if basis_points > MAX_SLIPPAGE_BASIS_POINTS as u128 {
+        MAX_SLIPPAGE_BASIS_POINTS as u128
+    } else {
+        basis_points
+    }
+}
+
 /// Calculate buy amount with slippage protection
 /// Add slippage percentage to the amount to ensure successful purchase
 ///
@@ -66,11 +86,7 @@ pub const MAX_SLIPPAGE_BASIS_POINTS: u64 = 9999;
 /// to prevent the amount from doubling when basis_points = 10000.
 #[inline(always)]
 pub const fn calculate_with_slippage_buy(amount: u64, basis_points: u64) -> u64 {
-    let bps = if basis_points > MAX_SLIPPAGE_BASIS_POINTS {
-        MAX_SLIPPAGE_BASIS_POINTS
-    } else {
-        basis_points
-    };
+    let bps = clamp_slippage_basis_points(basis_points);
     let result = amount as u128 + (amount as u128 * bps as u128 / 10_000);
     if result > u64::MAX as u128 {
         u64::MAX
@@ -96,11 +112,7 @@ pub const fn calculate_with_slippage_sell(amount: u64, basis_points: u64) -> u64
     if amount == 0 {
         return 0;
     }
-    let bps = if basis_points > MAX_SLIPPAGE_BASIS_POINTS {
-        MAX_SLIPPAGE_BASIS_POINTS
-    } else {
-        basis_points
-    };
+    let bps = clamp_slippage_basis_points(basis_points);
     amount - (amount as u128 * bps as u128 / 10_000) as u64
 }
 
@@ -126,5 +138,25 @@ mod tests {
         assert_eq!(calculate_with_slippage_sell(u64::MAX, 100), 18_262_276_632_972_456_099);
         assert_eq!(calculate_with_slippage_sell(10_000, u64::MAX), 1);
         assert_eq!(calculate_with_slippage_sell(1, u64::MAX), 1);
+    }
+
+    #[test]
+    fn clamp_slippage_basis_points_caps_at_max() {
+        assert_eq!(clamp_slippage_basis_points(0), 0);
+        assert_eq!(clamp_slippage_basis_points(100), 100);
+        assert_eq!(clamp_slippage_basis_points(MAX_SLIPPAGE_BASIS_POINTS), MAX_SLIPPAGE_BASIS_POINTS);
+        assert_eq!(clamp_slippage_basis_points(10_000), MAX_SLIPPAGE_BASIS_POINTS);
+        assert_eq!(clamp_slippage_basis_points(u64::MAX), MAX_SLIPPAGE_BASIS_POINTS);
+
+        assert_eq!(clamp_slippage_basis_points_u128(0), 0);
+        assert_eq!(clamp_slippage_basis_points_u128(100), 100);
+        assert_eq!(
+            clamp_slippage_basis_points_u128(10_000),
+            MAX_SLIPPAGE_BASIS_POINTS as u128
+        );
+        assert_eq!(
+            clamp_slippage_basis_points_u128(u128::MAX),
+            MAX_SLIPPAGE_BASIS_POINTS as u128
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Clamp Bonk/LetsBonk slippage helpers to `MAX_SLIPPAGE_BASIS_POINTS` (9999), matching the PumpFun path.
- Prevent `minimum_amount_out = 0` at 100% slippage and divide-by-zero in `get_amount_in`.
- Add shared `clamp_slippage_basis_points_u128` plus regression tests for boundary and normal slippage.

Closes #111

## Test plan
- [x] `cargo test --lib bonk`
- [x] `cargo test --lib slippage`
- [x] `cargo build --lib` (no unused-import warnings)

Made with [Cursor](https://cursor.com)