### PR TITLE
chore: sync current official program IDLs

### DIFF
--- a/idl/README.md
+++ b/idl/README.md
@@ -1,16 +1,23 @@
-# IDL files
+# IDL Sources
 
-Supported DEX IDLs are stored directly in this directory. The files below were
-synced from `bitquery/solana-idl-lib` commit `f804b17` and written to the SDK's
-canonical local filenames.
+Unversioned IDLs track current protocol-maintained files. Explicitly versioned files such as
+`_011`, `_015`, or `_090` remain compatibility snapshots. Canonical SHA-256 values use
+`jq -S -c . | sha256sum`, so JSON formatting does not affect comparisons.
 
-| SDK protocol | Local IDL | Source path |
-| --- | --- | --- |
-| Bonk / Raydium Launchpad | `bonk.json` | `raydium/launchpad.json` |
-| Raydium CPMM | `raydium_cpmm.json` | `raydium/raydium_cp.json` |
-| Raydium AMM v4 | `raydium_amm_v4.json` | `raydium/raydium_amm.json` |
-| Meteora DAMM v2 | `meteora_damm_v2.json` | `meteora/cp_amm_016.json` |
-| PumpFun | `pump.json` | `pumpfun/pump.json` |
-| PumpSwap | `pump_amm.json` | `pumpswap/amm.json` |
+| Local IDL | Official upstream | Version | Canonical SHA-256 |
+| --- | --- | --- | --- |
+| `pump.json` | `pump-fun/pump-public-docs/idl/pump.json` | 0.1.0 | `ab1b3b5a85b2bb3aade5dc7bacb2f5e75e62a242db6f2828d9addbf09d8d864e` |
+| `pump_amm.json` | `pump-fun/pump-public-docs/idl/pump_amm.json` | 0.1.0 | `b85ddba5f4611e9e2cd0695d1204a40f16db15d48b1b8ad4177abee194dc5141` |
+| `pump_fees.json` | `pump-fun/pump-public-docs/idl/pump_fees.json` | 0.1.0 | `1177093f22cfef08d5474025b44ace9ba97960ecd04dc87b4530a33072194bb5` |
+| `raydium_clmm.json` | `raydium-io/raydium-idl/raydium_clmm/raydium_clmm.json` | 0.1.0 | `ce860422ec1e3284e89e165d9740c9f19f861ab45e0ad5bfc7ca647b6af39496` |
+| `raydium_cpmm.json` | `raydium-io/raydium-idl/raydium_cpmm/raydium_cp_swap.json` | 0.2.0 | `a4cc67efdc1374a3d6f8a1d7f16627bcda2deecdb65b2413fa336e973b97b52f` |
+| `raydium_launchpad.json` | `raydium-io/raydium-idl/raydium_launchpad/raydium_launchpad.json` | 0.2.0 | `03713b809cd62272f63ebf5ca5ad06a64f6f7a3ac493a9f49d2c3b2aa43aca68` |
+| `meteora_lb_clmm.json` | `MeteoraAg/dlmm-sdk/idls/dlmm.json` | 0.12.0 | `1bc4333e5702dddb51d9ad92b6e9298940c9d9ff7f92fd761b634a03cf2d7daf` |
+| `meteora_damm_v2.json` | `MeteoraAg/damm-v2-sdk/src/idl/cp_amm.json` | 0.2.2 | `44cba19689609a51e3c0ab44fb04f7c85e9eacf72f05fd013f0f4c753eb42f0a` |
+| `meteora_dynamic_bonding_curve.json` | `MeteoraAg/dynamic-bonding-curve-sdk/packages/dynamic-bonding-curve/src/idl/dynamic-bonding-curve/idl.json` | 0.2.0 | `b28d0683f164e8ebc510190a605be493ea2ecd39c02c8852960e41120847a822` |
+| `meteora_amm.json` | `MeteoraAg/dynamic-bonding-curve/idls/dynamic_amm.json` | 0.5.2 | `21f59f98c8a593ac2a9d976889cff8d8b618fe3aa1fb5c0132d5ca598c59a833` |
+| `orca_whirlpool.json` / `orca_whirlpool_v2.json` | `@orca-so/whirlpools-sdk@0.22.0/dist/artifacts/whirlpool.json` | 0.9.0 | `301335733544288d52aae316827c4e2bbf4e27edbd3d87bd1711de1251e3b1ee` |
 
-No separate source snapshot tree is kept in the repository.
+Raydium AMM V4 is not an Anchor program and has no current protocol-maintained Anchor IDL.
+`raydium_amm_v4.json` and `raydium_pool_v4.json` remain compatibility references; current
+instruction and `ray_log` layouts are defined by `raydium-io/raydium-amm`.

--- a/idl/meteora_amm.json
+++ b/idl/meteora_amm.json
@@ -1,2322 +1,3111 @@
 {
-  "version": "0.4.12",
-  "name": "amm",
-  "docs": ["Program for AMM"],
+  "address": "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB",
+  "metadata": {
+    "name": "dynamic_amm",
+    "version": "0.5.2",
+    "spec": "0.1.0"
+  },
+  "docs": [
+    "Program for AMM"
+  ],
   "instructions": [
     {
-      "name": "initializePermissionedPool",
-      "docs": ["Initialize a new permissioned pool."],
+      "name": "initialize_permissioned_pool",
+      "docs": [
+        "Initialize a new permissioned pool."
+      ],
+      "discriminator": [
+        77,
+        85,
+        178,
+        157,
+        50,
+        48,
+        212,
+        126
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Pool account (arbitrary address)"]
+          "docs": [
+            "Pool account (arbitrary address)"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token A mint of the pool. Eg: USDT"]
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token B mint of the pool. Eg: USDC"]
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault A"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault B"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenA",
-          "isMut": true,
-          "isSigner": false,
+          "name": "admin_token_a",
           "docs": [
             "Admin token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenB",
-          "isMut": true,
-          "isSigner": false,
+          "name": "admin_token_b",
           "docs": [
             "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "admin_pool_lp",
           "docs": [
             "Admin pool LP token account. Used to receive LP during first deposit (initialize pool)",
             "Admin pool LP token account. Used to receive LP during first deposit (initialize pool)"
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_a_fee",
           "docs": [
-            "Admin fee token account for token A. Used to receive trading fee."
-          ]
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_b_fee",
           "docs": [
-            "Admin fee token account for token B. Used to receive trading fee."
-          ]
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
-        { "name": "feeOwner", "isMut": false, "isSigner": false },
+        {
+          "name": "fee_owner"
+        },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Rent account."]
+          "docs": [
+            "Rent account."
+          ]
         },
-        { "name": "mintMetadata", "isMut": true, "isSigner": false },
-        { "name": "metadataProgram", "isMut": false, "isSigner": false },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Associated token program."]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
-        }
-      ],
-      "args": [{ "name": "curveType", "type": { "defined": "CurveType" } }]
-    },
-    {
-      "name": "initializePermissionlessPool",
-      "docs": ["Initialize a new permissionless pool."],
-      "accounts": [
-        {
-          "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA address)"]
-        },
-        {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
-        },
-        {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token A mint of the pool. Eg: USDT"]
-        },
-        {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token B mint of the pool. Eg: USDC"]
-        },
-        {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_program",
           "docs": [
-            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+            "Token program."
           ]
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "associated_token_program",
           "docs": [
-            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+            "Associated token program."
           ]
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
-        },
-        {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
-        },
-        {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault A"]
-        },
-        {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault B"]
-        },
-        {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "system_program",
           "docs": [
-            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+            "System program."
           ]
-        },
-        {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
-        },
-        {
-          "name": "payerTokenA",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
-        },
-        {
-          "name": "payerTokenB",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
-        },
-        { "name": "payerPoolLp", "isMut": true, "isSigner": false },
-        {
-          "name": "adminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Admin fee token account for token A. Used to receive trading fee."
-          ]
-        },
-        {
-          "name": "adminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Admin fee token account for token B. Used to receive trading fee."
-          ]
-        },
-        {
-          "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "docs": [
-            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
-        },
-        { "name": "feeOwner", "isMut": false, "isSigner": false },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Rent account."]
-        },
-        { "name": "mintMetadata", "isMut": true, "isSigner": false },
-        { "name": "metadataProgram", "isMut": false, "isSigner": false },
-        {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": [
-            "Vault program. The pool will deposit/withdraw liquidity from the vault."
-          ]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Associated token program."]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
         }
       ],
       "args": [
-        { "name": "curveType", "type": { "defined": "CurveType" } },
-        { "name": "tokenAAmount", "type": "u64" },
-        { "name": "tokenBAmount", "type": "u64" }
+        {
+          "name": "curve_type",
+          "type": {
+            "defined": {
+              "name": "CurveType"
+            }
+          }
+        }
       ]
     },
     {
-      "name": "initializePermissionlessPoolWithFeeTier",
-      "docs": ["Initialize a new permissionless pool with customized fee tier"],
+      "name": "initialize_permissionless_pool",
+      "docs": [
+        "Initialize a new permissionless pool."
+      ],
+      "discriminator": [
+        118,
+        173,
+        41,
+        157,
+        173,
+        72,
+        97,
+        103
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA address)"]
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token A mint of the pool. Eg: USDT"]
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token B mint of the pool. Eg: USDC"]
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault A"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault B"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenA",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_a",
           "docs": [
             "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "payerTokenB",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_token_b",
           "docs": [
             "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
-          ]
-        },
-        { "name": "payerPoolLp", "isMut": true, "isSigner": false },
-        {
-          "name": "adminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": [
-            "Admin fee token account for token A. Used to receive trading fee."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
           "docs": [
-            "Admin fee token account for token B. Used to receive trading fee."
-          ]
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
         },
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true,
           "docs": [
             "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
-          ]
+          ],
+          "writable": true,
+          "signer": true
         },
-        { "name": "feeOwner", "isMut": false, "isSigner": false },
+        {
+          "name": "fee_owner"
+        },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Rent account."]
+          "docs": [
+            "Rent account."
+          ]
         },
-        { "name": "mintMetadata", "isMut": true, "isSigner": false },
-        { "name": "metadataProgram", "isMut": false, "isSigner": false },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Associated token program."]
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
         }
       ],
       "args": [
-        { "name": "curveType", "type": { "defined": "CurveType" } },
-        { "name": "tradeFeeBps", "type": "u64" },
-        { "name": "tokenAAmount", "type": "u64" },
-        { "name": "tokenBAmount", "type": "u64" }
+        {
+          "name": "curve_type",
+          "type": {
+            "defined": {
+              "name": "CurveType"
+            }
+          }
+        },
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "enableOrDisablePool",
+      "name": "initialize_permissionless_pool_with_fee_tier",
+      "docs": [
+        "Initialize a new permissionless pool with customized fee tier"
+      ],
+      "discriminator": [
+        6,
+        135,
+        68,
+        147,
+        229,
+        82,
+        169,
+        113
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
+        },
+        {
+          "name": "a_vault",
+          "docs": [
+            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "docs": [
+            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "docs": [
+            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "docs": [
+            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "docs": [
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_owner"
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Rent account."
+          ]
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
+          "docs": [
+            "Vault program. The pool will deposit/withdraw liquidity from the vault."
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "curve_type",
+          "type": {
+            "defined": {
+              "name": "CurveType"
+            }
+          }
+        },
+        {
+          "name": "trade_fee_bps",
+          "type": "u64"
+        },
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "enable_or_disable_pool",
       "docs": [
         "Enable or disable a pool. A disabled pool allow only remove balanced liquidity operation."
       ],
+      "discriminator": [
+        128,
+        6,
+        228,
+        131,
+        55,
+        161,
+        52,
+        169
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
+          "docs": [
+            "Admin account. Must be owner of the pool."
+          ],
+          "signer": true
         }
       ],
-      "args": [{ "name": "enable", "type": "bool" }]
+      "args": [
+        {
+          "name": "enable",
+          "type": "bool"
+        }
+      ]
     },
     {
       "name": "swap",
       "docs": [
         "Swap token A to B, or vice versa. An amount of trading fee will be charged for liquidity provider, and the admin of the pool."
       ],
+      "discriminator": [
+        248,
+        198,
+        158,
+        145,
+        225,
+        117,
+        135,
+        200
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "userSourceToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_source_token",
           "docs": [
             "User token account. Token from this account will be transfer into the vault by the pool in exchange for another token of the pool."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userDestinationToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_destination_token",
           "docs": [
             "User token account. The exchanged token will be transfer into this account from the pool."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lp token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "Lp token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lp token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "Lp token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "adminTokenFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "protocol_token_fee",
           "docs": [
-            "Admin fee token account. Used to receive trading fee. It's mint field must matched with user_source_token mint field."
-          ]
+            "Protocol fee token account. Used to receive trading fee. It's mint field must matched with user_source_token mint field."
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["User account. Must be owner of user_source_token."]
+          "docs": [
+            "User account. Must be owner of user_source_token."
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "inAmount", "type": "u64" },
-        { "name": "minimumOutAmount", "type": "u64" }
+        {
+          "name": "in_amount",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_out_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "removeLiquiditySingleSide",
+      "name": "remove_liquidity_single_side",
       "docs": [
         "Withdraw only single token from the pool. Only supported by pool with stable swap curve."
+      ],
+      "discriminator": [
+        84,
+        84,
+        177,
+        66,
+        254,
+        185,
+        10,
+        251
       ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "User pool lp token account. LP will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault A"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault B"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userDestinationToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_destination_token",
           "docs": [
             "User token account to receive token upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["User account. Must be owner of the user_pool_lp account."]
+          "docs": [
+            "User account. Must be owner of the user_pool_lp account."
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. The pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "poolTokenAmount", "type": "u64" },
-        { "name": "minimumOutAmount", "type": "u64" }
+        {
+          "name": "pool_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_out_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "addImbalanceLiquidity",
+      "name": "add_imbalance_liquidity",
       "docs": [
         "Deposit tokens to the pool in an imbalance ratio. Only supported by pool with stable swap curve."
       ],
+      "discriminator": [
+        79,
+        35,
+        122,
+        84,
+        173,
+        15,
+        93,
+        191
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "minimumPoolTokenAmount", "type": "u64" },
-        { "name": "tokenAAmount", "type": "u64" },
-        { "name": "tokenBAmount", "type": "u64" }
+        {
+          "name": "minimum_pool_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "removeBalanceLiquidity",
+      "name": "remove_balance_liquidity",
       "docs": [
         "Withdraw tokens from the pool in a balanced ratio. User will still able to withdraw from pool even the pool is disabled. This allow user to exit their liquidity when there's some unforeseen event happen."
       ],
+      "discriminator": [
+        133,
+        109,
+        44,
+        179,
+        56,
+        238,
+        114,
+        33
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "poolTokenAmount", "type": "u64" },
-        { "name": "minimumATokenOut", "type": "u64" },
-        { "name": "minimumBTokenOut", "type": "u64" }
+        {
+          "name": "pool_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_a_token_out",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_b_token_out",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "addBalanceLiquidity",
-      "docs": ["Deposit tokens to the pool in a balanced ratio."],
+      "name": "add_balance_liquidity",
+      "docs": [
+        "Deposit tokens to the pool in a balanced ratio."
+      ],
+      "discriminator": [
+        168,
+        227,
+        50,
+        62,
+        189,
+        171,
+        84,
+        176
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "poolTokenAmount", "type": "u64" },
-        { "name": "maximumTokenAAmount", "type": "u64" },
-        { "name": "maximumTokenBAmount", "type": "u64" }
+        {
+          "name": "pool_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "maximum_token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "maximum_token_b_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "setPoolFees",
-      "docs": ["Update trading fee charged for liquidity provider, and admin."],
+      "name": "set_pool_fees",
+      "docs": [
+        "Update trading fee charged for liquidity provider, and admin."
+      ],
+      "discriminator": [
+        102,
+        44,
+        158,
+        54,
+        205,
+        37,
+        126,
+        78
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
+          "name": "fee_operator",
+          "docs": [
+            "Fee operator account"
+          ],
+          "signer": true
         }
       ],
-      "args": [{ "name": "fees", "type": { "defined": "PoolFees" } }]
+      "args": [
+        {
+          "name": "fees",
+          "type": {
+            "defined": {
+              "name": "PoolFees"
+            }
+          }
+        },
+        {
+          "name": "new_partner_fee_numerator",
+          "type": "u64"
+        }
+      ]
     },
     {
-      "name": "overrideCurveParam",
+      "name": "override_curve_param",
       "docs": [
         "Update swap curve parameters. This function do not allow update of curve type. For example: stable swap curve to constant product curve. Only supported by pool with stable swap curve.",
         "Only amp is allowed to be override. The other attributes of stable swap curve will be ignored."
       ],
+      "discriminator": [
+        98,
+        86,
+        204,
+        51,
+        94,
+        71,
+        69,
+        187
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
           "name": "admin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
+          "docs": [
+            "Admin account."
+          ],
+          "signer": true
         }
       ],
-      "args": [{ "name": "curveType", "type": { "defined": "CurveType" } }]
+      "args": [
+        {
+          "name": "curve_type",
+          "type": {
+            "defined": {
+              "name": "CurveType"
+            }
+          }
+        }
+      ]
     },
     {
-      "name": "transferAdmin",
-      "docs": ["Transfer the admin of the pool to new admin."],
+      "name": "get_pool_info",
+      "docs": [
+        "Get the general information of the pool."
+      ],
+      "discriminator": [
+        9,
+        48,
+        220,
+        101,
+        22,
+        240,
+        78,
+        200
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ]
         },
         {
-          "name": "admin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ]
         },
         {
-          "name": "newAdmin",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["New admin account."]
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "getPoolInfo",
-      "docs": ["Get the general information of the pool."],
-      "accounts": [
-        {
-          "name": "pool",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
-        },
-        {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
-        },
-        {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "bVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "aVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "bVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ]
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ]
         }
       ],
       "args": []
     },
     {
-      "name": "bootstrapLiquidity",
-      "docs": ["Bootstrap the pool when liquidity is depleted."],
+      "name": "bootstrap_liquidity",
+      "docs": [
+        "Bootstrap the pool when liquidity is depleted."
+      ],
+      "discriminator": [
+        4,
+        228,
+        215,
+        71,
+        225,
+        253,
+        119,
+        206
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account (PDA)"]
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "userPoolLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_pool_lp",
           "docs": [
             "user pool lp token account. lp will be burned from this account upon success liquidity removal."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
           "name": "user",
-          "isMut": false,
-          "isSigner": true,
           "docs": [
             "User account. Must be owner of user_a_token, and user_b_token."
-          ]
+          ],
+          "signer": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         }
       ],
       "args": [
-        { "name": "tokenAAmount", "type": "u64" },
-        { "name": "tokenBAmount", "type": "u64" }
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "migrateFeeAccount",
-      "docs": ["Migrate old token fee owner to PDA"],
+      "name": "create_mint_metadata",
+      "docs": [
+        "Create mint metadata account for old pools"
+      ],
+      "discriminator": [
+        13,
+        70,
+        168,
+        41,
+        250,
+        100,
+        148,
+        90
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account"]
-        },
-        {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["A vault LP token account of the pool."]
-        },
-        {
-          "name": "adminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
-            "Admin fee token account for token A. Used to receive trading fee."
+            "Pool account"
           ]
         },
         {
-          "name": "adminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
+          "name": "lp_mint",
           "docs": [
-            "Admin fee token account for token B. Used to receive trading fee."
+            "LP mint account of the pool"
           ]
         },
         {
-          "name": "tokenAMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token A mint"]
+          "name": "a_vault_lp",
+          "docs": [
+            "Vault A LP account of the pool"
+          ]
         },
         {
-          "name": "tokenBMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token B mint"]
+          "name": "mint_metadata",
+          "writable": true
         },
         {
-          "name": "newAdminTokenAFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token fee account. Controlled by pool a_vault_lp PDA."]
+          "name": "metadata_program"
         },
         {
-          "name": "newAdminTokenBFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token fee account. Controlled by pool a_vault_lp PDA."]
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
         },
         {
-          "name": "admin",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Admin account. Must be owner of the pool."]
-        },
-        {
-          "name": "treasuryTokenAFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Treasury token a fee ATA."]
-        },
-        {
-          "name": "treasuryTokenBFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Treasury token b fee ATA."]
-        },
-        {
-          "name": "treasury",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Treasury signer"]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
+          "name": "payer",
+          "docs": [
+            "Payer"
+          ],
+          "writable": true,
+          "signer": true
         }
       ],
       "args": []
     },
     {
-      "name": "createMintMetadata",
-      "docs": ["Create mint metadata account for old pools"],
-      "accounts": [
-        {
-          "name": "pool",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Pool account"]
-        },
-        {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP mint account of the pool"]
-        },
-        {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Vault A LP account of the pool"]
-        },
-        { "name": "mintMetadata", "isMut": true, "isSigner": false },
-        { "name": "metadataProgram", "isMut": false, "isSigner": false },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
-        },
-        { "name": "payer", "isMut": true, "isSigner": true, "docs": ["Payer"] }
+      "name": "create_lock_escrow",
+      "docs": [
+        "Create lock account"
       ],
-      "args": []
-    },
-    {
-      "name": "createLockEscrow",
-      "docs": ["Create lock account"],
+      "discriminator": [
+        54,
+        87,
+        165,
+        19,
+        69,
+        227,
+        218,
+        224
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Pool account"]
+          "docs": [
+            "Pool account"
+          ]
         },
         {
-          "name": "lockEscrow",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lock account"]
+          "name": "lock_escrow",
+          "docs": [
+            "Lock account"
+          ],
+          "writable": true
         },
-        { "name": "owner", "isMut": false, "isSigner": false },
         {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "owner"
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ]
         },
         {
           "name": "payer",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Payer account"]
+          "docs": [
+            "Payer account"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["System program."]
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
         }
       ],
       "args": []
     },
     {
       "name": "lock",
-      "docs": ["Lock Lp token"],
+      "docs": [
+        "Lock Lp token"
+      ],
+      "discriminator": [
+        21,
+        19,
+        208,
+        43,
+        237,
+        62,
+        255,
+        87
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account"]
+          "docs": [
+            "Pool account"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ]
         },
         {
-          "name": "lockEscrow",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lock account"]
+          "name": "lock_escrow",
+          "docs": [
+            "Lock account"
+          ],
+          "writable": true
         },
         {
           "name": "owner",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Owner of lock account"]
+          "docs": [
+            "Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "sourceTokens",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["owner lp token account"]
+          "name": "source_tokens",
+          "docs": [
+            "owner lp token account"
+          ],
+          "writable": true
         },
         {
-          "name": "escrowVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Escrow vault"]
+          "name": "escrow_vault",
+          "docs": [
+            "Escrow vault"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         },
         {
-          "name": "aVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "bVault",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
           ]
         },
         {
-          "name": "aVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "bVaultLp",
-          "isMut": false,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
           ]
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ]
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ]
         }
       ],
-      "args": [{ "name": "amount", "type": "u64" }]
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
     },
     {
-      "name": "claimFee",
-      "docs": ["Claim fee"],
+      "name": "claim_fee",
+      "docs": [
+        "Claim fee"
+      ],
+      "discriminator": [
+        169,
+        32,
+        79,
+        137,
+        136,
+        232,
+        70,
+        137
+      ],
       "accounts": [
         {
           "name": "pool",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool account"]
+          "docs": [
+            "Pool account"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of the pool"]
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
         },
         {
-          "name": "lockEscrow",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lock account"]
+          "name": "lock_escrow",
+          "docs": [
+            "Lock account"
+          ],
+          "writable": true
         },
         {
           "name": "owner",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Owner of lock account"]
+          "docs": [
+            "Owner of lock account"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "sourceTokens",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["owner lp token account"]
+          "name": "source_tokens",
+          "docs": [
+            "owner lp token account"
+          ],
+          "writable": true
         },
         {
-          "name": "escrowVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Escrow vault"]
+          "name": "escrow_vault",
+          "docs": [
+            "Escrow vault"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program."]
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
         },
         {
-          "name": "aTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault A"]
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
         },
         {
-          "name": "bTokenVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Token vault account of vault B"]
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
         },
         {
-          "name": "aVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault",
           "docs": [
             "Vault account for token a. token a of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVault",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault",
           "docs": [
             "Vault account for token b. token b of the pool will be deposit / withdraw from this vault account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "a_vault_lp",
           "docs": [
             "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLp",
-          "isMut": true,
-          "isSigner": false,
+          "name": "b_vault_lp",
           "docs": [
             "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "aVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault a"]
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault a"
+          ],
+          "writable": true
         },
         {
-          "name": "bVaultLpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["LP token mint of vault b"]
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault b"
+          ],
+          "writable": true
         },
         {
-          "name": "userAToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_a_token",
           "docs": [
             "User token A account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "userBToken",
-          "isMut": true,
-          "isSigner": false,
+          "name": "user_b_token",
           "docs": [
             "User token B account. Token will be transfer from this account if it is add liquidity operation. Else, token will be transfer into this account."
-          ]
+          ],
+          "writable": true
         },
         {
-          "name": "vaultProgram",
-          "isMut": false,
-          "isSigner": false,
+          "name": "vault_program",
           "docs": [
             "Vault program. the pool will deposit/withdraw liquidity from the vault."
           ]
         }
       ],
-      "args": [{ "name": "maxAmount", "type": "u64" }]
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "create_config",
+      "docs": [
+        "Create config"
+      ],
+      "discriminator": [
+        201,
+        207,
+        243,
+        114,
+        75,
+        111,
+        47,
+        189
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "ConfigParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_config",
+      "docs": [
+        "Close config"
+      ],
+      "discriminator": [
+        145,
+        9,
+        72,
+        157,
+        95,
+        125,
+        61,
+        85
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_permissionless_constant_product_pool_with_config",
+      "docs": [
+        "Initialize permissionless pool with config"
+      ],
+      "discriminator": [
+        7,
+        166,
+        138,
+        171,
+        206,
+        171,
+        236,
+        244
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
+        },
+        {
+          "name": "a_vault",
+          "docs": [
+            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "docs": [
+            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "docs": [
+            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "docs": [
+            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "docs": [
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Rent account."
+          ]
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
+          "docs": [
+            "Vault program. The pool will deposit/withdraw liquidity from the vault."
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "initialize_permissionless_constant_product_pool_with_config2",
+      "docs": [
+        "Initialize permissionless pool with config 2"
+      ],
+      "discriminator": [
+        48,
+        149,
+        220,
+        130,
+        61,
+        11,
+        9,
+        178
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
+        },
+        {
+          "name": "a_vault",
+          "docs": [
+            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "docs": [
+            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "docs": [
+            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "docs": [
+            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "docs": [
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Rent account."
+          ]
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
+          "docs": [
+            "Vault program. The pool will deposit/withdraw liquidity from the vault."
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        },
+        {
+          "name": "activation_point",
+          "type": {
+            "option": "u64"
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_customizable_permissionless_constant_product_pool",
+      "docs": [
+        "Initialize permissionless pool with customizable params"
+      ],
+      "discriminator": [
+        145,
+        24,
+        172,
+        194,
+        219,
+        125,
+        3,
+        190
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA address)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "LP token mint of the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token A mint of the pool. Eg: USDT"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token B mint of the pool. Eg: USDC"
+          ]
+        },
+        {
+          "name": "a_vault",
+          "docs": [
+            "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault",
+          "docs": [
+            "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_token_vault",
+          "docs": [
+            "Token vault account of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_token_vault",
+          "docs": [
+            "Token vault account of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault A"
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp_mint",
+          "docs": [
+            "LP token mint of vault B"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp",
+          "docs": [
+            "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "b_vault_lp",
+          "docs": [
+            "LP token account of vault B. Used to receive/burn vault LP upon deposit/withdraw from the vault."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "Payer token account for pool token A mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "Admin token account for pool token B mint. Used to bootstrap the pool with initial liquidity."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_pool_lp",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "docs": [
+            "Protocol fee token account for token A. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "docs": [
+            "Protocol fee token account for token B. Used to receive trading fee."
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "Admin account. This account will be the admin of the pool, and the payer for PDA during initialize pool."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Rent account."
+          ]
+        },
+        {
+          "name": "mint_metadata",
+          "writable": true
+        },
+        {
+          "name": "metadata_program"
+        },
+        {
+          "name": "vault_program",
+          "docs": [
+            "Vault program. The pool will deposit/withdraw liquidity from the vault."
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program."
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated token program."
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program."
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "token_a_amount",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount",
+          "type": "u64"
+        },
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "CustomizableParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_activation_point",
+      "docs": [
+        "Update activation slot"
+      ],
+      "discriminator": [
+        150,
+        62,
+        125,
+        219,
+        171,
+        220,
+        26,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "docs": [
+            "Admin account."
+          ],
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "new_activation_point",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_protocol_fees",
+      "docs": [
+        "Withdraw protocol fee"
+      ],
+      "discriminator": [
+        11,
+        68,
+        165,
+        98,
+        18,
+        208,
+        134,
+        73
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA)"
+          ]
+        },
+        {
+          "name": "a_vault_lp"
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "writable": true
+        },
+        {
+          "name": "treasury_token_a",
+          "writable": true
+        },
+        {
+          "name": "treasury_token_b",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "set_whitelisted_vault",
+      "docs": [
+        "Set whitelisted vault"
+      ],
+      "discriminator": [
+        12,
+        148,
+        94,
+        42,
+        55,
+        57,
+        83,
+        247
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "admin",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "whitelisted_vault",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "partner_claim_fee",
+      "docs": [
+        "Partner claim fee"
+      ],
+      "discriminator": [
+        57,
+        53,
+        176,
+        30,
+        123,
+        70,
+        52,
+        64
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account (PDA)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "a_vault_lp"
+        },
+        {
+          "name": "protocol_token_a_fee",
+          "writable": true
+        },
+        {
+          "name": "protocol_token_b_fee",
+          "writable": true
+        },
+        {
+          "name": "partner_token_a",
+          "writable": true
+        },
+        {
+          "name": "partner_token_b",
+          "writable": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "partner_authority",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount_a",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_b",
+          "type": "u64"
+        }
+      ]
     }
   ],
   "accounts": [
     {
-      "name": "Pool",
-      "docs": ["State of pool account"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lpMint",
-            "docs": ["LP token mint of the pool"],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenAMint",
-            "docs": ["Token A mint of the pool. Eg: USDT"],
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenBMint",
-            "docs": ["Token B mint of the pool. Eg: USDC"],
-            "type": "publicKey"
-          },
-          {
-            "name": "aVault",
-            "docs": [
-              "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "bVault",
-            "docs": [
-              "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "aVaultLp",
-            "docs": [
-              "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "bVaultLp",
-            "docs": [
-              "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "aVaultLpBump",
-            "docs": ["\"A\" vault lp bump. Used to create signer seeds."],
-            "type": "u8"
-          },
-          {
-            "name": "enabled",
-            "docs": [
-              "Flag to determine whether the pool is enabled, or disabled."
-            ],
-            "type": "bool"
-          },
-          {
-            "name": "adminTokenAFee",
-            "docs": [
-              "Admin fee token account for token A. Used to receive trading fee."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "adminTokenBFee",
-            "docs": [
-              "Admin fee token account for token B. Used to receive trading fee."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "admin",
-            "docs": ["Owner of the pool."],
-            "type": "publicKey"
-          },
-          {
-            "name": "fees",
-            "docs": ["Store the fee charges setting."],
-            "type": { "defined": "PoolFees" }
-          },
-          {
-            "name": "poolType",
-            "docs": ["Pool type"],
-            "type": { "defined": "PoolType" }
-          },
-          {
-            "name": "stake",
-            "docs": ["Stake pubkey of SPL stake pool"],
-            "type": "publicKey"
-          },
-          {
-            "name": "totalLockedLp",
-            "docs": ["Total locked lp token"],
-            "type": "u64"
-          },
-          {
-            "name": "padding",
-            "docs": ["Padding for future pool field"],
-            "type": { "defined": "Padding" }
-          },
-          {
-            "name": "curveType",
-            "docs": ["The type of the swap curve supported by the pool."],
-            "type": { "defined": "CurveType" }
-          }
-        ]
-      }
+      "name": "Config",
+      "discriminator": [
+        155,
+        12,
+        170,
+        224,
+        30,
+        250,
+        204,
+        130
+      ]
     },
     {
       "name": "LockEscrow",
-      "docs": ["State of lock escrow account"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          { "name": "pool", "docs": ["Pool address"], "type": "publicKey" },
-          { "name": "owner", "docs": ["Owner address"], "type": "publicKey" },
-          {
-            "name": "escrowVault",
-            "docs": ["Vault address, store the lock user lock"],
-            "type": "publicKey"
-          },
-          { "name": "bump", "docs": ["bump, used to sign"], "type": "u8" },
-          {
-            "name": "totalLockedAmount",
-            "docs": ["Total locked amount"],
-            "type": "u64"
-          },
-          {
-            "name": "lpPerToken",
-            "docs": ["Lp per token, virtual price of lp token"],
-            "type": "u128"
-          },
-          {
-            "name": "unclaimedFeePending",
-            "docs": ["Unclaimed fee pending"],
-            "type": "u64"
-          },
-          {
-            "name": "aFee",
-            "docs": ["Total a fee claimed so far"],
-            "type": "u64"
-          },
-          {
-            "name": "bFee",
-            "docs": ["Total b fee claimed so far"],
-            "type": "u64"
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "TokenMultiplier",
-      "docs": [
-        "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tokenAMultiplier",
-            "docs": ["Multiplier for token A of the pool."],
-            "type": "u64"
-          },
-          {
-            "name": "tokenBMultiplier",
-            "docs": ["Multiplier for token B of the pool."],
-            "type": "u64"
-          },
-          {
-            "name": "precisionFactor",
-            "docs": [
-              "Record the highest token decimal in the pool. For example, Token A is 6 decimal, token B is 9 decimal. This will save value of 9."
-            ],
-            "type": "u8"
-          }
-        ]
-      }
+      "discriminator": [
+        190,
+        106,
+        121,
+        6,
+        200,
+        182,
+        21,
+        75
+      ]
     },
     {
-      "name": "PoolFees",
-      "docs": ["Information regarding fee charges"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "tradeFeeNumerator",
-            "docs": [
-              "Trade fees are extra token amounts that are held inside the token",
-              "accounts during a trade, making the value of liquidity tokens rise.",
-              "Trade fee numerator"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "tradeFeeDenominator",
-            "docs": ["Trade fee denominator"],
-            "type": "u64"
-          },
-          {
-            "name": "ownerTradeFeeNumerator",
-            "docs": [
-              "Owner trading fees are extra token amounts that are held inside the token",
-              "accounts during a trade, with the equivalent in pool tokens minted to",
-              "the owner of the program.",
-              "Owner trade fee numerator"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "ownerTradeFeeDenominator",
-            "docs": ["Owner trade fee denominator"],
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Depeg",
-      "docs": ["Contains information for depeg pool"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "baseVirtualPrice",
-            "docs": ["The virtual price of staking / interest bearing token"],
-            "type": "u64"
-          },
-          {
-            "name": "baseCacheUpdated",
-            "docs": ["The virtual price of staking / interest bearing token"],
-            "type": "u64"
-          },
-          {
-            "name": "depegType",
-            "docs": ["Type of the depeg pool"],
-            "type": { "defined": "DepegType" }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Padding",
-      "docs": ["Padding for future pool fields"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "padding0",
-            "docs": ["Padding 0"],
-            "type": { "array": ["u8", 7] }
-          },
-          {
-            "name": "padding",
-            "docs": ["Padding 1"],
-            "type": { "array": ["u128", 29] }
-          }
-        ]
-      }
-    },
-    {
-      "name": "RoundDirection",
-      "docs": ["Rounding direction"],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "Floor" }, { "name": "Ceiling" }]
-      }
-    },
-    {
-      "name": "TradeDirection",
-      "docs": ["Trade (swap) direction"],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "AtoB" }, { "name": "BtoA" }]
-      }
-    },
-    {
-      "name": "NewCurveType",
-      "docs": ["Type of the swap curve"],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          { "name": "ConstantProduct" },
-          {
-            "name": "Stable",
-            "fields": [
-              {
-                "name": "amp",
-                "docs": ["Amplification coefficient"],
-                "type": "u64"
-              },
-              {
-                "name": "token_multiplier",
-                "docs": [
-                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
-                ],
-                "type": { "defined": "TokenMultiplier" }
-              },
-              {
-                "name": "depeg",
-                "docs": [
-                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
-                ],
-                "type": { "defined": "Depeg" }
-              },
-              {
-                "name": "last_amp_updated_timestamp",
-                "docs": [
-                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
-                ],
-                "type": "u64"
-              }
-            ]
-          },
-          {
-            "name": "NewCurve",
-            "fields": [
-              { "name": "field_one", "type": "u64" },
-              { "name": "field_two", "type": "u64" }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "CurveType",
-      "docs": ["Type of the swap curve"],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          { "name": "ConstantProduct" },
-          {
-            "name": "Stable",
-            "fields": [
-              {
-                "name": "amp",
-                "docs": ["Amplification coefficient"],
-                "type": "u64"
-              },
-              {
-                "name": "token_multiplier",
-                "docs": [
-                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
-                ],
-                "type": { "defined": "TokenMultiplier" }
-              },
-              {
-                "name": "depeg",
-                "docs": [
-                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
-                ],
-                "type": { "defined": "Depeg" }
-              },
-              {
-                "name": "last_amp_updated_timestamp",
-                "docs": [
-                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
-                ],
-                "type": "u64"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "name": "DepegType",
-      "docs": ["Type of depeg pool"],
-      "type": {
-        "kind": "enum",
-        "variants": [
-          { "name": "None" },
-          { "name": "Marinade" },
-          { "name": "Lido" },
-          { "name": "SplStake" }
-        ]
-      }
-    },
-    {
-      "name": "Rounding",
-      "docs": ["Round up, down"],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "Up" }, { "name": "Down" }]
-      }
-    },
-    {
-      "name": "PoolType",
-      "docs": ["Pool type"],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "Permissioned" }, { "name": "Permissionless" }]
-      }
+      "name": "Pool",
+      "discriminator": [
+        241,
+        154,
+        109,
+        4,
+        17,
+        177,
+        109,
+        188
+      ]
     }
   ],
   "events": [
     {
       "name": "AddLiquidity",
-      "fields": [
-        { "name": "lpMintAmount", "type": "u64", "index": false },
-        { "name": "tokenAAmount", "type": "u64", "index": false },
-        { "name": "tokenBAmount", "type": "u64", "index": false }
+      "discriminator": [
+        31,
+        94,
+        125,
+        90,
+        227,
+        52,
+        61,
+        186
       ]
     },
     {
       "name": "RemoveLiquidity",
-      "fields": [
-        { "name": "lpUnmintAmount", "type": "u64", "index": false },
-        { "name": "tokenAOutAmount", "type": "u64", "index": false },
-        { "name": "tokenBOutAmount", "type": "u64", "index": false }
+      "discriminator": [
+        116,
+        244,
+        97,
+        232,
+        103,
+        31,
+        152,
+        58
       ]
     },
     {
       "name": "BootstrapLiquidity",
-      "fields": [
-        { "name": "lpMintAmount", "type": "u64", "index": false },
-        { "name": "tokenAAmount", "type": "u64", "index": false },
-        { "name": "tokenBAmount", "type": "u64", "index": false },
-        { "name": "pool", "type": "publicKey", "index": false }
+      "discriminator": [
+        121,
+        127,
+        38,
+        136,
+        92,
+        55,
+        14,
+        247
       ]
     },
     {
       "name": "Swap",
-      "fields": [
-        { "name": "inAmount", "type": "u64", "index": false },
-        { "name": "outAmount", "type": "u64", "index": false },
-        { "name": "tradeFee", "type": "u64", "index": false },
-        { "name": "adminFee", "type": "u64", "index": false },
-        { "name": "hostFee", "type": "u64", "index": false }
+      "discriminator": [
+        81,
+        108,
+        227,
+        190,
+        205,
+        208,
+        10,
+        196
       ]
     },
     {
       "name": "SetPoolFees",
-      "fields": [
-        { "name": "tradeFeeNumerator", "type": "u64", "index": false },
-        { "name": "tradeFeeDenominator", "type": "u64", "index": false },
-        { "name": "ownerTradeFeeNumerator", "type": "u64", "index": false },
-        { "name": "ownerTradeFeeDenominator", "type": "u64", "index": false },
-        { "name": "pool", "type": "publicKey", "index": false }
+      "discriminator": [
+        245,
+        26,
+        198,
+        164,
+        88,
+        18,
+        75,
+        9
       ]
     },
     {
       "name": "PoolInfo",
-      "fields": [
-        { "name": "tokenAAmount", "type": "u64", "index": false },
-        { "name": "tokenBAmount", "type": "u64", "index": false },
-        { "name": "virtualPrice", "type": "f64", "index": false },
-        { "name": "currentTimestamp", "type": "u64", "index": false }
+      "discriminator": [
+        207,
+        20,
+        87,
+        97,
+        251,
+        212,
+        234,
+        45
       ]
     },
     {
       "name": "TransferAdmin",
-      "fields": [
-        { "name": "admin", "type": "publicKey", "index": false },
-        { "name": "newAdmin", "type": "publicKey", "index": false },
-        { "name": "pool", "type": "publicKey", "index": false }
-      ]
-    },
-    {
-      "name": "SetAdminFeeAccount",
-      "fields": [
-        { "name": "adminTokenAFee", "type": "publicKey", "index": false },
-        { "name": "adminTokenBFee", "type": "publicKey", "index": false },
-        { "name": "newAdminTokenAFee", "type": "publicKey", "index": false },
-        { "name": "newAdminTokenBFee", "type": "publicKey", "index": false }
+      "discriminator": [
+        228,
+        169,
+        131,
+        244,
+        61,
+        56,
+        65,
+        254
       ]
     },
     {
       "name": "OverrideCurveParam",
-      "fields": [
-        { "name": "newAmp", "type": "u64", "index": false },
-        { "name": "updatedTimestamp", "type": "u64", "index": false },
-        { "name": "pool", "type": "publicKey", "index": false }
+      "discriminator": [
+        247,
+        20,
+        165,
+        248,
+        75,
+        5,
+        54,
+        246
       ]
     },
     {
       "name": "PoolCreated",
-      "fields": [
-        { "name": "lpMint", "type": "publicKey", "index": false },
-        { "name": "tokenAMint", "type": "publicKey", "index": false },
-        { "name": "tokenBMint", "type": "publicKey", "index": false },
-        {
-          "name": "poolType",
-          "type": { "defined": "PoolType" },
-          "index": false
-        },
-        { "name": "pool", "type": "publicKey", "index": false }
+      "discriminator": [
+        202,
+        44,
+        41,
+        88,
+        104,
+        220,
+        157,
+        82
       ]
     },
     {
       "name": "PoolEnabled",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "enabled", "type": "bool", "index": false }
+      "discriminator": [
+        2,
+        151,
+        18,
+        83,
+        204,
+        134,
+        92,
+        191
       ]
     },
     {
       "name": "MigrateFeeAccount",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "newAdminTokenAFee", "type": "publicKey", "index": false },
-        { "name": "newAdminTokenBFee", "type": "publicKey", "index": false },
-        { "name": "tokenAAmount", "type": "u64", "index": false },
-        { "name": "tokenBAmount", "type": "u64", "index": false }
+      "discriminator": [
+        223,
+        234,
+        232,
+        26,
+        252,
+        105,
+        180,
+        125
       ]
     },
     {
       "name": "CreateLockEscrow",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "owner", "type": "publicKey", "index": false }
+      "discriminator": [
+        74,
+        94,
+        106,
+        141,
+        49,
+        17,
+        98,
+        109
       ]
     },
     {
       "name": "Lock",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "owner", "type": "publicKey", "index": false },
-        { "name": "amount", "type": "u64", "index": false }
+      "discriminator": [
+        220,
+        183,
+        67,
+        215,
+        153,
+        207,
+        56,
+        234
       ]
     },
     {
       "name": "ClaimFee",
-      "fields": [
-        { "name": "pool", "type": "publicKey", "index": false },
-        { "name": "owner", "type": "publicKey", "index": false },
-        { "name": "amount", "type": "u64", "index": false },
-        { "name": "aFee", "type": "u64", "index": false },
-        { "name": "bFee", "type": "u64", "index": false }
+      "discriminator": [
+        75,
+        122,
+        154,
+        48,
+        140,
+        74,
+        123,
+        163
+      ]
+    },
+    {
+      "name": "CreateConfig",
+      "discriminator": [
+        199,
+        152,
+        10,
+        19,
+        39,
+        39,
+        157,
+        104
+      ]
+    },
+    {
+      "name": "CloseConfig",
+      "discriminator": [
+        249,
+        181,
+        108,
+        89,
+        4,
+        150,
+        90,
+        174
+      ]
+    },
+    {
+      "name": "WithdrawProtocolFees",
+      "discriminator": [
+        30,
+        240,
+        207,
+        196,
+        139,
+        239,
+        79,
+        28
+      ]
+    },
+    {
+      "name": "PartnerClaimFees",
+      "discriminator": [
+        135,
+        131,
+        10,
+        94,
+        119,
+        209,
+        202,
+        48
       ]
     }
   ],
   "errors": [
-    { "code": 6000, "name": "MathOverflow", "msg": "Math operation overflow" },
-    { "code": 6001, "name": "InvalidFee", "msg": "Invalid fee setup" },
-    { "code": 6002, "name": "InvalidInvariant", "msg": "Invalid invariant d" },
+    {
+      "code": 6000,
+      "name": "MathOverflow",
+      "msg": "Math operation overflow"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidFee",
+      "msg": "Invalid fee setup"
+    },
+    {
+      "code": 6002,
+      "name": "InvalidInvariant",
+      "msg": "Invalid invariant d"
+    },
     {
       "code": 6003,
       "name": "FeeCalculationFailure",
@@ -2352,7 +3141,11 @@
       "name": "MismatchedTokenMint",
       "msg": "Token mint mismatched"
     },
-    { "code": 6010, "name": "MismatchedLpMint", "msg": "LP mint mismatched" },
+    {
+      "code": 6010,
+      "name": "MismatchedLpMint",
+      "msg": "LP mint mismatched"
+    },
     {
       "code": 6011,
       "name": "MismatchedOwner",
@@ -2373,7 +3166,11 @@
       "name": "InvalidPoolLpMintAccount",
       "msg": "Invalid pool lp mint account"
     },
-    { "code": 6015, "name": "PoolDisabled", "msg": "Pool disabled" },
+    {
+      "code": 6015,
+      "name": "PoolDisabled",
+      "msg": "Pool disabled"
+    },
     {
       "code": 6016,
       "name": "InvalidAdminAccount",
@@ -2381,10 +3178,14 @@
     },
     {
       "code": 6017,
-      "name": "InvalidAdminFeeAccount",
-      "msg": "Invalid admin fee account"
+      "name": "InvalidProtocolFeeAccount",
+      "msg": "Invalid protocol fee account"
     },
-    { "code": 6018, "name": "SameAdminAccount", "msg": "Same admin account" },
+    {
+      "code": 6018,
+      "name": "SameAdminAccount",
+      "msg": "Same admin account"
+    },
     {
       "code": 6019,
       "name": "IdenticalSourceDestination",
@@ -2440,7 +3241,11 @@
       "name": "MismatchedDepegMint",
       "msg": "Token mint B doesn't matches depeg type token mint"
     },
-    { "code": 6030, "name": "InvalidApyAccount", "msg": "Invalid APY account" },
+    {
+      "code": 6030,
+      "name": "InvalidApyAccount",
+      "msg": "Invalid APY account"
+    },
     {
       "code": 6031,
       "name": "InvalidTokenMultiplier",
@@ -2456,28 +3261,1356 @@
       "name": "UpdateTimeConstraint",
       "msg": "Update time constraint violated"
     },
-    { "code": 6034, "name": "ExceedMaxFeeBps", "msg": "Exceeded max fee bps" },
+    {
+      "code": 6034,
+      "name": "ExceedMaxFeeBps",
+      "msg": "Exceeded max fee bps"
+    },
     {
       "code": 6035,
-      "name": "OwnerFeeOverHalfOfTradeFee",
-      "msg": "Owner fee exceed half of trade fee"
+      "name": "InvalidAdmin",
+      "msg": "Invalid admin"
     },
-    { "code": 6036, "name": "InvalidAdmin", "msg": "Invalid admin" },
     {
-      "code": 6037,
+      "code": 6036,
       "name": "PoolIsNotPermissioned",
       "msg": "Pool is not permissioned"
     },
     {
-      "code": 6038,
+      "code": 6037,
       "name": "InvalidDepositAmount",
       "msg": "Invalid deposit amount"
     },
-    { "code": 6039, "name": "InvalidFeeOwner", "msg": "Invalid fee owner" },
-    { "code": 6040, "name": "NonDepletedPool", "msg": "Pool is not depleted" },
-    { "code": 6041, "name": "AmountNotPeg", "msg": "Token amount is not 1:1" },
-    { "code": 6042, "name": "AmountIsZero", "msg": "Amount is zero" },
-    { "code": 6043, "name": "TypeCastFailed", "msg": "Type cast error" },
-    { "code": 6044, "name": "AmountIsNotEnough", "msg": "Amount is not enough" }
+    {
+      "code": 6038,
+      "name": "InvalidFeeOwner",
+      "msg": "Invalid fee owner"
+    },
+    {
+      "code": 6039,
+      "name": "NonDepletedPool",
+      "msg": "Pool is not depleted"
+    },
+    {
+      "code": 6040,
+      "name": "AmountNotPeg",
+      "msg": "Token amount is not 1:1"
+    },
+    {
+      "code": 6041,
+      "name": "AmountIsZero",
+      "msg": "Amount is zero"
+    },
+    {
+      "code": 6042,
+      "name": "TypeCastFailed",
+      "msg": "Type cast error"
+    },
+    {
+      "code": 6043,
+      "name": "AmountIsNotEnough",
+      "msg": "Amount is not enough"
+    },
+    {
+      "code": 6044,
+      "name": "InvalidActivationDuration",
+      "msg": "Invalid activation duration"
+    },
+    {
+      "code": 6045,
+      "name": "PoolIsNotLaunchPool",
+      "msg": "Pool is not launch pool"
+    },
+    {
+      "code": 6046,
+      "name": "UnableToModifyActivationPoint",
+      "msg": "Unable to modify activation point"
+    },
+    {
+      "code": 6047,
+      "name": "InvalidAuthorityToCreateThePool",
+      "msg": "Invalid authority to create the pool"
+    },
+    {
+      "code": 6048,
+      "name": "InvalidActivationType",
+      "msg": "Invalid activation type"
+    },
+    {
+      "code": 6049,
+      "name": "InvalidActivationPoint",
+      "msg": "Invalid activation point"
+    },
+    {
+      "code": 6050,
+      "name": "PreActivationSwapStarted",
+      "msg": "Pre activation swap window started"
+    },
+    {
+      "code": 6051,
+      "name": "InvalidPoolType",
+      "msg": "Invalid pool type"
+    },
+    {
+      "code": 6052,
+      "name": "InvalidQuoteMint",
+      "msg": "Quote token must be SOL,USDC"
+    }
+  ],
+  "types": [
+    {
+      "name": "TokenMultiplier",
+      "docs": [
+        "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_a_multiplier",
+            "docs": [
+              "Multiplier for token A of the pool."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_b_multiplier",
+            "docs": [
+              "Multiplier for token B of the pool."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "precision_factor",
+            "docs": [
+              "Record the highest token decimal in the pool. For example, Token A is 6 decimal, token B is 9 decimal. This will save value of 9."
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolFees",
+      "docs": [
+        "Information regarding fee charges"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "docs": [
+              "Trade fees are extra token amounts that are held inside the token",
+              "accounts during a trade, making the value of liquidity tokens rise.",
+              "Trade fee numerator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_denominator",
+            "docs": [
+              "Trade fee denominator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "docs": [
+              "Protocol trading fees are extra token amounts that are held inside the token",
+              "accounts during a trade, with the equivalent in pool tokens minted to",
+              "the protocol of the program.",
+              "Protocol trade fee numerator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_denominator",
+            "docs": [
+              "Protocol trade fee denominator"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Depeg",
+      "docs": [
+        "Contains information for depeg pool"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "base_virtual_price",
+            "docs": [
+              "The virtual price of staking / interest bearing token"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "base_cache_updated",
+            "docs": [
+              "The last time base_virtual_price is updated"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "depeg_type",
+            "docs": [
+              "Type of the depeg pool"
+            ],
+            "type": {
+              "defined": {
+                "name": "DepegType"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "activation_duration",
+            "type": "u64"
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "partner_fee_numerator",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CustomizableParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "docs": [
+              "Trading fee."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "The pool start trading."
+            ],
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "has_alpha_vault",
+            "docs": [
+              "Whether the pool support alpha vault"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Padding"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                90
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Padding",
+      "docs": [
+        "Padding for future pool fields"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "padding0",
+            "docs": [
+              "Padding 0"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "padding1",
+            "docs": [
+              "Padding 1"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                21
+              ]
+            }
+          },
+          {
+            "name": "padding2",
+            "docs": [
+              "Padding 2"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                21
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PartnerInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "partner_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "pending_fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "pending_fee_b",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Bootstrapping",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "activation_point",
+            "docs": [
+              "Activation point, can be slot or timestamp"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "whitelisted_vault",
+            "docs": [
+              "Whitelisted vault to be able to buy pool before activation_point"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator",
+            "docs": [
+              "Need to store pool creator in lauch pool, so they can modify liquidity before activation_point"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type, 0 means by slot, 1 means by timestamp"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ActivationType",
+      "docs": [
+        "Type of the activation"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Slot"
+          },
+          {
+            "name": "Timestamp"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RoundDirection",
+      "docs": [
+        "Rounding direction"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Floor"
+          },
+          {
+            "name": "Ceiling"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TradeDirection",
+      "docs": [
+        "Trade (swap) direction"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "AtoB"
+          },
+          {
+            "name": "BtoA"
+          }
+        ]
+      }
+    },
+    {
+      "name": "NewCurveType",
+      "docs": [
+        "Type of the swap curve"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ConstantProduct"
+          },
+          {
+            "name": "Stable",
+            "fields": [
+              {
+                "name": "amp",
+                "docs": [
+                  "Amplification coefficient"
+                ],
+                "type": "u64"
+              },
+              {
+                "name": "token_multiplier",
+                "docs": [
+                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
+                ],
+                "type": {
+                  "defined": {
+                    "name": "TokenMultiplier"
+                  }
+                }
+              },
+              {
+                "name": "depeg",
+                "docs": [
+                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
+                ],
+                "type": {
+                  "defined": {
+                    "name": "Depeg"
+                  }
+                }
+              },
+              {
+                "name": "last_amp_updated_timestamp",
+                "docs": [
+                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
+                ],
+                "type": "u64"
+              }
+            ]
+          },
+          {
+            "name": "NewCurve",
+            "fields": [
+              {
+                "name": "field_one",
+                "type": "u64"
+              },
+              {
+                "name": "field_two",
+                "type": "u64"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "CurveType",
+      "docs": [
+        "Type of the swap curve"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ConstantProduct"
+          },
+          {
+            "name": "Stable",
+            "fields": [
+              {
+                "name": "amp",
+                "docs": [
+                  "Amplification coefficient"
+                ],
+                "type": "u64"
+              },
+              {
+                "name": "token_multiplier",
+                "docs": [
+                  "Multiplier for the pool token. Used to normalized token with different decimal into the same precision."
+                ],
+                "type": {
+                  "defined": {
+                    "name": "TokenMultiplier"
+                  }
+                }
+              },
+              {
+                "name": "depeg",
+                "docs": [
+                  "Depeg pool information. Contains functions to allow token amount to be repeg using stake / interest bearing token virtual price"
+                ],
+                "type": {
+                  "defined": {
+                    "name": "Depeg"
+                  }
+                }
+              },
+              {
+                "name": "last_amp_updated_timestamp",
+                "docs": [
+                  "The last amp updated timestamp. Used to prevent update_curve_info called infinitely many times within a short period"
+                ],
+                "type": "u64"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepegType",
+      "docs": [
+        "Type of depeg pool"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "Marinade"
+          },
+          {
+            "name": "Lido"
+          },
+          {
+            "name": "SplStake"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Rounding",
+      "docs": [
+        "Round up, down"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Up"
+          },
+          {
+            "name": "Down"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolType",
+      "docs": [
+        "Pool type"
+      ],
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Permissioned"
+          },
+          {
+            "name": "Permissionless"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Config",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFees"
+              }
+            }
+          },
+          {
+            "name": "activation_duration",
+            "type": "u64"
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "docs": [
+              "Only pool_creator_authority can use the current config to initialize new pool. When it's Pubkey::default, it's a public config."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "partner_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                219
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LockEscrow",
+      "docs": [
+        "State of lock escrow account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "docs": [
+              "Pool address"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner address"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "escrow_vault",
+            "docs": [
+              "Vault address, store the lock user lock"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "bump, used to sign"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "total_locked_amount",
+            "docs": [
+              "Total locked amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "lp_per_token",
+            "docs": [
+              "Lp per token, virtual price of lp token"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "unclaimed_fee_pending",
+            "docs": [
+              "Unclaimed fee pending"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "a_fee",
+            "docs": [
+              "Total a fee claimed so far"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "b_fee",
+            "docs": [
+              "Total b fee claimed so far"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Pool",
+      "docs": [
+        "State of pool account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint",
+            "docs": [
+              "LP token mint of the pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_mint",
+            "docs": [
+              "Token A mint of the pool. Eg: USDT"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_b_mint",
+            "docs": [
+              "Token B mint of the pool. Eg: USDC"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "a_vault",
+            "docs": [
+              "Vault account for token A. Token A of the pool will be deposit / withdraw from this vault account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "b_vault",
+            "docs": [
+              "Vault account for token B. Token B of the pool will be deposit / withdraw from this vault account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "a_vault_lp",
+            "docs": [
+              "LP token account of vault A. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "b_vault_lp",
+            "docs": [
+              "LP token account of vault B. Used to receive/burn the vault LP upon deposit/withdraw from the vault."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "a_vault_lp_bump",
+            "docs": [
+              "\"A\" vault lp bump. Used to create signer seeds."
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "enabled",
+            "docs": [
+              "Flag to determine whether the pool is enabled, or disabled."
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "protocol_token_a_fee",
+            "docs": [
+              "Protocol fee token account for token A. Used to receive trading fee."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_token_b_fee",
+            "docs": [
+              "Protocol fee token account for token B. Used to receive trading fee."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_last_updated_at",
+            "docs": [
+              "Fee last updated timestamp"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding0",
+            "type": {
+              "array": [
+                "u8",
+                24
+              ]
+            }
+          },
+          {
+            "name": "fees",
+            "docs": [
+              "Store the fee charges setting."
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolFees"
+              }
+            }
+          },
+          {
+            "name": "pool_type",
+            "docs": [
+              "Pool type"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolType"
+              }
+            }
+          },
+          {
+            "name": "stake",
+            "docs": [
+              "Stake pubkey of SPL stake pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "total_locked_lp",
+            "docs": [
+              "Total locked lp token"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bootstrapping",
+            "docs": [
+              "bootstrapping config"
+            ],
+            "type": {
+              "defined": {
+                "name": "Bootstrapping"
+              }
+            }
+          },
+          {
+            "name": "partner_info",
+            "type": {
+              "defined": {
+                "name": "PartnerInfo"
+              }
+            }
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Padding for future pool field"
+            ],
+            "type": {
+              "defined": {
+                "name": "Padding"
+              }
+            }
+          },
+          {
+            "name": "curve_type",
+            "docs": [
+              "The type of the swap curve supported by the pool."
+            ],
+            "type": {
+              "defined": {
+                "name": "CurveType"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "AddLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemoveLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_unmint_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_out_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_out_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BootstrapLiquidity",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Swap",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "in_amount",
+            "type": "u64"
+          },
+          {
+            "name": "out_amount",
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "host_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SetPoolFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_denominator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_denominator",
+            "type": "u64"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "virtual_price",
+            "type": "f64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferAdmin",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_admin",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OverrideCurveParam",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "new_amp",
+            "type": "u64"
+          },
+          {
+            "name": "updated_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolCreated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "lp_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_b_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_type",
+            "type": {
+              "defined": {
+                "name": "PoolType"
+              }
+            }
+          },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolEnabled",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "enabled",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigrateFeeAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_admin_token_a_fee",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_admin_token_b_fee",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateLockEscrow",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Lock",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ClaimFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "b_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_trade_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CloseConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawProtocolFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_b_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_a_fee_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_b_fee_owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PartnerClaimFees",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "partner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    }
   ]
 }

--- a/idl/meteora_damm_v2.json
+++ b/idl/meteora_damm_v2.json
@@ -1,1513 +1,4160 @@
 {
   "address": "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG",
-  "metadata": { "name": "cp_amm", "version": "0.1.6", "spec": "0.1.0", "description": "Created with Anchor" },
+  "metadata": {
+    "name": "cp_amm",
+    "version": "0.2.2",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
   "instructions": [
     {
       "name": "add_liquidity",
-      "discriminator": [181, 157, 89, 67, 143, 182, 52, 72],
-      "accounts": [
-        { "name": "pool", "writable": true, "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "token_a_account", "docs": ["The user token a account"], "writable": true },
-        { "name": "token_b_account", "docs": ["The user token b account"], "writable": true },
-        {
-          "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
-          "writable": true,
-          "relations": ["pool"]
-        },
-        {
-          "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
-          "writable": true,
-          "relations": ["pool"]
-        },
-        { "name": "token_a_mint", "docs": ["The mint of token a"], "relations": ["pool"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"], "relations": ["pool"] },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        181,
+        157,
+        89,
+        67,
+        143,
+        182,
+        52,
+        72
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "AddLiquidityParameters" } } }]
-    },
-    {
-      "name": "claim_partner_fee",
-      "discriminator": [97, 206, 39, 105, 94, 94, 126, 148],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true },
-        { "name": "token_a_account", "docs": ["The treasury token a account"], "writable": true },
-        { "name": "token_b_account", "docs": ["The treasury token b account"], "writable": true },
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The user token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The user token b account"
+          ],
+          "writable": true
+        },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"], "relations": ["pool"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"], "relations": ["pool"] },
-        { "name": "partner", "signer": true, "relations": ["pool"] },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ],
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "program" }
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "max_amount_a", "type": "u64" },
-        { "name": "max_amount_b", "type": "u64" }
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "AddLiquidityParameters"
+            }
+          }
+        }
       ]
     },
     {
       "name": "claim_position_fee",
-      "discriminator": [180, 38, 154, 17, 133, 33, 162, 211],
+      "discriminator": [
+        180,
+        38,
+        154,
+        17,
+        133,
+        33,
+        162,
+        211
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "token_a_account", "docs": ["The user token a account"], "writable": true },
-        { "name": "token_b_account", "docs": ["The user token b account"], "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The user token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The user token b account"
+          ],
+          "writable": true
+        },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"], "relations": ["pool"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"], "relations": ["pool"] },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ],
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "program" }
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "claim_protocol_fee",
-      "discriminator": [165, 228, 133, 48, 99, 249, 255, 33],
+      "discriminator": [
+        165,
+        228,
+        133,
+        48,
+        99,
+        249,
+        255,
+        33
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"], "relations": ["pool"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"], "relations": ["pool"] },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
         {
           "name": "token_a_account",
-          "docs": ["The treasury token a account"],
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  48, 9, 89, 123, 106, 114, 131, 251, 50, 173, 254, 250, 10, 80, 160, 84, 143, 100,
-                  81, 249, 134, 112, 30, 213, 50, 166, 239, 78, 53, 175, 188, 85
-                ]
-              },
-              { "kind": "account", "path": "token_a_program" },
-              { "kind": "account", "path": "token_a_mint" }
-            ],
-            "program": {
-              "kind": "const",
-              "value": [
-                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19, 153,
-                218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
-              ]
-            }
-          }
+          "writable": true
         },
         {
           "name": "token_b_account",
-          "docs": ["The treasury token b account"],
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  48, 9, 89, 123, 106, 114, 131, 251, 50, 173, 254, 250, 10, 80, 160, 84, 143, 100,
-                  81, 249, 134, 112, 30, 213, 50, 166, 239, 78, 53, 175, 188, 85
-                ]
-              },
-              { "kind": "account", "path": "token_b_program" },
-              { "kind": "account", "path": "token_b_mint" }
-            ],
-            "program": {
-              "kind": "const",
-              "value": [
-                140, 151, 37, 143, 78, 36, 137, 241, 187, 61, 16, 41, 20, 142, 13, 131, 11, 90, 19, 153,
-                218, 255, 16, 132, 4, 142, 123, 216, 219, 233, 248, 89
-              ]
-            }
-          }
+          "writable": true
         },
-        { "name": "operator", "docs": ["Claim fee operator"] },
-        { "name": "whitelisted_address", "docs": ["Operator"], "signer": true, "relations": ["operator"] },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "operator",
+          "docs": [
+            "Claim fee operator"
+          ]
         },
-        { "name": "program" }
+        {
+          "name": "signer",
+          "docs": [
+            "Operator"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "max_amount_a", "type": "u64" },
-        { "name": "max_amount_b", "type": "u64" }
+        {
+          "name": "max_amount_a",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_b",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_protocol_fee2",
+      "discriminator": [
+        235,
+        194,
+        54,
+        69,
+        65,
+        10,
+        236,
+        112
+      ],
+      "accounts": [
+        {
+          "name": "receiver_token_account",
+          "docs": [
+            "receiver token account for the claimed token. validated through the protocol_fee program"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_mint",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_a_program"
+        },
+        {
+          "name": "token_b_program"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_vault",
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "token_b_vault",
+          "writable": true,
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "signer",
+          "signer": true,
+          "address": "FkU5rQCWQM131skHCpcEbK8P1JrQGsBgqXe55w525SSF"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
       ]
     },
     {
       "name": "claim_reward",
-      "discriminator": [149, 95, 181, 242, 94, 90, 158, 162],
+      "discriminator": [
+        149,
+        95,
+        181,
+        242,
+        94,
+        90,
+        158,
+        162
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true, "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "reward_vault", "docs": ["The vault token account for reward token"], "writable": true },
-        { "name": "reward_mint" },
-        { "name": "user_token_account", "writable": true },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        { "name": "token_program" },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
         },
-        { "name": "program" }
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "reward_vault",
+          "docs": [
+            "The vault token account for reward token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "user_token_account",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "reward_index", "type": "u8" },
-        { "name": "skip_reward", "type": "u8" }
+        {
+          "name": "reward_index",
+          "type": "u8"
+        },
+        {
+          "name": "skip_reward",
+          "type": "u8"
+        }
       ]
     },
     {
       "name": "close_config",
-      "discriminator": [145, 9, 72, 157, 95, 125, 61, 85],
+      "discriminator": [
+        145,
+        9,
+        72,
+        157,
+        95,
+        125,
+        61,
+        85
+      ],
       "accounts": [
-        { "name": "config", "writable": true },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        { "name": "rent_receiver", "writable": true },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "config",
+          "writable": true
         },
-        { "name": "program" }
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "close_operator_account",
-      "discriminator": [171, 9, 213, 74, 120, 23, 3, 29],
+      "discriminator": [
+        171,
+        9,
+        213,
+        74,
+        120,
+        23,
+        3,
+        29
+      ],
       "accounts": [
-        { "name": "operator", "writable": true },
-        { "name": "admin", "signer": true },
-        { "name": "rent_receiver", "writable": true },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "operator",
+          "writable": true
         },
-        { "name": "program" }
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "close_position",
-      "discriminator": [123, 134, 81, 0, 49, 68, 98, 98],
+      "discriminator": [
+        123,
+        134,
+        81,
+        0,
+        49,
+        68,
+        98,
+        98
+      ],
       "accounts": [
-        { "name": "position_nft_mint", "docs": ["position_nft_mint"], "writable": true },
-        { "name": "position_nft_account", "docs": ["The token account for nft"], "writable": true },
-        { "name": "pool", "writable": true, "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "rent_receiver", "writable": true },
-        { "name": "owner", "docs": ["Owner of position"], "signer": true },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "position_nft_mint"
+          ],
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "owner",
+          "docs": [
+            "Owner of position"
+          ],
+          "signer": true
+        },
         {
           "name": "token_program",
-          "docs": ["Program to create NFT mint/token account and transfer for token22 account"],
+          "docs": [
+            "Program to create NFT mint/token account and transfer for token22 account"
+          ],
           "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
-        { "name": "program" }
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "close_token_badge",
-      "discriminator": [108, 146, 86, 110, 179, 254, 10, 104],
+      "discriminator": [
+        108,
+        146,
+        86,
+        110,
+        179,
+        254,
+        10,
+        104
+      ],
       "accounts": [
-        { "name": "token_badge", "writable": true },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        { "name": "rent_receiver", "writable": true },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "token_badge",
+          "writable": true
         },
-        { "name": "program" }
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "create_config",
-      "docs": ["OPERATOR FUNCTIONS /////"],
-      "discriminator": [201, 207, 243, 114, 75, 111, 47, 189],
+      "docs": [
+        "OPERATOR FUNCTIONS /////"
+      ],
+      "discriminator": [
+        201,
+        207,
+        243,
+        114,
+        75,
+        111,
+        47,
+        189
+      ],
       "accounts": [
         {
           "name": "config",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [99, 111, 110, 102, 105, 103] },
-              { "kind": "arg", "path": "index" }
-            ]
-          }
-        },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        { "name": "payer", "writable": true, "signer": true },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
+              },
+              {
+                "kind": "arg",
+                "path": "index"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "index", "type": "u64" },
-        { "name": "config_parameters", "type": { "defined": { "name": "StaticConfigParameters" } } }
+        {
+          "name": "index",
+          "type": "u64"
+        },
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "StaticConfigParameters"
+            }
+          }
+        }
       ]
     },
     {
       "name": "create_dynamic_config",
-      "discriminator": [81, 251, 122, 78, 66, 57, 208, 82],
+      "discriminator": [
+        81,
+        251,
+        122,
+        78,
+        66,
+        57,
+        208,
+        82
+      ],
       "accounts": [
         {
           "name": "config",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [99, 111, 110, 102, 105, 103] },
-              { "kind": "arg", "path": "index" }
-            ]
-          }
-        },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        { "name": "payer", "writable": true, "signer": true },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
                 ]
+              },
+              {
+                "kind": "arg",
+                "path": "index"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "index", "type": "u64" },
-        { "name": "config_parameters", "type": { "defined": { "name": "DynamicConfigParameters" } } }
+        {
+          "name": "index",
+          "type": "u64"
+        },
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "DynamicConfigParameters"
+            }
+          }
+        }
       ]
     },
     {
       "name": "create_operator_account",
-      "docs": ["ADMIN FUNCTIONS /////"],
-      "discriminator": [221, 64, 246, 149, 240, 153, 229, 163],
+      "docs": [
+        "ADMIN FUNCTIONS /////"
+      ],
+      "discriminator": [
+        221,
+        64,
+        246,
+        149,
+        240,
+        153,
+        229,
+        163
+      ],
       "accounts": [
         {
           "name": "operator",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [111, 112, 101, 114, 97, 116, 111, 114] },
-              { "kind": "account", "path": "whitelisted_address" }
-            ]
-          }
-        },
-        { "name": "whitelisted_address" },
-        { "name": "admin", "signer": true },
-        { "name": "payer", "writable": true, "signer": true },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  111,
+                  114
                 ]
+              },
+              {
+                "kind": "account",
+                "path": "whitelisted_address"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "whitelisted_address"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "permission", "type": "u128" }]
+      "args": [
+        {
+          "name": "permission",
+          "type": "u128"
+        }
+      ]
     },
     {
       "name": "create_position",
-      "discriminator": [48, 215, 197, 153, 96, 203, 180, 133],
+      "discriminator": [
+        48,
+        215,
+        197,
+        153,
+        96,
+        203,
+        180,
+        133
+      ],
       "accounts": [
-        { "name": "owner" },
-        { "name": "position_nft_mint", "docs": ["position_nft_mint"], "writable": true, "signer": true },
+        {
+          "name": "owner"
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "position_nft_mint"
+          ],
+          "writable": true,
+          "signer": true
+        },
         {
           "name": "position_nft_account",
-          "docs": ["position nft account"],
+          "docs": [
+            "position nft account"
+          ],
           "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  112, 111, 115, 105, 116, 105, 111, 110, 95, 110, 102, 116, 95, 97, 99, 99, 111, 117,
-                  110, 116
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  110,
+                  102,
+                  116,
+                  95,
+                  97,
+                  99,
+                  99,
+                  111,
+                  117,
+                  110,
+                  116
                 ]
               },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
-        { "name": "pool", "writable": true },
+        {
+          "name": "pool",
+          "writable": true
+        },
         {
           "name": "position",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [112, 111, 115, 105, 116, 105, 111, 110] },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
         {
           "name": "payer",
-          "docs": ["Address paying to create the position. Can be anyone"],
+          "docs": [
+            "Address paying to create the position. Can be anyone"
+          ],
           "writable": true,
           "signer": true
         },
         {
           "name": "token_program",
-          "docs": ["Program to create NFT mint/token account and transfer for token22 account"],
+          "docs": [
+            "Program to create NFT mint/token account and transfer for token22 account"
+          ],
           "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         },
-        { "name": "program" }
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "create_token_badge",
-      "discriminator": [88, 206, 0, 91, 60, 175, 151, 118],
+      "discriminator": [
+        88,
+        206,
+        0,
+        91,
+        60,
+        175,
+        151,
+        118
+      ],
       "accounts": [
         {
           "name": "token_badge",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 98, 97, 100, 103, 101] },
-              { "kind": "account", "path": "token_mint" }
-            ]
-          }
-        },
-        { "name": "token_mint" },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        { "name": "payer", "writable": true, "signer": true },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  98,
+                  97,
+                  100,
+                  103,
+                  101
                 ]
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": []
     },
     {
       "name": "dummy_ix",
-      "discriminator": [234, 95, 176, 185, 7, 42, 35, 159],
-      "accounts": [
-        { "name": "pod_aligned_fee_time_scheduler" },
-        { "name": "pod_aligned_fee_rate_limiter" },
-        { "name": "pod_aligned_fee_market_cap_scheduler" }
+      "discriminator": [
+        234,
+        95,
+        176,
+        185,
+        7,
+        42,
+        35,
+        159
       ],
-      "args": [{ "name": "_ixs", "type": { "defined": { "name": "DummyParams" } } }]
+      "accounts": [
+        {
+          "name": "pod_aligned_fee_time_scheduler"
+        },
+        {
+          "name": "pod_aligned_fee_rate_limiter"
+        },
+        {
+          "name": "pod_aligned_fee_market_cap_scheduler"
+        }
+      ],
+      "args": [
+        {
+          "name": "_ixs",
+          "type": {
+            "defined": {
+              "name": "DummyParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fix_config_fee_params",
+      "discriminator": [
+        38,
+        30,
+        216,
+        81,
+        250,
+        177,
+        243,
+        254
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "BaseFeeParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fix_pool_fee_params",
+      "discriminator": [
+        132,
+        98,
+        81,
+        196,
+        44,
+        58,
+        120,
+        193
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "BaseFeeParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "fix_pool_layout_version",
+      "discriminator": [
+        166,
+        158,
+        69,
+        35,
+        81,
+        167,
+        200,
+        215
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        }
+      ],
+      "args": []
     },
     {
       "name": "fund_reward",
-      "discriminator": [188, 50, 249, 165, 93, 151, 38, 63],
+      "discriminator": [
+        188,
+        50,
+        249,
+        165,
+        93,
+        151,
+        38,
+        63
+      ],
       "accounts": [
-        { "name": "pool", "writable": true },
-        { "name": "reward_vault", "writable": true },
-        { "name": "reward_mint" },
-        { "name": "funder_token_account", "writable": true },
-        { "name": "funder", "signer": true },
-        { "name": "token_program" },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "pool",
+          "writable": true
         },
-        { "name": "program" }
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "reward_index", "type": "u8" },
-        { "name": "amount", "type": "u64" },
-        { "name": "carry_forward", "type": "bool" }
+        {
+          "name": "reward_index",
+          "type": "u8"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "carry_forward",
+          "type": "bool"
+        }
       ]
     },
     {
       "name": "initialize_customizable_pool",
-      "discriminator": [20, 161, 241, 24, 189, 221, 180, 2],
+      "discriminator": [
+        20,
+        161,
+        241,
+        24,
+        189,
+        221,
+        180,
+        2
+      ],
       "accounts": [
-        { "name": "creator" },
-        { "name": "position_nft_mint", "docs": ["position_nft_mint"], "writable": true, "signer": true },
+        {
+          "name": "creator"
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "position_nft_mint"
+          ],
+          "writable": true,
+          "signer": true
+        },
         {
           "name": "position_nft_account",
-          "docs": ["position nft account"],
+          "docs": [
+            "position nft account"
+          ],
           "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  112, 111, 115, 105, 116, 105, 111, 110, 95, 110, 102, 116, 95, 97, 99, 99, 111, 117,
-                  110, 116
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  110,
+                  102,
+                  116,
+                  95,
+                  97,
+                  99,
+                  99,
+                  111,
+                  117,
+                  110,
+                  116
                 ]
               },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
         {
           "name": "payer",
-          "docs": ["Address paying to create the pool. Can be anyone"],
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
           "writable": true,
           "signer": true
         },
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "docs": ["Initialize an account to store the pool state"], "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true
+        },
         {
           "name": "position",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [112, 111, 115, 105, 116, 105, 111, 110] },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
-        { "name": "token_a_mint", "docs": ["Token a mint"] },
-        { "name": "token_b_mint", "docs": ["Token b mint"] },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token a mint"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token b mint"
+          ]
+        },
         {
           "name": "token_a_vault",
-          "docs": ["Token a vault for the pool"],
+          "docs": [
+            "Token a vault for the pool"
+          ],
           "writable": true,
-          "pda": {
-            "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "token_a_mint" },
-              { "kind": "account", "path": "pool" }
-            ]
-          }
-        },
-        {
-          "name": "token_b_vault",
-          "docs": ["Token b vault for the pool"],
-          "writable": true,
-          "pda": {
-            "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "token_b_mint" },
-              { "kind": "account", "path": "pool" }
-            ]
-          }
-        },
-        { "name": "payer_token_a", "docs": ["payer token a account"], "writable": true },
-        { "name": "payer_token_b", "docs": ["creator token b account"], "writable": true },
-        { "name": "token_a_program", "docs": ["Program to create mint account and mint tokens"] },
-        { "name": "token_b_program", "docs": ["Program to create mint account and mint tokens"] },
-        {
-          "name": "token_2022_program",
-          "docs": ["Program to create NFT mint/token account and transfer for token22 account"],
-          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
-        },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
                 ]
+              },
+              {
+                "kind": "account",
+                "path": "token_a_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "token_b_vault",
+          "docs": [
+            "Token b vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_b_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "payer token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "creator token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_2022_program",
+          "docs": [
+            "Program to create NFT mint/token account and transfer for token22 account"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "InitializeCustomizablePoolParameters" } } }]
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializeCustomizablePoolParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "initialize_pool",
-      "docs": ["USER FUNCTIONS ////"],
-      "discriminator": [95, 180, 10, 172, 84, 174, 232, 40],
+      "docs": [
+        "USER FUNCTIONS ////"
+      ],
+      "discriminator": [
+        95,
+        180,
+        10,
+        172,
+        84,
+        174,
+        232,
+        40
+      ],
       "accounts": [
-        { "name": "creator" },
-        { "name": "position_nft_mint", "docs": ["position_nft_mint"], "writable": true, "signer": true },
+        {
+          "name": "creator"
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "position_nft_mint"
+          ],
+          "writable": true,
+          "signer": true
+        },
         {
           "name": "position_nft_account",
-          "docs": ["position nft account"],
+          "docs": [
+            "position nft account"
+          ],
           "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  112, 111, 115, 105, 116, 105, 111, 110, 95, 110, 102, 116, 95, 97, 99, 99, 111, 117,
-                  110, 116
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  110,
+                  102,
+                  116,
+                  95,
+                  97,
+                  99,
+                  99,
+                  111,
+                  117,
+                  110,
+                  116
                 ]
               },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
         {
           "name": "payer",
-          "docs": ["Address paying to create the pool. Can be anyone"],
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
           "writable": true,
           "signer": true
         },
-        { "name": "config", "docs": ["Which config the pool belongs to."] },
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "docs": ["Initialize an account to store the pool state"], "writable": true },
+        {
+          "name": "config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true
+        },
         {
           "name": "position",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [112, 111, 115, 105, 116, 105, 111, 110] },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
-        { "name": "token_a_mint", "docs": ["Token a mint"] },
-        { "name": "token_b_mint", "docs": ["Token b mint"] },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token a mint"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token b mint"
+          ]
+        },
         {
           "name": "token_a_vault",
-          "docs": ["Token a vault for the pool"],
+          "docs": [
+            "Token a vault for the pool"
+          ],
           "writable": true,
-          "pda": {
-            "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "token_a_mint" },
-              { "kind": "account", "path": "pool" }
-            ]
-          }
-        },
-        {
-          "name": "token_b_vault",
-          "docs": ["Token b vault for the pool"],
-          "writable": true,
-          "pda": {
-            "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "token_b_mint" },
-              { "kind": "account", "path": "pool" }
-            ]
-          }
-        },
-        { "name": "payer_token_a", "docs": ["payer token a account"], "writable": true },
-        { "name": "payer_token_b", "docs": ["creator token b account"], "writable": true },
-        { "name": "token_a_program", "docs": ["Program to create mint account and mint tokens"] },
-        { "name": "token_b_program", "docs": ["Program to create mint account and mint tokens"] },
-        {
-          "name": "token_2022_program",
-          "docs": ["Program to create NFT mint/token account and transfer for token22 account"],
-          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
-        },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
                 ]
+              },
+              {
+                "kind": "account",
+                "path": "token_a_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "token_b_vault",
+          "docs": [
+            "Token b vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_b_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "payer token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "creator token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_2022_program",
+          "docs": [
+            "Program to create NFT mint/token account and transfer for token22 account"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "InitializePoolParameters" } } }]
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializePoolParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "initialize_pool_with_dynamic_config",
-      "discriminator": [149, 82, 72, 197, 253, 252, 68, 15],
+      "discriminator": [
+        149,
+        82,
+        72,
+        197,
+        253,
+        252,
+        68,
+        15
+      ],
       "accounts": [
-        { "name": "creator" },
-        { "name": "position_nft_mint", "docs": ["position_nft_mint"], "writable": true, "signer": true },
+        {
+          "name": "creator"
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "position_nft_mint"
+          ],
+          "writable": true,
+          "signer": true
+        },
         {
           "name": "position_nft_account",
-          "docs": ["position nft account"],
+          "docs": [
+            "position nft account"
+          ],
           "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  112, 111, 115, 105, 116, 105, 111, 110, 95, 110, 102, 116, 95, 97, 99, 99, 111, 117,
-                  110, 116
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  110,
+                  102,
+                  116,
+                  95,
+                  97,
+                  99,
+                  99,
+                  111,
+                  117,
+                  110,
+                  116
                 ]
               },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
         {
           "name": "payer",
-          "docs": ["Address paying to create the pool. Can be anyone"],
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
           "writable": true,
           "signer": true
         },
-        { "name": "pool_creator_authority", "signer": true, "relations": ["config"] },
-        { "name": "config", "docs": ["Which config the pool belongs to."] },
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "docs": ["Initialize an account to store the pool state"], "writable": true },
+        {
+          "name": "pool_creator_authority",
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true
+        },
         {
           "name": "position",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [112, 111, 115, 105, 116, 105, 111, 110] },
-              { "kind": "account", "path": "position_nft_mint" }
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
             ]
           }
         },
-        { "name": "token_a_mint", "docs": ["Token a mint"] },
-        { "name": "token_b_mint", "docs": ["Token b mint"] },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "Token a mint"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "Token b mint"
+          ]
+        },
         {
           "name": "token_a_vault",
-          "docs": ["Token a vault for the pool"],
+          "docs": [
+            "Token a vault for the pool"
+          ],
           "writable": true,
-          "pda": {
-            "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "token_a_mint" },
-              { "kind": "account", "path": "pool" }
-            ]
-          }
-        },
-        {
-          "name": "token_b_vault",
-          "docs": ["Token b vault for the pool"],
-          "writable": true,
-          "pda": {
-            "seeds": [
-              { "kind": "const", "value": [116, 111, 107, 101, 110, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "token_b_mint" },
-              { "kind": "account", "path": "pool" }
-            ]
-          }
-        },
-        { "name": "payer_token_a", "docs": ["payer token a account"], "writable": true },
-        { "name": "payer_token_b", "docs": ["creator token b account"], "writable": true },
-        { "name": "token_a_program", "docs": ["Program to create mint account and mint tokens"] },
-        { "name": "token_b_program", "docs": ["Program to create mint account and mint tokens"] },
-        {
-          "name": "token_2022_program",
-          "docs": ["Program to create NFT mint/token account and transfer for token22 account"],
-          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
-        },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
                 ]
+              },
+              {
+                "kind": "account",
+                "path": "token_a_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "token_b_vault",
+          "docs": [
+            "Token b vault for the pool"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_b_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer_token_a",
+          "docs": [
+            "payer token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_token_b",
+          "docs": [
+            "creator token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ]
+        },
+        {
+          "name": "token_2022_program",
+          "docs": [
+            "Program to create NFT mint/token account and transfer for token22 account"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "InitializeCustomizablePoolParameters" } } }]
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializeCustomizablePoolParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "initialize_reward",
-      "discriminator": [95, 135, 192, 196, 242, 129, 230, 68],
+      "discriminator": [
+        95,
+        135,
+        192,
+        196,
+        242,
+        129,
+        230,
+        68
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
         {
           "name": "reward_vault",
           "writable": true,
           "pda": {
             "seeds": [
-              { "kind": "const", "value": [114, 101, 119, 97, 114, 100, 95, 118, 97, 117, 108, 116] },
-              { "kind": "account", "path": "pool" },
-              { "kind": "arg", "path": "reward_index" }
-            ]
-          }
-        },
-        { "name": "reward_mint" },
-        { "name": "signer", "signer": true },
-        { "name": "payer", "writable": true, "signer": true },
-        { "name": "token_program" },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
+                  114,
+                  101,
+                  119,
+                  97,
+                  114,
+                  100,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
                 ]
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              },
+              {
+                "kind": "arg",
+                "path": "reward_index"
               }
             ]
           }
         },
-        { "name": "program" }
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "reward_index", "type": "u8" },
-        { "name": "reward_duration", "type": "u64" },
-        { "name": "funder", "type": "pubkey" }
+        {
+          "name": "reward_index",
+          "type": "u8"
+        },
+        {
+          "name": "reward_duration",
+          "type": "u64"
+        },
+        {
+          "name": "funder",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "lock_inner_position",
+      "discriminator": [
+        72,
+        19,
+        49,
+        204,
+        18,
+        122,
+        23,
+        90
+      ],
+      "accounts": [
+        {
+          "name": "pool",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "VestingParameters"
+            }
+          }
+        }
       ]
     },
     {
       "name": "lock_position",
-      "discriminator": [227, 62, 2, 252, 247, 10, 171, 185],
-      "accounts": [
-        { "name": "pool", "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "vesting", "writable": true, "signer": true },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        { "name": "payer", "writable": true, "signer": true },
-        { "name": "system_program", "address": "11111111111111111111111111111111" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        227,
+        62,
+        2,
+        252,
+        247,
+        10,
+        171,
+        185
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "VestingParameters" } } }]
+      "accounts": [
+        {
+          "name": "pool",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "vesting",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "VestingParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "permanent_lock_position",
-      "discriminator": [165, 176, 125, 6, 231, 171, 186, 213],
-      "accounts": [
-        { "name": "pool", "writable": true, "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        165,
+        176,
+        125,
+        6,
+        231,
+        171,
+        186,
+        213
       ],
-      "args": [{ "name": "permanent_lock_liquidity", "type": "u128" }]
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "permanent_lock_liquidity",
+          "type": "u128"
+        }
+      ]
     },
     {
       "name": "refresh_vesting",
-      "discriminator": [9, 94, 216, 14, 116, 204, 247, 0],
+      "discriminator": [
+        9,
+        94,
+        216,
+        14,
+        116,
+        204,
+        247,
+        0
+      ],
       "accounts": [
-        { "name": "pool", "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner" }
+        {
+          "name": "pool",
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "owner"
+        }
       ],
       "args": []
     },
     {
       "name": "remove_all_liquidity",
-      "discriminator": [10, 51, 61, 35, 112, 105, 24, 85],
+      "discriminator": [
+        10,
+        51,
+        61,
+        35,
+        112,
+        105,
+        24,
+        85
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true, "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "token_a_account", "docs": ["The user token a account"], "writable": true },
-        { "name": "token_b_account", "docs": ["The user token b account"], "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The user token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The user token b account"
+          ],
+          "writable": true
+        },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"], "relations": ["pool"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"], "relations": ["pool"] },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ],
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "program" }
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "token_a_amount_threshold", "type": "u64" },
-        { "name": "token_b_amount_threshold", "type": "u64" }
+        {
+          "name": "token_a_amount_threshold",
+          "type": "u64"
+        },
+        {
+          "name": "token_b_amount_threshold",
+          "type": "u64"
+        }
       ]
     },
     {
       "name": "remove_liquidity",
-      "discriminator": [80, 85, 209, 72, 24, 206, 177, 108],
+      "discriminator": [
+        80,
+        85,
+        209,
+        72,
+        24,
+        206,
+        177,
+        108
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true, "relations": ["position"] },
-        { "name": "position", "writable": true },
-        { "name": "token_a_account", "docs": ["The user token a account"], "writable": true },
-        { "name": "token_b_account", "docs": ["The user token b account"], "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "position"
+          ]
+        },
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The user token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The user token b account"
+          ],
+          "writable": true
+        },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"], "relations": ["pool"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"], "relations": ["pool"] },
-        { "name": "position_nft_account", "docs": ["The token account for nft"] },
-        { "name": "owner", "docs": ["owner of position"], "signer": true },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ],
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "program" }
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ],
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Signer"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "RemoveLiquidityParameters" } } }]
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "RemoveLiquidityParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "set_pool_status",
-      "discriminator": [112, 87, 135, 223, 83, 204, 132, 53],
-      "accounts": [
-        { "name": "pool", "writable": true },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        112,
+        87,
+        135,
+        223,
+        83,
+        204,
+        132,
+        53
       ],
-      "args": [{ "name": "status", "type": "u8" }]
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": "u8"
+        }
+      ]
     },
     {
       "name": "split_position",
-      "discriminator": [172, 241, 221, 138, 161, 29, 253, 42],
-      "accounts": [
-        { "name": "pool", "writable": true, "relations": ["first_position", "second_position"] },
-        { "name": "first_position", "docs": ["The first position"], "writable": true },
-        { "name": "first_position_nft_account", "docs": ["The token account for position nft"] },
-        { "name": "second_position", "docs": ["The second position"], "writable": true },
-        { "name": "second_position_nft_account", "docs": ["The token account for position nft"] },
-        { "name": "first_owner", "docs": ["Owner of first position"], "signer": true },
-        { "name": "second_owner", "docs": ["Owner of second position"], "signer": true },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        172,
+        241,
+        221,
+        138,
+        161,
+        29,
+        253,
+        42
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "SplitPositionParameters" } } }]
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "first_position",
+            "second_position"
+          ]
+        },
+        {
+          "name": "first_position",
+          "docs": [
+            "The first position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "first_position_nft_account",
+          "docs": [
+            "The token account for position nft"
+          ]
+        },
+        {
+          "name": "second_position",
+          "docs": [
+            "The second position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "second_position_nft_account",
+          "docs": [
+            "The token account for position nft"
+          ]
+        },
+        {
+          "name": "first_owner",
+          "docs": [
+            "Owner of first position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "second_owner",
+          "docs": [
+            "Owner of second position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "SplitPositionParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "split_position2",
-      "discriminator": [221, 147, 228, 207, 140, 212, 17, 119],
-      "accounts": [
-        { "name": "pool", "writable": true, "relations": ["first_position", "second_position"] },
-        { "name": "first_position", "docs": ["The first position"], "writable": true },
-        { "name": "first_position_nft_account", "docs": ["The token account for position nft"] },
-        { "name": "second_position", "docs": ["The second position"], "writable": true },
-        { "name": "second_position_nft_account", "docs": ["The token account for position nft"] },
-        { "name": "first_owner", "docs": ["Owner of first position"], "signer": true },
-        { "name": "second_owner", "docs": ["Owner of second position"], "signer": true },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        221,
+        147,
+        228,
+        207,
+        140,
+        212,
+        17,
+        119
       ],
-      "args": [{ "name": "numerator", "type": "u32" }]
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true,
+          "relations": [
+            "first_position",
+            "second_position"
+          ]
+        },
+        {
+          "name": "first_position",
+          "docs": [
+            "The first position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "first_position_nft_account",
+          "docs": [
+            "The token account for position nft"
+          ]
+        },
+        {
+          "name": "second_position",
+          "docs": [
+            "The second position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "second_position_nft_account",
+          "docs": [
+            "The token account for position nft"
+          ]
+        },
+        {
+          "name": "first_owner",
+          "docs": [
+            "Owner of first position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "second_owner",
+          "docs": [
+            "Owner of second position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "numerator",
+          "type": "u32"
+        }
+      ]
     },
     {
       "name": "swap",
-      "discriminator": [248, 198, 158, 145, 225, 117, 135, 200],
+      "discriminator": [
+        248,
+        198,
+        158,
+        145,
+        225,
+        117,
+        135,
+        200
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "docs": ["Pool account"], "writable": true },
-        { "name": "input_token_account", "docs": ["The user token account for input token"], "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
         {
           "name": "output_token_account",
-          "docs": ["The user token account for output token"],
+          "docs": [
+            "The user token account for output token"
+          ],
           "writable": true
         },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"] },
-        { "name": "payer", "docs": ["The user performing the swap"], "signer": true },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
         {
           "name": "referral_token_account",
-          "docs": ["referral token account"],
+          "docs": [
+            "referral token account"
+          ],
           "writable": true,
           "optional": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
-        { "name": "program" }
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "_params", "type": { "defined": { "name": "SwapParameters" } } }]
+      "args": [
+        {
+          "name": "_params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "swap2",
-      "discriminator": [65, 75, 63, 76, 235, 91, 91, 136],
+      "discriminator": [
+        65,
+        75,
+        63,
+        76,
+        235,
+        91,
+        91,
+        136
+      ],
       "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "docs": ["Pool account"], "writable": true },
-        { "name": "input_token_account", "docs": ["The user token account for input token"], "writable": true },
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "docs": [
+            "Pool account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
         {
           "name": "output_token_account",
-          "docs": ["The user token account for output token"],
+          "docs": [
+            "The user token account for output token"
+          ],
           "writable": true
         },
         {
           "name": "token_a_vault",
-          "docs": ["The vault token account for input token"],
+          "docs": [
+            "The vault token account for input token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
         {
           "name": "token_b_vault",
-          "docs": ["The vault token account for output token"],
+          "docs": [
+            "The vault token account for output token"
+          ],
           "writable": true,
-          "relations": ["pool"]
+          "relations": [
+            "pool"
+          ]
         },
-        { "name": "token_a_mint", "docs": ["The mint of token a"] },
-        { "name": "token_b_mint", "docs": ["The mint of token b"] },
-        { "name": "payer", "docs": ["The user performing the swap"], "signer": true },
-        { "name": "token_a_program", "docs": ["Token a program"] },
-        { "name": "token_b_program", "docs": ["Token b program"] },
+        {
+          "name": "token_a_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "token_b_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_a_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_b_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
         {
           "name": "referral_token_account",
-          "docs": ["referral token account"],
+          "docs": [
+            "referral token account"
+          ],
           "writable": true,
           "optional": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
-        { "name": "program" }
+        {
+          "name": "program"
+        }
       ],
-      "args": [{ "name": "_params", "type": { "defined": { "name": "SwapParameters2" } } }]
+      "args": [
+        {
+          "name": "_params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters2"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_delegate_permission",
+      "discriminator": [
+        175,
+        165,
+        56,
+        64,
+        0,
+        251,
+        89,
+        47
+      ],
+      "accounts": [
+        {
+          "name": "position",
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "permission",
+          "type": "u32"
+        }
+      ]
     },
     {
       "name": "update_pool_fees",
-      "discriminator": [118, 217, 203, 179, 60, 8, 70, 89],
-      "accounts": [
-        { "name": "pool", "writable": true },
-        { "name": "operator" },
-        { "name": "whitelisted_address", "signer": true, "relations": ["operator"] },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        118,
+        217,
+        203,
+        179,
+        60,
+        8,
+        70,
+        89
       ],
-      "args": [{ "name": "params", "type": { "defined": { "name": "UpdatePoolFeesParameters" } } }]
+      "accounts": [
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "UpdatePoolFeesParameters"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "update_reward_duration",
-      "discriminator": [138, 174, 196, 169, 213, 235, 254, 107],
+      "discriminator": [
+        138,
+        174,
+        196,
+        169,
+        213,
+        235,
+        254,
+        107
+      ],
       "accounts": [
-        { "name": "pool", "writable": true },
-        { "name": "signer", "signer": true },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "pool",
+          "writable": true
         },
-        { "name": "program" }
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "reward_index", "type": "u8" },
-        { "name": "new_duration", "type": "u64" }
+        {
+          "name": "reward_index",
+          "type": "u8"
+        },
+        {
+          "name": "new_duration",
+          "type": "u64"
+        }
       ]
     },
     {
       "name": "update_reward_funder",
-      "discriminator": [211, 28, 48, 32, 215, 160, 35, 23],
+      "discriminator": [
+        211,
+        28,
+        48,
+        32,
+        215,
+        160,
+        35,
+        23
+      ],
       "accounts": [
-        { "name": "pool", "writable": true },
-        { "name": "signer", "signer": true },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
+          "name": "pool",
+          "writable": true
         },
-        { "name": "program" }
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
       ],
       "args": [
-        { "name": "reward_index", "type": "u8" },
-        { "name": "new_funder", "type": "pubkey" }
+        {
+          "name": "reward_index",
+          "type": "u8"
+        },
+        {
+          "name": "new_funder",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_dead_liquidity_reward",
+      "discriminator": [
+        121,
+        99,
+        224,
+        91,
+        178,
+        14,
+        22,
+        132
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u8"
+        }
       ]
     },
     {
       "name": "withdraw_ineligible_reward",
-      "discriminator": [148, 206, 42, 195, 247, 49, 103, 8],
-      "accounts": [
-        { "name": "pool_authority", "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC" },
-        { "name": "pool", "writable": true },
-        { "name": "reward_vault", "writable": true },
-        { "name": "reward_mint" },
-        { "name": "funder_token_account", "writable": true },
-        { "name": "funder", "signer": true },
-        { "name": "token_program" },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121
-                ]
-              }
-            ]
-          }
-        },
-        { "name": "program" }
+      "discriminator": [
+        148,
+        206,
+        42,
+        195,
+        247,
+        49,
+        103,
+        8
       ],
-      "args": [{ "name": "reward_index", "type": "u8" }]
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "reward_vault",
+          "writable": true
+        },
+        {
+          "name": "reward_mint"
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
+        },
+        {
+          "name": "funder",
+          "signer": true
+        },
+        {
+          "name": "token_program"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "zap_protocol_fee",
+      "discriminator": [
+        213,
+        155,
+        187,
+        34,
+        56,
+        182,
+        91,
+        240
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_vault",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "receiver_token",
+          "writable": true
+        },
+        {
+          "name": "operator",
+          "docs": [
+            "zap claim fee operator"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Operator"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program"
+          ]
+        },
+        {
+          "name": "sysvar_instructions",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
     }
   ],
   "accounts": [
-    { "name": "Config", "discriminator": [155, 12, 170, 224, 30, 250, 204, 130] },
-    { "name": "Operator", "discriminator": [219, 31, 188, 145, 69, 139, 204, 117] },
-    { "name": "PodAlignedFeeMarketCapScheduler", "discriminator": [251, 130, 208, 253, 245, 27, 145, 203] },
-    { "name": "PodAlignedFeeRateLimiter", "discriminator": [160, 219, 8, 251, 179, 7, 16, 117] },
-    { "name": "PodAlignedFeeTimeScheduler", "discriminator": [239, 132, 138, 213, 67, 154, 130, 70] },
-    { "name": "Pool", "discriminator": [241, 154, 109, 4, 17, 177, 109, 188] },
-    { "name": "Position", "discriminator": [170, 188, 143, 228, 122, 64, 247, 208] },
-    { "name": "TokenBadge", "discriminator": [116, 219, 204, 229, 249, 116, 255, 150] },
-    { "name": "Vesting", "discriminator": [100, 149, 66, 138, 95, 200, 128, 241] }
+    {
+      "name": "Config",
+      "discriminator": [
+        155,
+        12,
+        170,
+        224,
+        30,
+        250,
+        204,
+        130
+      ]
+    },
+    {
+      "name": "Operator",
+      "discriminator": [
+        219,
+        31,
+        188,
+        145,
+        69,
+        139,
+        204,
+        117
+      ]
+    },
+    {
+      "name": "PodAlignedFeeMarketCapScheduler",
+      "discriminator": [
+        251,
+        130,
+        208,
+        253,
+        245,
+        27,
+        145,
+        203
+      ]
+    },
+    {
+      "name": "PodAlignedFeeRateLimiter",
+      "discriminator": [
+        160,
+        219,
+        8,
+        251,
+        179,
+        7,
+        16,
+        117
+      ]
+    },
+    {
+      "name": "PodAlignedFeeTimeScheduler",
+      "discriminator": [
+        239,
+        132,
+        138,
+        213,
+        67,
+        154,
+        130,
+        70
+      ]
+    },
+    {
+      "name": "Pool",
+      "discriminator": [
+        241,
+        154,
+        109,
+        4,
+        17,
+        177,
+        109,
+        188
+      ]
+    },
+    {
+      "name": "Position",
+      "discriminator": [
+        170,
+        188,
+        143,
+        228,
+        122,
+        64,
+        247,
+        208
+      ]
+    },
+    {
+      "name": "TokenBadge",
+      "discriminator": [
+        116,
+        219,
+        204,
+        229,
+        249,
+        116,
+        255,
+        150
+      ]
+    },
+    {
+      "name": "Vesting",
+      "discriminator": [
+        100,
+        149,
+        66,
+        138,
+        95,
+        200,
+        128,
+        241
+      ]
+    }
   ],
   "events": [
-    { "name": "EvtClaimPartnerFee", "discriminator": [118, 99, 77, 10, 226, 1, 1, 87] },
-    { "name": "EvtClaimPositionFee", "discriminator": [198, 182, 183, 52, 97, 12, 49, 56] },
-    { "name": "EvtClaimProtocolFee", "discriminator": [186, 244, 75, 251, 188, 13, 25, 33] },
-    { "name": "EvtClaimReward", "discriminator": [218, 86, 147, 200, 235, 188, 215, 231] },
-    { "name": "EvtCloseConfig", "discriminator": [36, 30, 239, 45, 58, 132, 14, 5] },
-    { "name": "EvtClosePosition", "discriminator": [20, 145, 144, 68, 143, 142, 214, 178] },
-    { "name": "EvtCreateConfig", "discriminator": [131, 207, 180, 174, 180, 73, 165, 54] },
-    { "name": "EvtCreateDynamicConfig", "discriminator": [231, 197, 13, 164, 248, 213, 133, 152] },
-    { "name": "EvtCreatePosition", "discriminator": [156, 15, 119, 198, 29, 181, 221, 55] },
-    { "name": "EvtCreateTokenBadge", "discriminator": [141, 120, 134, 116, 34, 28, 114, 160] },
-    { "name": "EvtFundReward", "discriminator": [104, 233, 237, 122, 199, 191, 121, 85] },
-    { "name": "EvtInitializePool", "discriminator": [228, 50, 246, 85, 203, 66, 134, 37] },
-    { "name": "EvtInitializeReward", "discriminator": [129, 91, 188, 3, 246, 52, 185, 249] },
-    { "name": "EvtLiquidityChange", "discriminator": [197, 171, 78, 127, 224, 211, 87, 13] },
-    { "name": "EvtLockPosition", "discriminator": [168, 63, 108, 83, 219, 82, 2, 200] },
-    { "name": "EvtPermanentLockPosition", "discriminator": [145, 143, 162, 218, 218, 80, 67, 11] },
-    { "name": "EvtSetPoolStatus", "discriminator": [100, 213, 74, 3, 95, 91, 228, 146] },
-    { "name": "EvtSplitPosition2", "discriminator": [165, 32, 203, 174, 72, 100, 233, 103] },
-    { "name": "EvtSwap2", "discriminator": [189, 66, 51, 168, 38, 80, 117, 153] },
-    { "name": "EvtUpdatePoolFees", "discriminator": [76, 165, 246, 102, 102, 217, 156, 44] },
-    { "name": "EvtUpdateRewardDuration", "discriminator": [149, 135, 65, 231, 129, 153, 65, 57] },
-    { "name": "EvtUpdateRewardFunder", "discriminator": [76, 154, 208, 13, 40, 115, 246, 146] },
-    { "name": "EvtWithdrawIneligibleReward", "discriminator": [248, 215, 184, 78, 31, 180, 179, 168] }
+    {
+      "name": "EvtClaimPositionFee",
+      "discriminator": [
+        198,
+        182,
+        183,
+        52,
+        97,
+        12,
+        49,
+        56
+      ]
+    },
+    {
+      "name": "EvtClaimProtocolFee",
+      "discriminator": [
+        186,
+        244,
+        75,
+        251,
+        188,
+        13,
+        25,
+        33
+      ]
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "discriminator": [
+        187,
+        133,
+        66,
+        9,
+        205,
+        161,
+        84,
+        13
+      ]
+    },
+    {
+      "name": "EvtClaimReward",
+      "discriminator": [
+        218,
+        86,
+        147,
+        200,
+        235,
+        188,
+        215,
+        231
+      ]
+    },
+    {
+      "name": "EvtCloseConfig",
+      "discriminator": [
+        36,
+        30,
+        239,
+        45,
+        58,
+        132,
+        14,
+        5
+      ]
+    },
+    {
+      "name": "EvtClosePosition",
+      "discriminator": [
+        20,
+        145,
+        144,
+        68,
+        143,
+        142,
+        214,
+        178
+      ]
+    },
+    {
+      "name": "EvtCreateConfig",
+      "discriminator": [
+        131,
+        207,
+        180,
+        174,
+        180,
+        73,
+        165,
+        54
+      ]
+    },
+    {
+      "name": "EvtCreateDynamicConfig",
+      "discriminator": [
+        231,
+        197,
+        13,
+        164,
+        248,
+        213,
+        133,
+        152
+      ]
+    },
+    {
+      "name": "EvtCreatePosition",
+      "discriminator": [
+        156,
+        15,
+        119,
+        198,
+        29,
+        181,
+        221,
+        55
+      ]
+    },
+    {
+      "name": "EvtCreateTokenBadge",
+      "discriminator": [
+        141,
+        120,
+        134,
+        116,
+        34,
+        28,
+        114,
+        160
+      ]
+    },
+    {
+      "name": "EvtFundReward",
+      "discriminator": [
+        104,
+        233,
+        237,
+        122,
+        199,
+        191,
+        121,
+        85
+      ]
+    },
+    {
+      "name": "EvtInitializePool",
+      "discriminator": [
+        228,
+        50,
+        246,
+        85,
+        203,
+        66,
+        134,
+        37
+      ]
+    },
+    {
+      "name": "EvtInitializeReward",
+      "discriminator": [
+        129,
+        91,
+        188,
+        3,
+        246,
+        52,
+        185,
+        249
+      ]
+    },
+    {
+      "name": "EvtLiquidityChange",
+      "discriminator": [
+        197,
+        171,
+        78,
+        127,
+        224,
+        211,
+        87,
+        13
+      ]
+    },
+    {
+      "name": "EvtLockPosition",
+      "discriminator": [
+        168,
+        63,
+        108,
+        83,
+        219,
+        82,
+        2,
+        200
+      ]
+    },
+    {
+      "name": "EvtPermanentLockPosition",
+      "discriminator": [
+        145,
+        143,
+        162,
+        218,
+        218,
+        80,
+        67,
+        11
+      ]
+    },
+    {
+      "name": "EvtSetPoolStatus",
+      "discriminator": [
+        100,
+        213,
+        74,
+        3,
+        95,
+        91,
+        228,
+        146
+      ]
+    },
+    {
+      "name": "EvtSplitPosition2",
+      "discriminator": [
+        165,
+        32,
+        203,
+        174,
+        72,
+        100,
+        233,
+        103
+      ]
+    },
+    {
+      "name": "EvtSplitPosition3",
+      "discriminator": [
+        232,
+        117,
+        190,
+        218,
+        85,
+        162,
+        207,
+        78
+      ]
+    },
+    {
+      "name": "EvtSwap2",
+      "discriminator": [
+        189,
+        66,
+        51,
+        168,
+        38,
+        80,
+        117,
+        153
+      ]
+    },
+    {
+      "name": "EvtUpdateDelegatePermission",
+      "discriminator": [
+        66,
+        188,
+        75,
+        151,
+        150,
+        232,
+        87,
+        93
+      ]
+    },
+    {
+      "name": "EvtUpdatePoolFees",
+      "discriminator": [
+        76,
+        165,
+        246,
+        102,
+        102,
+        217,
+        156,
+        44
+      ]
+    },
+    {
+      "name": "EvtUpdateRewardDuration",
+      "discriminator": [
+        149,
+        135,
+        65,
+        231,
+        129,
+        153,
+        65,
+        57
+      ]
+    },
+    {
+      "name": "EvtUpdateRewardFunder",
+      "discriminator": [
+        76,
+        154,
+        208,
+        13,
+        40,
+        115,
+        246,
+        146
+      ]
+    },
+    {
+      "name": "EvtWithdrawDeadLiquidityReward",
+      "discriminator": [
+        228,
+        66,
+        150,
+        195,
+        42,
+        62,
+        163,
+        13
+      ]
+    },
+    {
+      "name": "EvtWithdrawIneligibleReward",
+      "discriminator": [
+        248,
+        215,
+        184,
+        78,
+        31,
+        180,
+        179,
+        168
+      ]
+    }
   ],
   "errors": [
-    { "code": 6000, "name": "MathOverflow", "msg": "Math operation overflow" },
-    { "code": 6001, "name": "InvalidFee", "msg": "Invalid fee setup" },
-    { "code": 6002, "name": "ExceededSlippage", "msg": "Exceeded slippage tolerance" },
-    { "code": 6003, "name": "PoolDisabled", "msg": "Pool disabled" },
-    { "code": 6004, "name": "ExceedMaxFeeBps", "msg": "Exceeded max fee bps" },
-    { "code": 6005, "name": "InvalidAdmin", "msg": "Invalid admin" },
-    { "code": 6006, "name": "AmountIsZero", "msg": "Amount is zero" },
-    { "code": 6007, "name": "TypeCastFailed", "msg": "Type cast error" },
-    { "code": 6008, "name": "UnableToModifyActivationPoint", "msg": "Unable to modify activation point" },
-    { "code": 6009, "name": "InvalidAuthorityToCreateThePool", "msg": "Invalid authority to create the pool" },
-    { "code": 6010, "name": "InvalidActivationType", "msg": "Invalid activation type" },
-    { "code": 6011, "name": "InvalidActivationPoint", "msg": "Invalid activation point" },
-    { "code": 6012, "name": "InvalidQuoteMint", "msg": "Quote token must be SOL,USDC" },
-    { "code": 6013, "name": "InvalidFeeCurve", "msg": "Invalid fee curve" },
-    { "code": 6014, "name": "InvalidPriceRange", "msg": "Invalid Price Range" },
-    { "code": 6015, "name": "PriceRangeViolation", "msg": "Trade is over price range" },
-    { "code": 6016, "name": "InvalidParameters", "msg": "Invalid parameters" },
-    { "code": 6017, "name": "InvalidCollectFeeMode", "msg": "Invalid collect fee mode" },
-    { "code": 6018, "name": "InvalidInput", "msg": "Invalid input" },
+    {
+      "code": 6000,
+      "name": "MathOverflow",
+      "msg": "Math operation overflow"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidFee",
+      "msg": "Invalid fee setup"
+    },
+    {
+      "code": 6002,
+      "name": "ExceededSlippage",
+      "msg": "Exceeded slippage tolerance"
+    },
+    {
+      "code": 6003,
+      "name": "PoolDisabled",
+      "msg": "Pool disabled"
+    },
+    {
+      "code": 6004,
+      "name": "ExceedMaxFeeBps",
+      "msg": "Exceeded max fee bps"
+    },
+    {
+      "code": 6005,
+      "name": "InvalidAdmin",
+      "msg": "Invalid admin"
+    },
+    {
+      "code": 6006,
+      "name": "AmountIsZero",
+      "msg": "Amount is zero"
+    },
+    {
+      "code": 6007,
+      "name": "TypeCastFailed",
+      "msg": "Type cast error"
+    },
+    {
+      "code": 6008,
+      "name": "UnableToModifyActivationPoint",
+      "msg": "Unable to modify activation point"
+    },
+    {
+      "code": 6009,
+      "name": "InvalidAuthorityToCreateThePool",
+      "msg": "Invalid authority to create the pool"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidActivationType",
+      "msg": "Invalid activation type"
+    },
+    {
+      "code": 6011,
+      "name": "InvalidActivationPoint",
+      "msg": "Invalid activation point"
+    },
+    {
+      "code": 6012,
+      "name": "InvalidQuoteMint",
+      "msg": "Quote token must be SOL,USDC"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidFeeCurve",
+      "msg": "Invalid fee curve"
+    },
+    {
+      "code": 6014,
+      "name": "InvalidPriceRange",
+      "msg": "Invalid Price Range"
+    },
+    {
+      "code": 6015,
+      "name": "PriceRangeViolation",
+      "msg": "Trade is over price range"
+    },
+    {
+      "code": 6016,
+      "name": "InvalidParameters",
+      "msg": "Invalid parameters"
+    },
+    {
+      "code": 6017,
+      "name": "InvalidCollectFeeMode",
+      "msg": "Invalid collect fee mode"
+    },
+    {
+      "code": 6018,
+      "name": "InvalidInput",
+      "msg": "Invalid input"
+    },
     {
       "code": 6019,
       "name": "CannotCreateTokenBadgeOnSupportedMint",
       "msg": "Cannot create token badge on supported mint"
     },
-    { "code": 6020, "name": "InvalidTokenBadge", "msg": "Invalid token badge" },
-    { "code": 6021, "name": "InvalidMinimumLiquidity", "msg": "Invalid minimum liquidity" },
-    { "code": 6022, "name": "InvalidVestingInfo", "msg": "Invalid vesting information" },
-    { "code": 6023, "name": "InsufficientLiquidity", "msg": "Insufficient liquidity" },
-    { "code": 6024, "name": "InvalidVestingAccount", "msg": "Invalid vesting account" },
-    { "code": 6025, "name": "InvalidPoolStatus", "msg": "Invalid pool status" },
-    { "code": 6026, "name": "UnsupportNativeMintToken2022", "msg": "Unsupported native mint token2022" },
-    { "code": 6027, "name": "InvalidRewardIndex", "msg": "Invalid reward index" },
-    { "code": 6028, "name": "InvalidRewardDuration", "msg": "Invalid reward duration" },
-    { "code": 6029, "name": "RewardInitialized", "msg": "Reward already initialized" },
-    { "code": 6030, "name": "RewardUninitialized", "msg": "Reward not initialized" },
-    { "code": 6031, "name": "InvalidRewardVault", "msg": "Invalid reward vault" },
-    { "code": 6032, "name": "MustWithdrawnIneligibleReward", "msg": "Must withdraw ineligible reward" },
-    { "code": 6033, "name": "IdenticalRewardDuration", "msg": "Reward duration is the same" },
-    { "code": 6034, "name": "RewardCampaignInProgress", "msg": "Reward campaign in progress" },
-    { "code": 6035, "name": "IdenticalFunder", "msg": "Identical funder" },
-    { "code": 6036, "name": "InvalidFunder", "msg": "Invalid funder" },
-    { "code": 6037, "name": "RewardNotEnded", "msg": "Reward not ended" },
-    { "code": 6038, "name": "FeeInverseIsIncorrect", "msg": "Fee inverse is incorrect" },
-    { "code": 6039, "name": "PositionIsNotEmpty", "msg": "Position is not empty" },
-    { "code": 6040, "name": "InvalidPoolCreatorAuthority", "msg": "Invalid pool creator authority" },
-    { "code": 6041, "name": "InvalidConfigType", "msg": "Invalid config type" },
-    { "code": 6042, "name": "InvalidPoolCreator", "msg": "Invalid pool creator" },
+    {
+      "code": 6020,
+      "name": "InvalidTokenBadge",
+      "msg": "Invalid token badge"
+    },
+    {
+      "code": 6021,
+      "name": "InvalidMinimumLiquidity",
+      "msg": "Invalid minimum liquidity"
+    },
+    {
+      "code": 6022,
+      "name": "InvalidVestingInfo",
+      "msg": "Invalid vesting information"
+    },
+    {
+      "code": 6023,
+      "name": "InsufficientLiquidity",
+      "msg": "Insufficient liquidity"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidVestingAccount",
+      "msg": "Invalid vesting account"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidPoolStatus",
+      "msg": "Invalid pool status"
+    },
+    {
+      "code": 6026,
+      "name": "UnsupportNativeMintToken2022",
+      "msg": "Unsupported native mint token2022"
+    },
+    {
+      "code": 6027,
+      "name": "InvalidRewardIndex",
+      "msg": "Invalid reward index"
+    },
+    {
+      "code": 6028,
+      "name": "InvalidRewardDuration",
+      "msg": "Invalid reward duration"
+    },
+    {
+      "code": 6029,
+      "name": "RewardInitialized",
+      "msg": "Reward already initialized"
+    },
+    {
+      "code": 6030,
+      "name": "RewardUninitialized",
+      "msg": "Reward not initialized"
+    },
+    {
+      "code": 6031,
+      "name": "InvalidRewardVault",
+      "msg": "Invalid reward vault"
+    },
+    {
+      "code": 6032,
+      "name": "MustWithdrawnIneligibleReward",
+      "msg": "Must withdraw ineligible reward"
+    },
+    {
+      "code": 6033,
+      "name": "IdenticalRewardDuration",
+      "msg": "Reward duration is the same"
+    },
+    {
+      "code": 6034,
+      "name": "RewardCampaignInProgress",
+      "msg": "Reward campaign in progress"
+    },
+    {
+      "code": 6035,
+      "name": "IdenticalFunder",
+      "msg": "Identical funder"
+    },
+    {
+      "code": 6036,
+      "name": "InvalidFunder",
+      "msg": "Invalid funder"
+    },
+    {
+      "code": 6037,
+      "name": "RewardNotEnded",
+      "msg": "Reward not ended"
+    },
+    {
+      "code": 6038,
+      "name": "FeeInverseIsIncorrect",
+      "msg": "Fee inverse is incorrect"
+    },
+    {
+      "code": 6039,
+      "name": "PositionIsNotEmpty",
+      "msg": "Position is not empty"
+    },
+    {
+      "code": 6040,
+      "name": "InvalidPoolCreatorAuthority",
+      "msg": "Invalid pool creator authority"
+    },
+    {
+      "code": 6041,
+      "name": "InvalidConfigType",
+      "msg": "Invalid config type"
+    },
+    {
+      "code": 6042,
+      "name": "InvalidPoolCreator",
+      "msg": "Invalid pool creator"
+    },
     {
       "code": 6043,
       "name": "RewardVaultFrozenSkipRequired",
       "msg": "Reward vault is frozen, must skip reward to proceed"
     },
-    { "code": 6044, "name": "InvalidSplitPositionParameters", "msg": "Invalid parameters for split position" },
+    {
+      "code": 6044,
+      "name": "InvalidSplitPositionParameters",
+      "msg": "Invalid parameters for split position"
+    },
     {
       "code": 6045,
       "name": "UnsupportPositionHasVestingLock",
       "msg": "Unsupported split position has vesting lock"
     },
-    { "code": 6046, "name": "SamePosition", "msg": "Same position" },
-    { "code": 6047, "name": "InvalidBaseFeeMode", "msg": "Invalid base fee mode" },
-    { "code": 6048, "name": "InvalidFeeRateLimiter", "msg": "Invalid fee rate limiter" },
+    {
+      "code": 6046,
+      "name": "SamePosition",
+      "msg": "Same position"
+    },
+    {
+      "code": 6047,
+      "name": "InvalidBaseFeeMode",
+      "msg": "Invalid base fee mode"
+    },
+    {
+      "code": 6048,
+      "name": "InvalidFeeRateLimiter",
+      "msg": "Invalid fee rate limiter"
+    },
     {
       "code": 6049,
       "name": "FailToValidateSingleSwapInstruction",
       "msg": "Fail to validate single swap instruction in rate limiter"
     },
-    { "code": 6050, "name": "InvalidFeeTimeScheduler", "msg": "Invalid fee scheduler" },
-    { "code": 6051, "name": "UndeterminedError", "msg": "Undetermined error" },
-    { "code": 6052, "name": "InvalidPoolVersion", "msg": "Invalid pool version" },
-    { "code": 6053, "name": "InvalidAuthority", "msg": "Invalid authority to do that action" },
-    { "code": 6054, "name": "InvalidPermission", "msg": "Invalid permission" },
-    { "code": 6055, "name": "InvalidFeeMarketCapScheduler", "msg": "Invalid fee market cap scheduler" },
-    { "code": 6056, "name": "CannotUpdateBaseFee", "msg": "Cannot update base fee" },
-    { "code": 6057, "name": "InvalidDynamicFeeParameters", "msg": "Invalid dynamic fee parameters" },
-    { "code": 6058, "name": "InvalidUpdatePoolFeesParameters", "msg": "Invalid update pool fees parameters" },
-    { "code": 6059, "name": "MissingOperatorAccount", "msg": "Missing operator account" }
+    {
+      "code": 6050,
+      "name": "InvalidFeeTimeScheduler",
+      "msg": "Invalid fee scheduler"
+    },
+    {
+      "code": 6051,
+      "name": "UndeterminedError",
+      "msg": "Undetermined error"
+    },
+    {
+      "code": 6052,
+      "name": "InvalidPoolVersion",
+      "msg": "Invalid pool version"
+    },
+    {
+      "code": 6053,
+      "name": "InvalidAuthority",
+      "msg": "Invalid authority to do that action"
+    },
+    {
+      "code": 6054,
+      "name": "InvalidPermission",
+      "msg": "Invalid permission"
+    },
+    {
+      "code": 6055,
+      "name": "InvalidFeeMarketCapScheduler",
+      "msg": "Invalid fee market cap scheduler"
+    },
+    {
+      "code": 6056,
+      "name": "CannotUpdateBaseFee",
+      "msg": "Cannot update base fee"
+    },
+    {
+      "code": 6057,
+      "name": "InvalidDynamicFeeParameters",
+      "msg": "Invalid dynamic fee parameters"
+    },
+    {
+      "code": 6058,
+      "name": "InvalidUpdatePoolFeesParameters",
+      "msg": "Invalid update pool fees parameters"
+    },
+    {
+      "code": 6059,
+      "name": "MissingOperatorAccount",
+      "msg": "Missing operator account"
+    },
+    {
+      "code": 6060,
+      "name": "IncorrectATA",
+      "msg": "Incorrect ATA"
+    },
+    {
+      "code": 6061,
+      "name": "InvalidZapOutParameters",
+      "msg": "Invalid zap out parameters"
+    },
+    {
+      "code": 6062,
+      "name": "InvalidWithdrawProtocolFeeZapAccounts",
+      "msg": "Invalid withdraw protocol fee zap accounts"
+    },
+    {
+      "code": 6063,
+      "name": "MintRestrictedFromZap",
+      "msg": "SOL,USDC protocol fee cannot be withdrawn via zap"
+    },
+    {
+      "code": 6064,
+      "name": "CpiDisabled",
+      "msg": "CPI disabled"
+    },
+    {
+      "code": 6065,
+      "name": "MissingZapOutInstruction",
+      "msg": "Missing zap out instruction"
+    },
+    {
+      "code": 6066,
+      "name": "InvalidZapAccounts",
+      "msg": "Invalid zap accounts"
+    },
+    {
+      "code": 6067,
+      "name": "InvalidCompoundingFeeBps",
+      "msg": "Invalid compounding fee bps"
+    },
+    {
+      "code": 6068,
+      "name": "InvalidClaimProtocolFeeAccounts",
+      "msg": "Invalid claim protocol fee accounts"
+    },
+    {
+      "code": 6069,
+      "name": "TransferFeeExcludedAmountIsZero",
+      "msg": "Transfer fee excluded amount is zero"
+    },
+    {
+      "code": 6070,
+      "name": "DelegatedAmountNonZero",
+      "msg": "Delegated amount is not zero"
+    }
   ],
   "types": [
     {
@@ -1515,31 +4162,89 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "liquidity_delta", "docs": ["delta liquidity"], "type": "u128" },
-          { "name": "token_a_amount_threshold", "docs": ["maximum token a amount"], "type": "u64" },
-          { "name": "token_b_amount_threshold", "docs": ["maximum token b amount"], "type": "u64" }
+          {
+            "name": "liquidity_delta",
+            "docs": [
+              "delta liquidity"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "token_a_amount_threshold",
+            "docs": [
+              "maximum token a amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount_threshold",
+            "docs": [
+              "maximum token b amount"
+            ],
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "BaseFeeInfo",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
-      "type": { "kind": "struct", "fields": [{ "name": "data", "type": { "array": ["u8", 32] } }] }
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
     },
     {
       "name": "BaseFeeParameters",
-      "type": { "kind": "struct", "fields": [{ "name": "data", "type": { "array": ["u8", 30] } }] }
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "data",
+            "type": {
+              "array": [
+                "u8",
+                27
+              ]
+            }
+          }
+        ]
+      }
     },
     {
       "name": "BaseFeeStruct",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "base_fee_info", "type": { "defined": { "name": "BaseFeeInfo" } } },
-          { "name": "padding_1", "type": "u64" }
+          {
+            "name": "base_fee_info",
+            "type": {
+              "defined": {
+                "name": "BaseFeeInfo"
+              }
+            }
+          },
+          {
+            "name": "padding_1",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -1548,13 +4253,30 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_fee_numerator", "type": "u64" },
-          { "name": "number_of_period", "type": "u16" },
-          { "name": "sqrt_price_step_bps", "type": "u32" },
-          { "name": "scheduler_expiration_duration", "type": "u32" },
-          { "name": "reduction_factor", "type": "u64" },
-          { "name": "base_fee_mode", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 3] } }
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "sqrt_price_step_bps",
+            "type": "u32"
+          },
+          {
+            "name": "scheduler_expiration_duration",
+            "type": "u32"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          }
         ]
       }
     },
@@ -1576,13 +4298,30 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_fee_numerator", "type": "u64" },
-          { "name": "fee_increment_bps", "type": "u16" },
-          { "name": "max_limiter_duration", "type": "u32" },
-          { "name": "max_fee_bps", "type": "u32" },
-          { "name": "reference_amount", "type": "u64" },
-          { "name": "base_fee_mode", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 3] } }
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "fee_increment_bps",
+            "type": "u16"
+          },
+          {
+            "name": "max_limiter_duration",
+            "type": "u32"
+          },
+          {
+            "name": "max_fee_bps",
+            "type": "u32"
+          },
+          {
+            "name": "reference_amount",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          }
         ]
       }
     },
@@ -1591,23 +4330,45 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_fee_numerator", "type": "u64" },
-          { "name": "number_of_period", "type": "u16" },
-          { "name": "period_frequency", "type": "u64" },
-          { "name": "reduction_factor", "type": "u64" },
-          { "name": "base_fee_mode", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 3] } }
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "period_frequency",
+            "type": "u64"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          }
         ]
       }
     },
     {
       "name": "Config",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "vault_config_key", "docs": ["Vault config key"], "type": "pubkey" },
+          {
+            "name": "vault_config_key",
+            "docs": [
+              "Vault config key"
+            ],
+            "type": "pubkey"
+          },
           {
             "name": "pool_creator_authority",
             "docs": [
@@ -1615,18 +4376,83 @@
             ],
             "type": "pubkey"
           },
-          { "name": "pool_fees", "docs": ["Pool fee"], "type": { "defined": { "name": "PoolFeesConfig" } } },
-          { "name": "activation_type", "docs": ["Activation type"], "type": "u8" },
-          { "name": "collect_fee_mode", "docs": ["Collect fee mode"], "type": "u8" },
-          { "name": "config_type", "docs": ["Config type mode, 0 for static, 1 for dynamic"], "type": "u8" },
-          { "name": "_padding_0", "docs": ["padding 0"], "type": { "array": ["u8", 5] } },
-          { "name": "index", "docs": ["config index"], "type": "u64" },
-          { "name": "sqrt_min_price", "docs": ["sqrt min price"], "type": "u128" },
-          { "name": "sqrt_max_price", "docs": ["sqrt max price"], "type": "u128" },
+          {
+            "name": "pool_fees",
+            "docs": [
+              "Pool fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolFeesConfig"
+              }
+            }
+          },
+          {
+            "name": "activation_type",
+            "docs": [
+              "Activation type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": [
+              "Collect fee mode"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "config_type",
+            "docs": [
+              "Config type mode, 0 for static, 1 for dynamic"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "padding 0"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "index",
+            "docs": [
+              "config index"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "sqrt_min_price",
+            "docs": [
+              "sqrt min price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_max_price",
+            "docs": [
+              "sqrt max price"
+            ],
+            "type": "u128"
+          },
           {
             "name": "_padding_1",
-            "docs": ["Fee curve point", "Padding for further use"],
-            "type": { "array": ["u64", 10] }
+            "docs": [
+              "Fee curve point",
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                10
+              ]
+            }
           }
         ]
       }
@@ -1638,40 +4464,102 @@
         "fields": [
           {
             "name": "borsh_fee_time_scheduler_params",
-            "type": { "defined": { "name": "BorshFeeTimeScheduler" } }
+            "type": {
+              "defined": {
+                "name": "BorshFeeTimeScheduler"
+              }
+            }
           },
           {
             "name": "borsh_fee_rate_limiter_params",
-            "type": { "defined": { "name": "BorshFeeRateLimiter" } }
+            "type": {
+              "defined": {
+                "name": "BorshFeeRateLimiter"
+              }
+            }
           },
           {
             "name": "borsh_fee_market_cap_scheduler_params",
-            "type": { "defined": { "name": "BorshFeeMarketCapScheduler" } }
+            "type": {
+              "defined": {
+                "name": "BorshFeeMarketCapScheduler"
+              }
+            }
           }
         ]
       }
     },
     {
       "name": "DynamicConfigParameters",
-      "type": { "kind": "struct", "fields": [{ "name": "pool_creator_authority", "type": "pubkey" }] }
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          }
+        ]
+      }
     },
     {
       "name": "DynamicFeeConfig",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "initialized", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 7] } },
-          { "name": "max_volatility_accumulator", "type": "u32" },
-          { "name": "variable_fee_control", "type": "u32" },
-          { "name": "bin_step", "type": "u16" },
-          { "name": "filter_period", "type": "u16" },
-          { "name": "decay_period", "type": "u16" },
-          { "name": "reduction_factor", "type": "u16" },
-          { "name": "padding_1", "type": { "array": ["u8", 8] } },
-          { "name": "bin_step_u128", "type": "u128" }
+          {
+            "name": "initialized",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "variable_fee_control",
+            "type": "u32"
+          },
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "padding_1",
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          },
+          {
+            "name": "bin_step_u128",
+            "type": "u128"
+          }
         ]
       }
     },
@@ -1680,47 +4568,103 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "bin_step", "type": "u16" },
-          { "name": "bin_step_u128", "type": "u128" },
-          { "name": "filter_period", "type": "u16" },
-          { "name": "decay_period", "type": "u16" },
-          { "name": "reduction_factor", "type": "u16" },
-          { "name": "max_volatility_accumulator", "type": "u32" },
-          { "name": "variable_fee_control", "type": "u32" }
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "bin_step_u128",
+            "type": "u128"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "variable_fee_control",
+            "type": "u32"
+          }
         ]
       }
     },
     {
       "name": "DynamicFeeStruct",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "initialized", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 7] } },
-          { "name": "max_volatility_accumulator", "type": "u32" },
-          { "name": "variable_fee_control", "type": "u32" },
-          { "name": "bin_step", "type": "u16" },
-          { "name": "filter_period", "type": "u16" },
-          { "name": "decay_period", "type": "u16" },
-          { "name": "reduction_factor", "type": "u16" },
-          { "name": "last_update_timestamp", "type": "u64" },
-          { "name": "bin_step_u128", "type": "u128" },
-          { "name": "sqrt_price_reference", "type": "u128" },
-          { "name": "volatility_accumulator", "type": "u128" },
-          { "name": "volatility_reference", "type": "u128" }
-        ]
-      }
-    },
-    {
-      "name": "EvtClaimPartnerFee",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "token_a_amount", "type": "u64" },
-          { "name": "token_b_amount", "type": "u64" }
+          {
+            "name": "initialized",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "variable_fee_control",
+            "type": "u32"
+          },
+          {
+            "name": "bin_step",
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "last_update_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "bin_step_u128",
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_price_reference",
+            "type": "u128"
+          },
+          {
+            "name": "volatility_accumulator",
+            "type": "u128"
+          },
+          {
+            "name": "volatility_reference",
+            "type": "u128"
+          }
         ]
       }
     },
@@ -1729,11 +4673,26 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "owner", "type": "pubkey" },
-          { "name": "fee_a_claimed", "type": "u64" },
-          { "name": "fee_b_claimed", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_a_claimed",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b_claimed",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -1742,9 +4701,42 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "token_a_amount", "type": "u64" },
-          { "name": "token_b_amount", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver_token_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -1753,23 +4745,55 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "owner", "type": "pubkey" },
-          { "name": "mint_reward", "type": "pubkey" },
-          { "name": "reward_index", "type": "u8" },
-          { "name": "total_reward", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint_reward",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u8"
+          },
+          {
+            "name": "total_reward",
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "EvtCloseConfig",
-      "docs": ["Close config"],
+      "docs": [
+        "Close config"
+      ],
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "config", "docs": ["Config pubkey"], "type": "pubkey" },
-          { "name": "admin", "docs": ["admin pk"], "type": "pubkey" }
+          {
+            "name": "config",
+            "docs": [
+              "Config pubkey"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "admin",
+            "docs": [
+              "admin pk"
+            ],
+            "type": "pubkey"
+          }
         ]
       }
     },
@@ -1778,40 +4802,96 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "owner", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "position_nft_mint", "type": "pubkey" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "position_nft_mint",
+            "type": "pubkey"
+          }
         ]
       }
     },
     {
       "name": "EvtCreateConfig",
-      "docs": ["Create static config"],
+      "docs": [
+        "Create static config"
+      ],
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool_fees", "type": { "defined": { "name": "PoolFeeParameters" } } },
-          { "name": "vault_config_key", "type": "pubkey" },
-          { "name": "pool_creator_authority", "type": "pubkey" },
-          { "name": "activation_type", "type": "u8" },
-          { "name": "sqrt_min_price", "type": "u128" },
-          { "name": "sqrt_max_price", "type": "u128" },
-          { "name": "collect_fee_mode", "type": "u8" },
-          { "name": "index", "type": "u64" },
-          { "name": "config", "type": "pubkey" }
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "sqrt_min_price",
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_max_price",
+            "type": "u128"
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          }
         ]
       }
     },
     {
       "name": "EvtCreateDynamicConfig",
-      "docs": ["Create dynamic config"],
+      "docs": [
+        "Create dynamic config"
+      ],
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "config", "type": "pubkey" },
-          { "name": "pool_creator_authority", "type": "pubkey" },
-          { "name": "index", "type": "u64" }
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "index",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -1820,32 +4900,81 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "owner", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "position_nft_mint", "type": "pubkey" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "position_nft_mint",
+            "type": "pubkey"
+          }
         ]
       }
     },
     {
       "name": "EvtCreateTokenBadge",
-      "docs": ["Create token badge"],
-      "type": { "kind": "struct", "fields": [{ "name": "token_mint", "type": "pubkey" }] }
+      "docs": [
+        "Create token badge"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_mint",
+            "type": "pubkey"
+          }
+        ]
+      }
     },
     {
       "name": "EvtFundReward",
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "funder", "type": "pubkey" },
-          { "name": "mint_reward", "type": "pubkey" },
-          { "name": "reward_index", "type": "u8" },
-          { "name": "amount", "type": "u64" },
-          { "name": "transfer_fee_excluded_amount_in", "type": "u64" },
-          { "name": "reward_duration_end", "type": "u64" },
-          { "name": "pre_reward_rate", "type": "u128" },
-          { "name": "post_reward_rate", "type": "u128" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint_reward",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u8"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_excluded_amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "reward_duration_end",
+            "type": "u64"
+          },
+          {
+            "name": "pre_reward_rate",
+            "type": "u128"
+          },
+          {
+            "name": "post_reward_rate",
+            "type": "u128"
+          }
         ]
       }
     },
@@ -1854,27 +4983,94 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "token_a_mint", "type": "pubkey" },
-          { "name": "token_b_mint", "type": "pubkey" },
-          { "name": "creator", "type": "pubkey" },
-          { "name": "payer", "type": "pubkey" },
-          { "name": "alpha_vault", "type": "pubkey" },
-          { "name": "pool_fees", "type": { "defined": { "name": "PoolFeeParameters" } } },
-          { "name": "sqrt_min_price", "type": "u128" },
-          { "name": "sqrt_max_price", "type": "u128" },
-          { "name": "activation_type", "type": "u8" },
-          { "name": "collect_fee_mode", "type": "u8" },
-          { "name": "liquidity", "type": "u128" },
-          { "name": "sqrt_price", "type": "u128" },
-          { "name": "activation_point", "type": "u64" },
-          { "name": "token_a_flag", "type": "u8" },
-          { "name": "token_b_flag", "type": "u8" },
-          { "name": "token_a_amount", "type": "u64" },
-          { "name": "token_b_amount", "type": "u64" },
-          { "name": "total_amount_a", "type": "u64" },
-          { "name": "total_amount_b", "type": "u64" },
-          { "name": "pool_type", "type": "u8" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_b_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "payer",
+            "type": "pubkey"
+          },
+          {
+            "name": "alpha_vault",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "sqrt_min_price",
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_max_price",
+            "type": "u128"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "activation_point",
+            "type": "u64"
+          },
+          {
+            "name": "token_a_flag",
+            "type": "u8"
+          },
+          {
+            "name": "token_b_flag",
+            "type": "u8"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "total_amount_a",
+            "type": "u64"
+          },
+          {
+            "name": "total_amount_b",
+            "type": "u64"
+          },
+          {
+            "name": "pool_type",
+            "type": "u8"
+          }
         ]
       }
     },
@@ -1883,12 +5079,30 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "reward_mint", "type": "pubkey" },
-          { "name": "funder", "type": "pubkey" },
-          { "name": "creator", "type": "pubkey" },
-          { "name": "reward_index", "type": "u8" },
-          { "name": "reward_duration", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u8"
+          },
+          {
+            "name": "reward_duration",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -1897,19 +5111,58 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "owner", "type": "pubkey" },
-          { "name": "token_a_amount", "type": "u64" },
-          { "name": "token_b_amount", "type": "u64" },
-          { "name": "transfer_fee_included_token_a_amount", "type": "u64" },
-          { "name": "transfer_fee_included_token_b_amount", "type": "u64" },
-          { "name": "reserve_a_amount", "type": "u64" },
-          { "name": "reserve_b_amount", "type": "u64" },
-          { "name": "liquidity_delta", "type": "u128" },
-          { "name": "token_a_amount_threshold", "type": "u64" },
-          { "name": "token_b_amount_threshold", "type": "u64" },
-          { "name": "change_type", "type": "u8" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_included_token_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_included_token_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "reserve_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "reserve_b_amount",
+            "type": "u64"
+          },
+          {
+            "name": "liquidity_delta",
+            "type": "u128"
+          },
+          {
+            "name": "token_a_amount_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "change_type",
+            "type": "u8"
+          }
         ]
       }
     },
@@ -1918,15 +5171,42 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "owner", "type": "pubkey" },
-          { "name": "vesting", "type": "pubkey" },
-          { "name": "cliff_point", "type": "u64" },
-          { "name": "period_frequency", "type": "u64" },
-          { "name": "cliff_unlock_liquidity", "type": "u128" },
-          { "name": "liquidity_per_period", "type": "u128" },
-          { "name": "number_of_period", "type": "u16" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "vesting",
+            "type": "pubkey"
+          },
+          {
+            "name": "cliff_point",
+            "type": "u64"
+          },
+          {
+            "name": "period_frequency",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity_per_period",
+            "type": "u128"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          }
         ]
       }
     },
@@ -1935,10 +5215,22 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "position", "type": "pubkey" },
-          { "name": "lock_liquidity_amount", "type": "u128" },
-          { "name": "total_permanent_locked_liquidity", "type": "u128" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "lock_liquidity_amount",
+            "type": "u128"
+          },
+          {
+            "name": "total_permanent_locked_liquidity",
+            "type": "u128"
+          }
         ]
       }
     },
@@ -1947,8 +5239,14 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "status", "type": "u8" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "status",
+            "type": "u8"
+          }
         ]
       }
     },
@@ -1957,18 +5255,125 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "first_owner", "type": "pubkey" },
-          { "name": "second_owner", "type": "pubkey" },
-          { "name": "first_position", "type": "pubkey" },
-          { "name": "second_position", "type": "pubkey" },
-          { "name": "current_sqrt_price", "type": "u128" },
-          { "name": "amount_splits", "type": { "defined": { "name": "SplitAmountInfo" } } },
-          { "name": "first_position_info", "type": { "defined": { "name": "SplitPositionInfo" } } },
-          { "name": "second_position_info", "type": { "defined": { "name": "SplitPositionInfo" } } },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "first_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "second_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "first_position",
+            "type": "pubkey"
+          },
+          {
+            "name": "second_position",
+            "type": "pubkey"
+          },
+          {
+            "name": "current_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "amount_splits",
+            "type": {
+              "defined": {
+                "name": "SplitAmountInfo"
+              }
+            }
+          },
+          {
+            "name": "first_position_info",
+            "type": {
+              "defined": {
+                "name": "SplitPositionInfo"
+              }
+            }
+          },
+          {
+            "name": "second_position_info",
+            "type": {
+              "defined": {
+                "name": "SplitPositionInfo"
+              }
+            }
+          },
           {
             "name": "split_position_parameters",
-            "type": { "defined": { "name": "SplitPositionParameters2" } }
+            "type": {
+              "defined": {
+                "name": "SplitPositionParameters2"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtSplitPosition3",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "first_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "second_owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "first_position",
+            "type": "pubkey"
+          },
+          {
+            "name": "second_position",
+            "type": "pubkey"
+          },
+          {
+            "name": "current_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "amount_splits",
+            "type": {
+              "defined": {
+                "name": "SplitAmountInfo2"
+              }
+            }
+          },
+          {
+            "name": "first_position_info",
+            "type": {
+              "defined": {
+                "name": "SplitPositionInfo2"
+              }
+            }
+          },
+          {
+            "name": "second_position_info",
+            "type": {
+              "defined": {
+                "name": "SplitPositionInfo2"
+              }
+            }
+          },
+          {
+            "name": "split_position_parameters",
+            "type": {
+              "defined": {
+                "name": "SplitPositionParameters3"
+              }
+            }
           }
         ]
       }
@@ -1978,18 +5383,88 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "trade_direction", "type": "u8" },
-          { "name": "collect_fee_mode", "type": "u8" },
-          { "name": "has_referral", "type": "bool" },
-          { "name": "params", "type": { "defined": { "name": "SwapParameters2" } } },
-          { "name": "swap_result", "type": { "defined": { "name": "SwapResult2" } } },
-          { "name": "included_transfer_fee_amount_in", "type": "u64" },
-          { "name": "included_transfer_fee_amount_out", "type": "u64" },
-          { "name": "excluded_transfer_fee_amount_out", "type": "u64" },
-          { "name": "current_timestamp", "type": "u64" },
-          { "name": "reserve_a_amount", "type": "u64" },
-          { "name": "reserve_b_amount", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_direction",
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "has_referral",
+            "type": "bool"
+          },
+          {
+            "name": "params",
+            "type": {
+              "defined": {
+                "name": "SwapParameters2"
+              }
+            }
+          },
+          {
+            "name": "swap_result",
+            "type": {
+              "defined": {
+                "name": "SwapResult2"
+              }
+            }
+          },
+          {
+            "name": "included_transfer_fee_amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "included_transfer_fee_amount_out",
+            "type": "u64"
+          },
+          {
+            "name": "excluded_transfer_fee_amount_out",
+            "type": "u64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          },
+          {
+            "name": "reserve_a_amount",
+            "type": "u64"
+          },
+          {
+            "name": "reserve_b_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtUpdateDelegatePermission",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "permission",
+            "type": "u32"
+          },
+          {
+            "name": "delegate",
+            "type": {
+              "option": "pubkey"
+            }
+          }
         ]
       }
     },
@@ -1998,9 +5473,22 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "operator", "type": "pubkey" },
-          { "name": "params", "type": { "defined": { "name": "UpdatePoolFeesParameters" } } }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "operator",
+            "type": "pubkey"
+          },
+          {
+            "name": "params",
+            "type": {
+              "defined": {
+                "name": "UpdatePoolFeesParameters"
+              }
+            }
+          }
         ]
       }
     },
@@ -2009,10 +5497,22 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "reward_index", "type": "u8" },
-          { "name": "old_reward_duration", "type": "u64" },
-          { "name": "new_reward_duration", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u8"
+          },
+          {
+            "name": "old_reward_duration",
+            "type": "u64"
+          },
+          {
+            "name": "new_reward_duration",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2021,10 +5521,42 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "reward_index", "type": "u8" },
-          { "name": "old_funder", "type": "pubkey" },
-          { "name": "new_funder", "type": "pubkey" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_index",
+            "type": "u8"
+          },
+          {
+            "name": "old_funder",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_funder",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtWithdrawDeadLiquidityReward",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2033,9 +5565,18 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "reward_mint", "type": "pubkey" },
-          { "name": "amount", "type": "u64" }
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2046,13 +5587,43 @@
         "fields": [
           {
             "name": "pool_fees",
-            "docs": ["pool fees"],
-            "type": { "defined": { "name": "PoolFeeParameters" } }
+            "docs": [
+              "pool fees"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
           },
-          { "name": "sqrt_min_price", "docs": ["sqrt min price"], "type": "u128" },
-          { "name": "sqrt_max_price", "docs": ["sqrt max price"], "type": "u128" },
-          { "name": "has_alpha_vault", "docs": ["has alpha vault"], "type": "bool" },
-          { "name": "liquidity", "docs": ["initialize liquidity"], "type": "u128" },
+          {
+            "name": "sqrt_min_price",
+            "docs": [
+              "sqrt min price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_max_price",
+            "docs": [
+              "sqrt max price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "has_alpha_vault",
+            "docs": [
+              "has alpha vault"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "initialize liquidity"
+            ],
+            "type": "u128"
+          },
           {
             "name": "sqrt_price",
             "docs": [
@@ -2060,9 +5631,29 @@
             ],
             "type": "u128"
           },
-          { "name": "activation_type", "docs": ["activation type"], "type": "u8" },
-          { "name": "collect_fee_mode", "docs": ["collect fee mode"], "type": "u8" },
-          { "name": "activation_point", "docs": ["activation point"], "type": { "option": "u64" } }
+          {
+            "name": "activation_type",
+            "docs": [
+              "activation type"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "docs": [
+              "collect fee mode"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "activation point"
+            ],
+            "type": {
+              "option": "u64"
+            }
+          }
         ]
       }
     },
@@ -2071,164 +5662,575 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "liquidity", "docs": ["initialize liquidity"], "type": "u128" },
           {
-            "name": "sqrt_price",
-            "docs": ["The init price of the pool as a sqrt(token_b/token_a) Q64.64 value"],
+            "name": "liquidity",
+            "docs": [
+              "initialize liquidity"
+            ],
             "type": "u128"
           },
-          { "name": "activation_point", "docs": ["activation point"], "type": { "option": "u64" } }
+          {
+            "name": "sqrt_price",
+            "docs": [
+              "The init price of the pool as a sqrt(token_b/token_a) Q64.64 value"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "activation_point",
+            "docs": [
+              "activation point"
+            ],
+            "type": {
+              "option": "u64"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "InnerVesting",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "cliff_point",
+            "type": "u64"
+          },
+          {
+            "name": "period_frequency",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity_per_period",
+            "type": "u128"
+          },
+          {
+            "name": "total_released_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                14
+              ]
+            }
+          }
         ]
       }
     },
     {
       "name": "Operator",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "whitelisted_address", "type": "pubkey" },
-          { "name": "permission", "type": "u128" },
-          { "name": "padding", "type": { "array": ["u64", 2] } }
+          {
+            "name": "whitelisted_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "permission",
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          }
         ]
       }
     },
     {
       "name": "PodAlignedFeeMarketCapScheduler",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_fee_numerator", "type": "u64" },
-          { "name": "base_fee_mode", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 5] } },
-          { "name": "number_of_period", "type": "u16" },
-          { "name": "sqrt_price_step_bps", "type": "u32" },
-          { "name": "scheduler_expiration_duration", "type": "u32" },
-          { "name": "reduction_factor", "type": "u64" }
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "sqrt_price_step_bps",
+            "type": "u32"
+          },
+          {
+            "name": "scheduler_expiration_duration",
+            "type": "u32"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "PodAlignedFeeRateLimiter",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_fee_numerator", "type": "u64" },
-          { "name": "base_fee_mode", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 5] } },
-          { "name": "fee_increment_bps", "type": "u16" },
-          { "name": "max_limiter_duration", "type": "u32" },
-          { "name": "max_fee_bps", "type": "u32" },
-          { "name": "reference_amount", "type": "u64" }
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "fee_increment_bps",
+            "type": "u16"
+          },
+          {
+            "name": "max_limiter_duration",
+            "type": "u32"
+          },
+          {
+            "name": "max_fee_bps",
+            "type": "u32"
+          },
+          {
+            "name": "reference_amount",
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "PodAlignedFeeTimeScheduler",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_fee_numerator", "type": "u64" },
-          { "name": "base_fee_mode", "type": "u8" },
-          { "name": "padding", "type": { "array": ["u8", 5] } },
-          { "name": "number_of_period", "type": "u16" },
-          { "name": "period_frequency", "type": "u64" },
-          { "name": "reduction_factor", "type": "u64" }
+          {
+            "name": "cliff_fee_numerator",
+            "type": "u64"
+          },
+          {
+            "name": "base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "period_frequency",
+            "type": "u64"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "Pool",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool_fees", "docs": ["Pool fee"], "type": { "defined": { "name": "PoolFeesStruct" } } },
-          { "name": "token_a_mint", "docs": ["token a mint"], "type": "pubkey" },
-          { "name": "token_b_mint", "docs": ["token b mint"], "type": "pubkey" },
-          { "name": "token_a_vault", "docs": ["token a vault"], "type": "pubkey" },
-          { "name": "token_b_vault", "docs": ["token b vault"], "type": "pubkey" },
           {
-            "name": "whitelisted_vault",
-            "docs": ["Whitelisted vault to be able to buy pool before activation_point"],
+            "name": "pool_fees",
+            "docs": [
+              "Pool fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolFeesStruct"
+              }
+            }
+          },
+          {
+            "name": "token_a_mint",
+            "docs": [
+              "token a mint"
+            ],
             "type": "pubkey"
           },
-          { "name": "partner", "docs": ["partner"], "type": "pubkey" },
-          { "name": "liquidity", "docs": ["liquidity share"], "type": "u128" },
           {
-            "name": "_padding",
-            "docs": ["padding, previous reserve amount, be careful to use that field"],
+            "name": "token_b_mint",
+            "docs": [
+              "token b mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_vault",
+            "docs": [
+              "token a vault"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_b_vault",
+            "docs": [
+              "token b vault"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "whitelisted_vault",
+            "docs": [
+              "Whitelisted vault to be able to buy pool before activation_point"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding_0",
+            "docs": [
+              "padding, previously partner pubkey, be careful when using this field"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "liquidity share"
+            ],
             "type": "u128"
           },
-          { "name": "protocol_a_fee", "docs": ["protocol a fee"], "type": "u64" },
-          { "name": "protocol_b_fee", "docs": ["protocol b fee"], "type": "u64" },
-          { "name": "partner_a_fee", "docs": ["partner a fee"], "type": "u64" },
-          { "name": "partner_b_fee", "docs": ["partner b fee"], "type": "u64" },
-          { "name": "sqrt_min_price", "docs": ["min price"], "type": "u128" },
-          { "name": "sqrt_max_price", "docs": ["max price"], "type": "u128" },
-          { "name": "sqrt_price", "docs": ["current price"], "type": "u128" },
+          {
+            "name": "padding_1",
+            "docs": [
+              "padding, previous reserve amount, be careful to use that field"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "protocol_a_fee",
+            "docs": [
+              "protocol a fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_b_fee",
+            "docs": [
+              "protocol b fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding_2",
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_min_price",
+            "docs": [
+              "min price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_max_price",
+            "docs": [
+              "max price"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_price",
+            "docs": [
+              "current price"
+            ],
+            "type": "u128"
+          },
           {
             "name": "activation_point",
-            "docs": ["Activation point, can be slot or timestamp"],
+            "docs": [
+              "Activation point, can be slot or timestamp"
+            ],
             "type": "u64"
           },
           {
             "name": "activation_type",
-            "docs": ["Activation type, 0 means by slot, 1 means by timestamp"],
+            "docs": [
+              "Activation type, 0 means by slot, 1 means by timestamp"
+            ],
             "type": "u8"
           },
-          { "name": "pool_status", "docs": ["pool status, 0: enable, 1 disable"], "type": "u8" },
-          { "name": "token_a_flag", "docs": ["token a flag"], "type": "u8" },
-          { "name": "token_b_flag", "docs": ["token b flag"], "type": "u8" },
+          {
+            "name": "pool_status",
+            "docs": [
+              "pool status, 0: enable, 1 disable"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_a_flag",
+            "docs": [
+              "token a flag"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "token_b_flag",
+            "docs": [
+              "token b flag"
+            ],
+            "type": "u8"
+          },
           {
             "name": "collect_fee_mode",
-            "docs": ["0 is collect fee in both token, 1 only collect fee only in token b"],
+            "docs": [
+              "0 is collect fee in both token, 1 only collect fee only in token b"
+            ],
             "type": "u8"
           },
-          { "name": "pool_type", "docs": ["pool type"], "type": "u8" },
           {
-            "name": "version",
-            "docs": ["pool version, 0: max_fee is still capped at 50%, 1: max_fee is capped at 99%"],
+            "name": "pool_type",
+            "docs": [
+              "pool type"
+            ],
             "type": "u8"
           },
-          { "name": "_padding_0", "docs": ["padding"], "type": "u8" },
-          { "name": "fee_a_per_liquidity", "docs": ["cumulative"], "type": { "array": ["u8", 32] } },
-          { "name": "fee_b_per_liquidity", "docs": ["cumulative"], "type": { "array": ["u8", 32] } },
-          { "name": "permanent_lock_liquidity", "type": "u128" },
-          { "name": "metrics", "docs": ["metrics"], "type": { "defined": { "name": "PoolMetrics" } } },
-          { "name": "creator", "docs": ["pool creator"], "type": "pubkey" },
-          { "name": "_padding_1", "docs": ["Padding for further use"], "type": { "array": ["u64", 6] } },
+          {
+            "name": "fee_version",
+            "docs": [
+              "pool fee version, 0: max_fee is still capped at 50%, 1: max_fee is capped at 99%"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_3",
+            "docs": [
+              "padding"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fee_a_per_liquidity",
+            "docs": [
+              "cumulative"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "fee_b_per_liquidity",
+            "docs": [
+              "cumulative"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "permanent_lock_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "metrics",
+            "docs": [
+              "metrics"
+            ],
+            "type": {
+              "defined": {
+                "name": "PoolMetrics"
+              }
+            }
+          },
+          {
+            "name": "creator",
+            "docs": [
+              "pool creator"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_a_amount",
+            "docs": [
+              "token a amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount",
+            "docs": [
+              "token b amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "layout_version",
+            "docs": [
+              "layout version: version 0: haven't track token_a_amount and token_b_amount, version 1: track token_a_amount and token_b_amount"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_4",
+            "docs": [
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
+            "name": "padding_5",
+            "docs": [
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                3
+              ]
+            }
+          },
           {
             "name": "reward_infos",
-            "docs": ["Farming reward information"],
-            "type": { "array": [{ "defined": { "name": "RewardInfo" } }, 2] }
+            "docs": [
+              "Farming reward information"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "RewardInfo"
+                  }
+                },
+                2
+              ]
+            }
           }
         ]
       }
     },
     {
       "name": "PoolFeeParameters",
-      "docs": ["Information regarding fee charges"],
+      "docs": [
+        "Information regarding fee charges"
+      ],
       "type": {
         "kind": "struct",
         "fields": [
           {
             "name": "base_fee",
-            "docs": ["Base fee"],
-            "type": { "defined": { "name": "BaseFeeParameters" } }
+            "docs": [
+              "Base fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "BaseFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "compounding fee bps, only have value if CollectFeeMode::Compounding"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": "u8"
           },
           {
             "name": "dynamic_fee",
-            "docs": ["dynamic fee"],
-            "type": { "option": { "defined": { "name": "DynamicFeeParameters" } } }
+            "docs": [
+              "dynamic fee"
+            ],
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "DynamicFeeParameters"
+                }
+              }
+            }
           }
         ]
       }
@@ -2236,17 +6238,65 @@
     {
       "name": "PoolFeesConfig",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "base_fee", "type": { "defined": { "name": "BaseFeeInfo" } } },
-          { "name": "dynamic_fee", "type": { "defined": { "name": "DynamicFeeConfig" } } },
-          { "name": "protocol_fee_percent", "type": "u8" },
-          { "name": "partner_fee_percent", "type": "u8" },
-          { "name": "referral_fee_percent", "type": "u8" },
-          { "name": "padding_0", "type": { "array": ["u8", 5] } },
-          { "name": "padding_1", "type": { "array": ["u64", 5] } }
+          {
+            "name": "base_fee",
+            "type": {
+              "defined": {
+                "name": "BaseFeeInfo"
+              }
+            }
+          },
+          {
+            "name": "dynamic_fee",
+            "type": {
+              "defined": {
+                "name": "DynamicFeeConfig"
+              }
+            }
+          },
+          {
+            "name": "protocol_fee_percent",
+            "type": "u8"
+          },
+          {
+            "name": "padding_0",
+            "type": "u8"
+          },
+          {
+            "name": "referral_fee_percent",
+            "type": "u8"
+          },
+          {
+            "name": "padding_1",
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "Compounding fee bps, only non-zero if collect_fee_mode is compounding"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "padding_2",
+            "type": {
+              "array": [
+                "u64",
+                5
+              ]
+            }
+          }
         ]
       }
     },
@@ -2256,11 +6306,12 @@
         "Information regarding fee charges",
         "trading_fee = amount * trade_fee_numerator / denominator",
         "protocol_fee = trading_fee * protocol_fee_percentage / 100",
-        "referral_fee = protocol_fee * referral_percentage / 100",
-        "partner_fee = (protocol_fee - referral_fee) * partner_fee_percentage / denominator"
+        "referral_fee = protocol_fee * referral_percentage / 100"
       ],
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
@@ -2271,7 +6322,11 @@
               "accounts during a trade, making the value of liquidity tokens rise.",
               "Trade fee numerator"
             ],
-            "type": { "defined": { "name": "BaseFeeStruct" } }
+            "type": {
+              "defined": {
+                "name": "BaseFeeStruct"
+              }
+            }
           },
           {
             "name": "protocol_fee_percent",
@@ -2283,79 +6338,258 @@
             ],
             "type": "u8"
           },
-          { "name": "partner_fee_percent", "docs": ["partner fee"], "type": "u8" },
-          { "name": "referral_fee_percent", "docs": ["referral fee"], "type": "u8" },
-          { "name": "padding_0", "docs": ["padding"], "type": { "array": ["u8", 5] } },
+          {
+            "name": "padding_0",
+            "docs": [
+              "padding for future use"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "referral_fee_percent",
+            "docs": [
+              "referral fee"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_1",
+            "docs": [
+              "padding"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                3
+              ]
+            }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "compounding fee bps, only non-zero in CollectFeeMode::Compounding"
+            ],
+            "type": "u16"
+          },
           {
             "name": "dynamic_fee",
-            "docs": ["dynamic fee"],
-            "type": { "defined": { "name": "DynamicFeeStruct" } }
+            "docs": [
+              "dynamic fee"
+            ],
+            "type": {
+              "defined": {
+                "name": "DynamicFeeStruct"
+              }
+            }
           },
-          { "name": "init_sqrt_price", "type": "u128" }
+          {
+            "name": "init_sqrt_price",
+            "type": "u128"
+          }
         ]
       }
     },
     {
       "name": "PoolMetrics",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "total_lp_a_fee", "type": "u128" },
-          { "name": "total_lp_b_fee", "type": "u128" },
-          { "name": "total_protocol_a_fee", "type": "u64" },
-          { "name": "total_protocol_b_fee", "type": "u64" },
-          { "name": "total_partner_a_fee", "type": "u64" },
-          { "name": "total_partner_b_fee", "type": "u64" },
-          { "name": "total_position", "type": "u64" },
-          { "name": "padding", "type": "u64" }
+          {
+            "name": "total_lp_a_fee",
+            "type": "u128"
+          },
+          {
+            "name": "total_lp_b_fee",
+            "type": "u128"
+          },
+          {
+            "name": "total_protocol_a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "total_protocol_b_fee",
+            "type": "u64"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
+          },
+          {
+            "name": "total_position",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "Position",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool", "type": "pubkey" },
-          { "name": "nft_mint", "docs": ["nft mint"], "type": "pubkey" },
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "nft_mint",
+            "docs": [
+              "nft mint"
+            ],
+            "type": "pubkey"
+          },
           {
             "name": "fee_a_per_token_checkpoint",
-            "docs": ["fee a checkpoint"],
-            "type": { "array": ["u8", 32] }
+            "docs": [
+              "fee a checkpoint"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "fee_b_per_token_checkpoint",
-            "docs": ["fee b checkpoint"],
-            "type": { "array": ["u8", 32] }
+            "docs": [
+              "fee b checkpoint"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
-          { "name": "fee_a_pending", "docs": ["fee a pending"], "type": "u64" },
-          { "name": "fee_b_pending", "docs": ["fee b pending"], "type": "u64" },
-          { "name": "unlocked_liquidity", "docs": ["unlock liquidity"], "type": "u128" },
-          { "name": "vested_liquidity", "docs": ["vesting liquidity"], "type": "u128" },
-          { "name": "permanent_locked_liquidity", "docs": ["permanent locked liquidity"], "type": "u128" },
-          { "name": "metrics", "docs": ["metrics"], "type": { "defined": { "name": "PositionMetrics" } } },
+          {
+            "name": "fee_a_pending",
+            "docs": [
+              "fee a pending"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fee_b_pending",
+            "docs": [
+              "fee b pending"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "unlocked_liquidity",
+            "docs": [
+              "unlock liquidity"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "vested_liquidity",
+            "docs": [
+              "vesting liquidity"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "permanent_locked_liquidity",
+            "docs": [
+              "permanent locked liquidity"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "metrics",
+            "docs": [
+              "metrics"
+            ],
+            "type": {
+              "defined": {
+                "name": "PositionMetrics"
+              }
+            }
+          },
           {
             "name": "reward_infos",
-            "docs": ["Farming reward information"],
-            "type": { "array": [{ "defined": { "name": "UserRewardInfo" } }, 2] }
+            "docs": [
+              "Farming reward information"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "UserRewardInfo"
+                  }
+                },
+                2
+              ]
+            }
           },
-          { "name": "padding", "docs": ["padding for future usage"], "type": { "array": ["u128", 6] } }
+          {
+            "name": "inner_vesting",
+            "docs": [
+              "inner vesting info"
+            ],
+            "type": {
+              "defined": {
+                "name": "InnerVesting"
+              }
+            }
+          },
+          {
+            "name": "delegate_permission",
+            "docs": [
+              "delegate permission bitmask (paired with SPL token Approve)"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future usage"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                12
+              ]
+            }
+          }
         ]
       }
     },
     {
       "name": "PositionMetrics",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "total_claimed_a_fee", "type": "u64" },
-          { "name": "total_claimed_b_fee", "type": "u64" }
+          {
+            "name": "total_claimed_a_fee",
+            "type": "u64"
+          },
+          {
+            "name": "total_claimed_b_fee",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2364,42 +6598,134 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "liquidity_delta", "docs": ["delta liquidity"], "type": "u128" },
-          { "name": "token_a_amount_threshold", "docs": ["minimum token a amount"], "type": "u64" },
-          { "name": "token_b_amount_threshold", "docs": ["minimum token b amount"], "type": "u64" }
+          {
+            "name": "liquidity_delta",
+            "docs": [
+              "delta liquidity"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "token_a_amount_threshold",
+            "docs": [
+              "minimum token a amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_b_amount_threshold",
+            "docs": [
+              "minimum token b amount"
+            ],
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "RewardInfo",
-      "docs": ["Stores the state relevant for tracking liquidity mining rewards"],
+      "docs": [
+        "Stores the state relevant for tracking liquidity mining rewards"
+      ],
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "initialized", "docs": ["Indicates if the reward has been initialized"], "type": "u8" },
-          { "name": "reward_token_flag", "docs": ["reward token flag"], "type": "u8" },
-          { "name": "_padding_0", "docs": ["padding"], "type": { "array": ["u8", 6] } },
           {
-            "name": "_padding_1",
-            "docs": ["Padding to ensure `reward_rate: u128` is 16-byte aligned"],
-            "type": { "array": ["u8", 8] }
+            "name": "initialized",
+            "docs": [
+              "Indicates if the reward has been initialized"
+            ],
+            "type": "u8"
           },
-          { "name": "mint", "docs": ["Reward token mint."], "type": "pubkey" },
-          { "name": "vault", "docs": ["Reward vault token account."], "type": "pubkey" },
-          { "name": "funder", "docs": ["Authority account that allows to fund rewards"], "type": "pubkey" },
-          { "name": "reward_duration", "docs": ["reward duration"], "type": "u64" },
-          { "name": "reward_duration_end", "docs": ["reward duration end"], "type": "u64" },
-          { "name": "reward_rate", "docs": ["reward rate"], "type": "u128" },
+          {
+            "name": "reward_token_flag",
+            "docs": [
+              "reward token flag"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "padding"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "dead_liquidity_reward_checkpoint",
+            "docs": [
+              "Cumulative dead-liquidity reward (Compounding Pool only)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "mint",
+            "docs": [
+              "Reward token mint."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "vault",
+            "docs": [
+              "Reward vault token account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "funder",
+            "docs": [
+              "Authority account that allows to fund rewards"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_duration",
+            "docs": [
+              "reward duration"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "reward_duration_end",
+            "docs": [
+              "reward duration end"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "reward_rate",
+            "docs": [
+              "reward rate"
+            ],
+            "type": "u128"
+          },
           {
             "name": "reward_per_token_stored",
-            "docs": ["Reward per token stored"],
-            "type": { "array": ["u8", 32] }
+            "docs": [
+              "Reward per token stored"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
             "name": "last_update_time",
-            "docs": ["The last time reward states were updated."],
+            "docs": [
+              "The last time reward states were updated."
+            ],
             "type": "u64"
           },
           {
@@ -2418,12 +6744,66 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "permanent_locked_liquidity", "type": "u128" },
-          { "name": "unlocked_liquidity", "type": "u128" },
-          { "name": "fee_a", "type": "u64" },
-          { "name": "fee_b", "type": "u64" },
-          { "name": "reward_0", "type": "u64" },
-          { "name": "reward_1", "type": "u64" }
+          {
+            "name": "permanent_locked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "unlocked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "reward_0",
+            "type": "u64"
+          },
+          {
+            "name": "reward_1",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SplitAmountInfo2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "permanent_locked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "unlocked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "vested_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "reward_0",
+            "type": "u64"
+          },
+          {
+            "name": "reward_1",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2432,11 +6812,62 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "liquidity", "type": "u128" },
-          { "name": "fee_a", "type": "u64" },
-          { "name": "fee_b", "type": "u64" },
-          { "name": "reward_0", "type": "u64" },
-          { "name": "reward_1", "type": "u64" }
+          {
+            "name": "liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "reward_0",
+            "type": "u64"
+          },
+          {
+            "name": "reward_1",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SplitPositionInfo2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "unlocked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "permanent_locked_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "vested_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "fee_a",
+            "type": "u64"
+          },
+          {
+            "name": "fee_b",
+            "type": "u64"
+          },
+          {
+            "name": "reward_0",
+            "type": "u64"
+          },
+          {
+            "name": "reward_1",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2447,35 +6878,65 @@
         "fields": [
           {
             "name": "unlocked_liquidity_percentage",
-            "docs": ["Percentage of unlocked liquidity to split to the second position"],
+            "docs": [
+              "Percentage of unlocked liquidity to split to the second position"
+            ],
             "type": "u8"
           },
           {
             "name": "permanent_locked_liquidity_percentage",
-            "docs": ["Percentage of permanent locked liquidity to split to the second position"],
+            "docs": [
+              "Percentage of permanent locked liquidity to split to the second position"
+            ],
             "type": "u8"
           },
           {
             "name": "fee_a_percentage",
-            "docs": ["Percentage of fee A pending to split to the second position"],
+            "docs": [
+              "Percentage of fee A pending to split to the second position"
+            ],
             "type": "u8"
           },
           {
             "name": "fee_b_percentage",
-            "docs": ["Percentage of fee B pending to split to the second position"],
+            "docs": [
+              "Percentage of fee B pending to split to the second position"
+            ],
             "type": "u8"
           },
           {
             "name": "reward_0_percentage",
-            "docs": ["Percentage of reward 0 pending to split to the second position"],
+            "docs": [
+              "Percentage of reward 0 pending to split to the second position"
+            ],
             "type": "u8"
           },
           {
             "name": "reward_1_percentage",
-            "docs": ["Percentage of reward 1 pending to split to the second position"],
+            "docs": [
+              "Percentage of reward 1 pending to split to the second position"
+            ],
             "type": "u8"
           },
-          { "name": "padding", "docs": ["padding for future"], "type": { "array": ["u8", 16] } }
+          {
+            "name": "inner_vesting_liquidity_percentage",
+            "docs": [
+              "Percentage of inner vesting liquidity"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                15
+              ]
+            }
+          }
         ]
       }
     },
@@ -2484,12 +6945,66 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "unlocked_liquidity_numerator", "type": "u32" },
-          { "name": "permanent_locked_liquidity_numerator", "type": "u32" },
-          { "name": "fee_a_numerator", "type": "u32" },
-          { "name": "fee_b_numerator", "type": "u32" },
-          { "name": "reward_0_numerator", "type": "u32" },
-          { "name": "reward_1_numerator", "type": "u32" }
+          {
+            "name": "unlocked_liquidity_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "permanent_locked_liquidity_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "fee_a_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "fee_b_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "reward_0_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "reward_1_numerator",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SplitPositionParameters3",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "unlocked_liquidity_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "permanent_locked_liquidity_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "fee_a_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "fee_b_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "reward_0_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "reward_1_numerator",
+            "type": "u32"
+          },
+          {
+            "name": "inner_vesting_liquidity_numerator",
+            "type": "u32"
+          }
         ]
       }
     },
@@ -2498,13 +7013,38 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "pool_fees", "type": { "defined": { "name": "PoolFeeParameters" } } },
-          { "name": "sqrt_min_price", "type": "u128" },
-          { "name": "sqrt_max_price", "type": "u128" },
-          { "name": "vault_config_key", "type": "pubkey" },
-          { "name": "pool_creator_authority", "type": "pubkey" },
-          { "name": "activation_type", "type": "u8" },
-          { "name": "collect_fee_mode", "type": "u8" }
+          {
+            "name": "pool_fees",
+            "type": {
+              "defined": {
+                "name": "PoolFeeParameters"
+              }
+            }
+          },
+          {
+            "name": "sqrt_min_price",
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_max_price",
+            "type": "u128"
+          },
+          {
+            "name": "vault_config_key",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "activation_type",
+            "type": "u8"
+          },
+          {
+            "name": "collect_fee_mode",
+            "type": "u8"
+          }
         ]
       }
     },
@@ -2513,8 +7053,14 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "amount_in", "type": "u64" },
-          { "name": "minimum_amount_out", "type": "u64" }
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "minimum_amount_out",
+            "type": "u64"
+          }
         ]
       }
     },
@@ -2537,7 +7083,13 @@
             ],
             "type": "u64"
           },
-          { "name": "swap_mode", "docs": ["Swap mode, refer [SwapMode]"], "type": "u8" }
+          {
+            "name": "swap_mode",
+            "docs": [
+              "Swap mode, refer [SwapMode]"
+            ],
+            "type": "u8"
+          }
         ]
       }
     },
@@ -2546,28 +7098,76 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "included_fee_input_amount", "type": "u64" },
-          { "name": "excluded_fee_input_amount", "type": "u64" },
-          { "name": "amount_left", "type": "u64" },
-          { "name": "output_amount", "type": "u64" },
-          { "name": "next_sqrt_price", "type": "u128" },
-          { "name": "trading_fee", "type": "u64" },
-          { "name": "protocol_fee", "type": "u64" },
-          { "name": "partner_fee", "type": "u64" },
-          { "name": "referral_fee", "type": "u64" }
+          {
+            "name": "included_fee_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "excluded_fee_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "amount_left",
+            "type": "u64"
+          },
+          {
+            "name": "output_amount",
+            "type": "u64"
+          },
+          {
+            "name": "next_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "claiming_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "compounding_fee",
+            "type": "u64"
+          },
+          {
+            "name": "referral_fee",
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "TokenBadge",
-      "docs": ["Parameter that set by the protocol"],
+      "docs": [
+        "Parameter that set by the protocol"
+      ],
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "token_mint", "docs": ["token mint"], "type": "pubkey" },
-          { "name": "_padding", "docs": ["Reserve"], "type": { "array": ["u8", 128] } }
+          {
+            "name": "token_mint",
+            "docs": [
+              "token mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "_padding",
+            "docs": [
+              "Reserve"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                128
+              ]
+            }
+          }
         ]
       }
     },
@@ -2583,7 +7183,9 @@
               "- None: skip base fee update",
               "- Some: update new cliff_fee_numerator if base fee is static"
             ],
-            "type": { "option": "u64" }
+            "type": {
+              "option": "u64"
+            }
           },
           {
             "name": "dynamic_fee",
@@ -2593,7 +7195,24 @@
               "- Some(with default value): disable dynamic fee",
               "- Some(with non default value): enable dynamic fee if disabled or update dynamic fee if enabled"
             ],
-            "type": { "option": { "defined": { "name": "DynamicFeeParameters" } } }
+            "type": {
+              "option": {
+                "defined": {
+                  "name": "DynamicFeeParameters"
+                }
+              }
+            }
+          },
+          {
+            "name": "compounding_fee_bps",
+            "docs": [
+              "Compounding fee update mode:",
+              "- None: skip compounding fee update",
+              "- Some: update compounding_fee_bps; pool must use CollectFeeMode::Compounding"
+            ],
+            "type": {
+              "option": "u16"
+            }
           }
         ]
       }
@@ -2601,36 +7220,71 @@
     {
       "name": "UserRewardInfo",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
           {
             "name": "reward_per_token_checkpoint",
-            "docs": ["The latest update reward checkpoint"],
-            "type": { "array": ["u8", 32] }
+            "docs": [
+              "The latest update reward checkpoint"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
-          { "name": "reward_pendings", "docs": ["Current pending rewards"], "type": "u64" },
-          { "name": "total_claimed_rewards", "docs": ["Total claimed rewards"], "type": "u64" }
+          {
+            "name": "reward_pendings",
+            "docs": [
+              "Current pending rewards"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_claimed_rewards",
+            "docs": [
+              "Total claimed rewards"
+            ],
+            "type": "u64"
+          }
         ]
       }
     },
     {
       "name": "Vesting",
       "serialization": "bytemuck",
-      "repr": { "kind": "c" },
+      "repr": {
+        "kind": "c"
+      },
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "position", "type": "pubkey" },
-          { "name": "cliff_point", "type": "u64" },
-          { "name": "period_frequency", "type": "u64" },
-          { "name": "cliff_unlock_liquidity", "type": "u128" },
-          { "name": "liquidity_per_period", "type": "u128" },
-          { "name": "total_released_liquidity", "type": "u128" },
-          { "name": "number_of_period", "type": "u16" },
-          { "name": "padding", "type": { "array": ["u8", 14] } },
-          { "name": "padding2", "type": { "array": ["u128", 4] } }
+          {
+            "name": "position",
+            "type": "pubkey"
+          },
+          {
+            "name": "inner_vesting",
+            "type": {
+              "defined": {
+                "name": "InnerVesting"
+              }
+            }
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u128",
+                4
+              ]
+            }
+          }
         ]
       }
     },
@@ -2639,23 +7293,58 @@
       "type": {
         "kind": "struct",
         "fields": [
-          { "name": "cliff_point", "type": { "option": "u64" } },
-          { "name": "period_frequency", "type": "u64" },
-          { "name": "cliff_unlock_liquidity", "type": "u128" },
-          { "name": "liquidity_per_period", "type": "u128" },
-          { "name": "number_of_period", "type": "u16" }
+          {
+            "name": "cliff_point",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "period_frequency",
+            "type": "u64"
+          },
+          {
+            "name": "cliff_unlock_liquidity",
+            "type": "u128"
+          },
+          {
+            "name": "liquidity_per_period",
+            "type": "u128"
+          },
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          }
         ]
       }
     }
   ],
   "constants": [
-    { "name": "BIN_STEP_BPS_DEFAULT", "type": "u16", "value": "1" },
+    {
+      "name": "BIN_STEP_BPS_DEFAULT",
+      "type": "u16",
+      "value": "1"
+    },
     {
       "name": "BIN_STEP_U128_DEFAULT_LE_BYTES",
-      "type": { "array": ["u8", 16] },
+      "type": {
+        "array": [
+          "u8",
+          16
+        ]
+      },
       "value": "[203, 16, 199, 186, 184, 141, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
     },
-    { "name": "CUSTOMIZABLE_POOL_PREFIX", "type": "bytes", "value": "[99, 112, 111, 111, 108]" },
+    {
+      "name": "CURRENT_POOL_VERSION",
+      "type": "u8",
+      "value": "1"
+    },
+    {
+      "name": "CUSTOMIZABLE_POOL_PREFIX",
+      "type": "bytes",
+      "value": "[99, 112, 111, 111, 108]"
+    },
     {
       "name": "FEE_DENOMINATOR",
       "docs": [
@@ -2664,15 +7353,47 @@
       "type": "u64",
       "value": "1000000000"
     },
-    { "name": "MAX_BASIS_POINT", "docs": ["Max basis point. 100% in pct"], "type": "u64", "value": "10000" },
+    {
+      "name": "MAX_BASIS_POINT",
+      "docs": [
+        "Max basis point. 100% in pct"
+      ],
+      "type": "u16",
+      "value": "10000"
+    },
+    {
+      "name": "MAX_FEE_NUMERATOR_V0",
+      "type": "u64",
+      "value": "500000000"
+    },
+    {
+      "name": "MAX_FEE_NUMERATOR_V1",
+      "type": "u64",
+      "value": "990000000"
+    },
     {
       "name": "MAX_SQRT_PRICE_LE_BYTES",
-      "type": { "array": ["u8", 16] },
+      "type": {
+        "array": [
+          "u8",
+          16
+        ]
+      },
       "value": "[155, 87, 105, 78, 169, 26, 92, 132, 177, 196, 254, 255, 0, 0, 0, 0]"
     },
     {
+      "name": "MIN_FEE_NUMERATOR",
+      "type": "u64",
+      "value": "100000"
+    },
+    {
       "name": "MIN_SQRT_PRICE_LE_BYTES",
-      "type": { "array": ["u8", 16] },
+      "type": {
+        "array": [
+          "u8",
+          16
+        ]
+      },
       "value": "[80, 59, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
     },
     {
@@ -2680,14 +7401,26 @@
       "type": "bytes",
       "value": "[112, 111, 111, 108, 95, 97, 117, 116, 104, 111, 114, 105, 116, 121]"
     },
-    { "name": "POOL_PREFIX", "type": "bytes", "value": "[112, 111, 111, 108]" },
+    {
+      "name": "POOL_PREFIX",
+      "type": "bytes",
+      "value": "[112, 111, 111, 108]"
+    },
     {
       "name": "POSITION_NFT_ACCOUNT_PREFIX",
       "type": "bytes",
       "value": "[112, 111, 115, 105, 116, 105, 111, 110, 95, 110, 102, 116, 95, 97, 99, 99, 111, 117, 110, 116]"
     },
-    { "name": "POSITION_PREFIX", "type": "bytes", "value": "[112, 111, 115, 105, 116, 105, 111, 110]" },
-    { "name": "SPLIT_POSITION_DENOMINATOR", "type": "u32", "value": "1000000000" },
+    {
+      "name": "POSITION_PREFIX",
+      "type": "bytes",
+      "value": "[112, 111, 115, 105, 116, 105, 111, 110]"
+    },
+    {
+      "name": "SPLIT_POSITION_DENOMINATOR",
+      "type": "u32",
+      "value": "1000000000"
+    },
     {
       "name": "TOKEN_VAULT_PREFIX",
       "type": "bytes",

--- a/idl/meteora_dynamic_bonding_curve.json
+++ b/idl/meteora_dynamic_bonding_curve.json
@@ -2,13 +2,16 @@
   "address": "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN",
   "metadata": {
     "name": "dynamic_bonding_curve",
-    "version": "0.1.6",
+    "version": "0.2.0",
     "spec": "0.1.0",
     "description": "Created with Anchor"
   },
   "instructions": [
     {
       "name": "claim_creator_trading_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
       "discriminator": [
         82,
         220,
@@ -47,28 +50,19 @@
           "docs": [
             "The vault token account for input token"
           ],
-          "writable": true,
-          "relations": [
-            "pool"
-          ]
+          "writable": true
         },
         {
           "name": "quote_vault",
           "docs": [
             "The vault token account for output token"
           ],
-          "writable": true,
-          "relations": [
-            "pool"
-          ]
+          "writable": true
         },
         {
           "name": "base_mint",
           "docs": [
             "The mint of token a"
-          ],
-          "relations": [
-            "pool"
           ]
         },
         {
@@ -79,10 +73,7 @@
         },
         {
           "name": "creator",
-          "signer": true,
-          "relations": [
-            "pool"
-          ]
+          "signer": true
         },
         {
           "name": "token_base_program",
@@ -97,33 +88,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -141,7 +106,156 @@
       ]
     },
     {
+      "name": "claim_creator_trading_fee2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        238,
+        247,
+        213,
+        94,
+        110,
+        145,
+        88,
+        142
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_base_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_quote_amount",
+          "type": "u64"
+        },
+        {
+          "name": "transfer_hook_accounts_info",
+          "type": {
+            "defined": {
+              "name": "TransferHookAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "claim_partner_pool_creation_fee",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        250,
+        238,
+        26,
+        4,
+        139,
+        10,
+        101,
+        248
+      ],
+      "accounts": [
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "fee_receiver",
+          "writable": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "claim_protocol_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
       "discriminator": [
         165,
         228,
@@ -207,205 +321,21 @@
         },
         {
           "name": "token_base_account",
-          "docs": [
-            "The treasury token a account"
-          ],
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  48,
-                  9,
-                  89,
-                  123,
-                  106,
-                  114,
-                  131,
-                  251,
-                  50,
-                  173,
-                  254,
-                  250,
-                  10,
-                  80,
-                  160,
-                  84,
-                  143,
-                  100,
-                  81,
-                  249,
-                  134,
-                  112,
-                  30,
-                  213,
-                  50,
-                  166,
-                  239,
-                  78,
-                  53,
-                  175,
-                  188,
-                  85
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "token_base_program"
-              },
-              {
-                "kind": "account",
-                "path": "base_mint"
-              }
-            ],
-            "program": {
-              "kind": "const",
-              "value": [
-                140,
-                151,
-                37,
-                143,
-                78,
-                36,
-                137,
-                241,
-                187,
-                61,
-                16,
-                41,
-                20,
-                142,
-                13,
-                131,
-                11,
-                90,
-                19,
-                153,
-                218,
-                255,
-                16,
-                132,
-                4,
-                142,
-                123,
-                216,
-                219,
-                233,
-                248,
-                89
-              ]
-            }
-          }
+          "writable": true
         },
         {
           "name": "token_quote_account",
-          "docs": [
-            "The treasury token b account"
-          ],
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  48,
-                  9,
-                  89,
-                  123,
-                  106,
-                  114,
-                  131,
-                  251,
-                  50,
-                  173,
-                  254,
-                  250,
-                  10,
-                  80,
-                  160,
-                  84,
-                  143,
-                  100,
-                  81,
-                  249,
-                  134,
-                  112,
-                  30,
-                  213,
-                  50,
-                  166,
-                  239,
-                  78,
-                  53,
-                  175,
-                  188,
-                  85
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "token_quote_program"
-              },
-              {
-                "kind": "account",
-                "path": "quote_mint"
-              }
-            ],
-            "program": {
-              "kind": "const",
-              "value": [
-                140,
-                151,
-                37,
-                143,
-                78,
-                36,
-                137,
-                241,
-                187,
-                61,
-                16,
-                41,
-                20,
-                142,
-                13,
-                131,
-                11,
-                90,
-                19,
-                153,
-                218,
-                255,
-                16,
-                132,
-                4,
-                142,
-                123,
-                216,
-                219,
-                233,
-                248,
-                89
-              ]
-            }
-          }
+          "writable": true
         },
         {
-          "name": "claim_fee_operator",
-          "docs": [
-            "Claim fee operator"
-          ]
+          "name": "operator"
         },
         {
-          "name": "operator",
+          "name": "signer",
           "docs": [
-            "Operator"
+            "Signer"
           ],
-          "signer": true,
-          "relations": [
-            "claim_fee_operator"
-          ]
+          "signer": true
         },
         {
           "name": "token_base_program",
@@ -420,33 +350,130 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_base_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_quote_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_protocol_fee2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        235,
+        194,
+        54,
+        69,
+        65,
+        10,
+        236,
+        112
+      ],
+      "accounts": [
+        {
+          "name": "receiver_token_account",
+          "docs": [
+            "receiver token account for the claimed token. validated through the protocol_fee program"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint"
+        },
+        {
+          "name": "quote_mint"
+        },
+        {
+          "name": "token_base_program"
+        },
+        {
+          "name": "token_quote_program"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "writable": true
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "signer",
+          "signer": true,
+          "address": "FkU5rQCWQM131skHCpcEbK8P1JrQGsBgqXe55w525SSF"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "claim_protocol_pool_creation_fee",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
+      "discriminator": [
+        114,
+        205,
+        83,
+        188,
+        240,
+        153,
+        25,
+        54
+      ],
+      "accounts": [
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "operator"
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Operator"
+          ],
+          "signer": true
+        },
+        {
+          "name": "treasury",
+          "writable": true,
+          "address": "6aYhxiNGmG8AyU25rh2R7iFu4pBrqnQHpNUGhmsEXRcm"
+        },
+        {
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -456,6 +483,9 @@
     },
     {
       "name": "claim_trading_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
       "discriminator": [
         8,
         236,
@@ -472,10 +502,7 @@
           "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
         },
         {
-          "name": "config",
-          "relations": [
-            "pool"
-          ]
+          "name": "config"
         },
         {
           "name": "pool",
@@ -500,45 +527,30 @@
           "docs": [
             "The vault token account for input token"
           ],
-          "writable": true,
-          "relations": [
-            "pool"
-          ]
+          "writable": true
         },
         {
           "name": "quote_vault",
           "docs": [
             "The vault token account for output token"
           ],
-          "writable": true,
-          "relations": [
-            "pool"
-          ]
+          "writable": true
         },
         {
           "name": "base_mint",
           "docs": [
             "The mint of token a"
-          ],
-          "relations": [
-            "pool"
           ]
         },
         {
           "name": "quote_mint",
           "docs": [
             "The mint of token b"
-          ],
-          "relations": [
-            "config"
           ]
         },
         {
           "name": "fee_claimer",
-          "signer": true,
-          "relations": [
-            "config"
-          ]
+          "signer": true
         },
         {
           "name": "token_base_program",
@@ -553,33 +565,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -597,16 +583,125 @@
       ]
     },
     {
-      "name": "close_claim_fee_operator",
+      "name": "claim_trading_fee2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
       "discriminator": [
-        38,
-        134,
-        82,
-        216,
-        95,
-        124,
-        17,
-        99
+        84,
+        191,
+        71,
+        50,
+        9,
+        162,
+        55,
+        193
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_a_account",
+          "docs": [
+            "The treasury token a account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_b_account",
+          "docs": [
+            "The treasury token b account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of token a"
+          ]
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of token b"
+          ]
+        },
+        {
+          "name": "fee_claimer",
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token a program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token b program"
+          ]
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount_a",
+          "type": "u64"
+        },
+        {
+          "name": "max_amount_b",
+          "type": "u64"
+        },
+        {
+          "name": "transfer_hook_accounts_info",
+          "type": {
+            "defined": {
+              "name": "TransferHookAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "close_claim_protocol_fee_operator",
+      "discriminator": [
+        8,
+        41,
+        87,
+        35,
+        80,
+        48,
+        121,
+        26
       ],
       "accounts": [
         {
@@ -618,37 +713,11 @@
           "writable": true
         },
         {
-          "name": "admin",
+          "name": "signer",
           "signer": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -657,92 +726,29 @@
       "args": []
     },
     {
-      "name": "create_claim_fee_operator",
-      "docs": [
-        "ADMIN FUNCTIONS_ ///"
-      ],
+      "name": "close_operator_account",
       "discriminator": [
-        169,
-        62,
-        207,
-        107,
-        58,
-        187,
-        162,
-        109
+        171,
+        9,
+        213,
+        74,
+        120,
+        23,
+        3,
+        29
       ],
       "accounts": [
         {
-          "name": "claim_fee_operator",
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  99,
-                  102,
-                  95,
-                  111,
-                  112,
-                  101,
-                  114,
-                  97,
-                  116,
-                  111,
-                  114
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "operator"
-              }
-            ]
-          }
+          "name": "operator",
+          "writable": true
         },
         {
-          "name": "operator"
-        },
-        {
-          "name": "admin",
-          "writable": true,
+          "name": "signer",
           "signer": true
         },
         {
-          "name": "system_program",
-          "address": "11111111111111111111111111111111"
-        },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "name": "program"
+          "name": "rent_receiver",
+          "writable": true
         }
       ],
       "args": []
@@ -787,33 +793,67 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "config_parameters",
+          "type": {
+            "defined": {
+              "name": "ConfigParameters"
+            }
           }
+        }
+      ]
+    },
+    {
+      "name": "create_config_with_transfer_hook",
+      "discriminator": [
+        216,
+        37,
+        1,
+        57,
+        88,
+        226,
+        25,
+        41
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "fee_claimer"
+        },
+        {
+          "name": "leftover_receiver"
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "quote mint"
+          ]
+        },
+        {
+          "name": "transfer_hook_program"
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -834,7 +874,8 @@
       "name": "create_locker",
       "docs": [
         "PERMISSIONLESS FUNCTIONS ///",
-        "create locker"
+        "create locker",
+        "Accepts: VirtualPool or TransferHookPool."
       ],
       "discriminator": [
         167,
@@ -849,19 +890,10 @@
       "accounts": [
         {
           "name": "virtual_pool",
-          "docs": [
-            "Virtual pool"
-          ],
           "writable": true
         },
         {
-          "name": "config",
-          "docs": [
-            "Config"
-          ],
-          "relations": [
-            "virtual_pool"
-          ]
+          "name": "config"
         },
         {
           "name": "pool_authority",
@@ -870,17 +902,11 @@
         },
         {
           "name": "base_vault",
-          "writable": true,
-          "relations": [
-            "virtual_pool"
-          ]
+          "writable": true
         },
         {
           "name": "base_mint",
-          "writable": true,
-          "relations": [
-            "virtual_pool"
-          ]
+          "writable": true
         },
         {
           "name": "base",
@@ -911,10 +937,7 @@
           }
         },
         {
-          "name": "creator",
-          "relations": [
-            "virtual_pool"
-          ]
+          "name": "creator"
         },
         {
           "name": "escrow",
@@ -950,9 +973,77 @@
       "args": []
     },
     {
+      "name": "create_operator_account",
+      "discriminator": [
+        221,
+        64,
+        246,
+        149,
+        240,
+        153,
+        229,
+        163
+      ],
+      "accounts": [
+        {
+          "name": "operator",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  111,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "whitelisted_address"
+              }
+            ]
+          }
+        },
+        {
+          "name": "whitelisted_address"
+        },
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "permission",
+          "type": "u128"
+        }
+      ]
+    },
+    {
       "name": "create_partner_metadata",
       "docs": [
-        "PARTNER FUNCTIONS ////"
+        "PARTNER FUNCTIONS ///"
       ],
       "discriminator": [
         192,
@@ -1024,33 +1115,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1069,6 +1134,9 @@
     },
     {
       "name": "create_virtual_pool_metadata",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
       "discriminator": [
         45,
         97,
@@ -1081,8 +1149,7 @@
       ],
       "accounts": [
         {
-          "name": "virtual_pool",
-          "writable": true
+          "name": "virtual_pool"
         },
         {
           "name": "virtual_pool_metadata",
@@ -1127,10 +1194,7 @@
         },
         {
           "name": "creator",
-          "signer": true,
-          "relations": [
-            "virtual_pool"
-          ]
+          "signer": true
         },
         {
           "name": "payer",
@@ -1148,33 +1212,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1193,6 +1231,9 @@
     },
     {
       "name": "creator_withdraw_surplus",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
       "discriminator": [
         165,
         3,
@@ -1209,10 +1250,7 @@
           "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
         },
         {
-          "name": "config",
-          "relations": [
-            "virtual_pool"
-          ]
+          "name": "config"
         },
         {
           "name": "virtual_pool",
@@ -1230,26 +1268,17 @@
           "docs": [
             "The vault token account for output token"
           ],
-          "writable": true,
-          "relations": [
-            "virtual_pool"
-          ]
+          "writable": true
         },
         {
           "name": "quote_mint",
           "docs": [
             "The mint of quote token"
-          ],
-          "relations": [
-            "config"
           ]
         },
         {
           "name": "creator",
-          "signer": true,
-          "relations": [
-            "virtual_pool"
-          ]
+          "signer": true
         },
         {
           "name": "token_quote_program",
@@ -1258,33 +1287,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1295,7 +1298,8 @@
     {
       "name": "initialize_virtual_pool_with_spl_token",
       "docs": [
-        "POOL CREATOR FUNCTIONS ////"
+        "POOL CREATOR FUNCTIONS ////",
+        "Accepts: VirtualPool only."
       ],
       "discriminator": [
         140,
@@ -1441,33 +1445,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1486,6 +1464,9 @@
     },
     {
       "name": "initialize_virtual_pool_with_token2022",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
       "discriminator": [
         169,
         118,
@@ -1625,33 +1606,156 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "InitializePoolParameters"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_virtual_pool_with_token2022_transfer_hook",
+      "docs": [
+        "Accepts: TransferHookPool only."
+      ],
+      "discriminator": [
+        182,
+        13,
+        233,
+        177,
+        42,
+        145,
+        135,
+        2
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "docs": [
+            "Transfer hook config — contains the transfer hook program set by partner"
+          ]
+        },
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "creator",
+          "signer": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "Unique token mint address, initialize in contract"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "quote_mint",
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
+                  116,
+                  111,
+                  107,
                   101,
                   110,
-                  116,
                   95,
+                  118,
                   97,
                   117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  108,
+                  116
                 ]
+              },
+              {
+                "kind": "account",
+                "path": "base_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
               }
             ]
           }
+        },
+        {
+          "name": "quote_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  111,
+                  107,
+                  101,
+                  110,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "quote_mint"
+              },
+              {
+                "kind": "account",
+                "path": "pool"
+              }
+            ]
+          }
+        },
+        {
+          "name": "transfer_hook_program"
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_quote_program"
+        },
+        {
+          "name": "token_program",
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -1670,6 +1774,9 @@
     },
     {
       "name": "migrate_meteora_damm",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
       "discriminator": [
         27,
         1,
@@ -1829,6 +1936,9 @@
     },
     {
       "name": "migrate_meteora_damm_claim_lp_token",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
       "discriminator": [
         139,
         133,
@@ -2063,6 +2173,9 @@
     },
     {
       "name": "migrate_meteora_damm_lock_lp_token",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
       "discriminator": [
         177,
         55,
@@ -2243,6 +2356,9 @@
     },
     {
       "name": "migration_damm_v2",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
       "discriminator": [
         156,
         169,
@@ -2256,28 +2372,13 @@
       "accounts": [
         {
           "name": "virtual_pool",
-          "docs": [
-            "virtual pool"
-          ],
-          "writable": true,
-          "relations": [
-            "migration_metadata"
-          ]
+          "writable": true
         },
         {
-          "name": "migration_metadata",
-          "docs": [
-            "migration metadata"
-          ]
+          "name": "migration_metadata"
         },
         {
-          "name": "config",
-          "docs": [
-            "virtual pool config key"
-          ],
-          "relations": [
-            "virtual_pool"
-          ]
+          "name": "config"
         },
         {
           "name": "pool_authority",
@@ -2290,7 +2391,8 @@
         },
         {
           "name": "first_position_nft_mint",
-          "writable": true
+          "writable": true,
+          "signer": true
         },
         {
           "name": "first_position_nft_account",
@@ -2303,6 +2405,7 @@
         {
           "name": "second_position_nft_mint",
           "writable": true,
+          "signer": true,
           "optional": true
         },
         {
@@ -2340,17 +2443,11 @@
         },
         {
           "name": "base_vault",
-          "writable": true,
-          "relations": [
-            "virtual_pool"
-          ]
+          "writable": true
         },
         {
           "name": "quote_vault",
-          "writable": true,
-          "relations": [
-            "virtual_pool"
-          ]
+          "writable": true
         },
         {
           "name": "payer",
@@ -2381,6 +2478,9 @@
     },
     {
       "name": "migration_damm_v2_create_metadata",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
       "discriminator": [
         109,
         189,
@@ -2396,72 +2496,19 @@
           "name": "virtual_pool"
         },
         {
-          "name": "config",
-          "relations": [
-            "virtual_pool"
-          ]
+          "name": "config"
         },
         {
-          "name": "migration_metadata",
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  100,
-                  97,
-                  109,
-                  109,
-                  95,
-                  118,
-                  50
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "virtual_pool"
-              }
-            ]
-          }
+          "name": "migration_metadata"
         },
         {
-          "name": "payer",
-          "writable": true,
-          "signer": true
+          "name": "payer"
         },
         {
-          "name": "system_program",
-          "address": "11111111111111111111111111111111"
+          "name": "system_program"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2472,7 +2519,7 @@
     {
       "name": "migration_meteora_damm_create_metadata",
       "docs": [
-        "migrate damm v1"
+        "Accepts: VirtualPool only."
       ],
       "discriminator": [
         47,
@@ -2528,33 +2575,7 @@
           "address": "11111111111111111111111111111111"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2564,6 +2585,9 @@
     },
     {
       "name": "partner_withdraw_surplus",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
       "discriminator": [
         168,
         173,
@@ -2580,10 +2604,7 @@
           "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
         },
         {
-          "name": "config",
-          "relations": [
-            "virtual_pool"
-          ]
+          "name": "config"
         },
         {
           "name": "virtual_pool",
@@ -2601,26 +2622,17 @@
           "docs": [
             "The vault token account for output token"
           ],
-          "writable": true,
-          "relations": [
-            "virtual_pool"
-          ]
+          "writable": true
         },
         {
           "name": "quote_mint",
           "docs": [
             "The mint of quote token"
-          ],
-          "relations": [
-            "config"
           ]
         },
         {
           "name": "fee_claimer",
-          "signer": true,
-          "relations": [
-            "config"
-          ]
+          "signer": true
         },
         {
           "name": "token_quote_program",
@@ -2629,213 +2641,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
-        },
-        {
-          "name": "program"
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "protocol_withdraw_surplus",
-      "discriminator": [
-        54,
-        136,
-        225,
-        138,
-        172,
-        182,
-        214,
-        167
-      ],
-      "accounts": [
-        {
-          "name": "pool_authority",
-          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
-        },
-        {
-          "name": "config",
-          "relations": [
-            "virtual_pool"
-          ]
-        },
-        {
-          "name": "virtual_pool",
-          "writable": true
-        },
-        {
-          "name": "token_quote_account",
-          "docs": [
-            "The treasury quote token account"
-          ],
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  48,
-                  9,
-                  89,
-                  123,
-                  106,
-                  114,
-                  131,
-                  251,
-                  50,
-                  173,
-                  254,
-                  250,
-                  10,
-                  80,
-                  160,
-                  84,
-                  143,
-                  100,
-                  81,
-                  249,
-                  134,
-                  112,
-                  30,
-                  213,
-                  50,
-                  166,
-                  239,
-                  78,
-                  53,
-                  175,
-                  188,
-                  85
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "token_quote_program"
-              },
-              {
-                "kind": "account",
-                "path": "quote_mint"
-              }
-            ],
-            "program": {
-              "kind": "const",
-              "value": [
-                140,
-                151,
-                37,
-                143,
-                78,
-                36,
-                137,
-                241,
-                187,
-                61,
-                16,
-                41,
-                20,
-                142,
-                13,
-                131,
-                11,
-                90,
-                19,
-                153,
-                218,
-                255,
-                16,
-                132,
-                4,
-                142,
-                123,
-                216,
-                219,
-                233,
-                248,
-                89
-              ]
-            }
-          }
-        },
-        {
-          "name": "quote_vault",
-          "docs": [
-            "The vault token account for quote token"
-          ],
-          "writable": true,
-          "relations": [
-            "virtual_pool"
-          ]
-        },
-        {
-          "name": "quote_mint",
-          "docs": [
-            "The mint of token"
-          ],
-          "relations": [
-            "config"
-          ]
-        },
-        {
-          "name": "token_quote_program",
-          "docs": [
-            "Token b program"
-          ]
-        },
-        {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2846,7 +2652,8 @@
     {
       "name": "swap",
       "docs": [
-        "TRADING BOTS FUNCTIONS ////"
+        "TRADING BOTS FUNCTIONS ////",
+        "Accepts: VirtualPool only."
       ],
       "discriminator": [
         248,
@@ -2864,19 +2671,10 @@
           "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
         },
         {
-          "name": "config",
-          "docs": [
-            "config key"
-          ],
-          "relations": [
-            "pool"
-          ]
+          "name": "config"
         },
         {
           "name": "pool",
-          "docs": [
-            "Pool account"
-          ],
           "writable": true
         },
         {
@@ -2898,20 +2696,14 @@
           "docs": [
             "The vault token account for base token"
           ],
-          "writable": true,
-          "relations": [
-            "pool"
-          ]
+          "writable": true
         },
         {
           "name": "quote_vault",
           "docs": [
             "The vault token account for quote token"
           ],
-          "writable": true,
-          "relations": [
-            "pool"
-          ]
+          "writable": true
         },
         {
           "name": "base_mint",
@@ -2953,33 +2745,7 @@
           "optional": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -2998,6 +2764,9 @@
     },
     {
       "name": "swap2",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
       "discriminator": [
         65,
         75,
@@ -3014,19 +2783,10 @@
           "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
         },
         {
-          "name": "config",
-          "docs": [
-            "config key"
-          ],
-          "relations": [
-            "pool"
-          ]
+          "name": "config"
         },
         {
           "name": "pool",
-          "docs": [
-            "Pool account"
-          ],
           "writable": true
         },
         {
@@ -3048,20 +2808,14 @@
           "docs": [
             "The vault token account for base token"
           ],
-          "writable": true,
-          "relations": [
-            "pool"
-          ]
+          "writable": true
         },
         {
           "name": "quote_vault",
           "docs": [
             "The vault token account for quote token"
           ],
-          "writable": true,
-          "relations": [
-            "pool"
-          ]
+          "writable": true
         },
         {
           "name": "base_mint",
@@ -3103,33 +2857,7 @@
           "optional": true
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3147,7 +2875,132 @@
       ]
     },
     {
+      "name": "swap2_with_transfer_hook",
+      "docs": [
+        "Accepts: TransferHookPool only."
+      ],
+      "discriminator": [
+        183,
+        93,
+        153,
+        40,
+        24,
+        230,
+        194,
+        151
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config"
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_vault",
+          "docs": [
+            "The vault token account for base token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_vault",
+          "docs": [
+            "The vault token account for quote token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "base_mint",
+          "docs": [
+            "The mint of base token",
+            "must be mutable so we can revoke the transfer hook after the last swap is performed"
+          ],
+          "writable": true
+        },
+        {
+          "name": "quote_mint",
+          "docs": [
+            "The mint of quote token"
+          ]
+        },
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_base_program",
+          "docs": [
+            "Token base program"
+          ]
+        },
+        {
+          "name": "token_quote_program",
+          "docs": [
+            "Token quote program"
+          ]
+        },
+        {
+          "name": "referral_token_account",
+          "docs": [
+            "referral token account"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "event_authority"
+        },
+        {
+          "name": "program"
+        }
+      ],
+      "args": [
+        {
+          "name": "params",
+          "type": {
+            "defined": {
+              "name": "SwapParameters2"
+            }
+          }
+        },
+        {
+          "name": "transfer_hook_accounts_info",
+          "type": {
+            "defined": {
+              "name": "TransferHookAccountsInfo"
+            }
+          }
+        }
+      ]
+    },
+    {
       "name": "transfer_pool_creator",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
       "discriminator": [
         20,
         7,
@@ -3164,49 +3017,17 @@
           "writable": true
         },
         {
-          "name": "config",
-          "relations": [
-            "virtual_pool"
-          ]
+          "name": "config"
         },
         {
           "name": "creator",
-          "signer": true,
-          "relations": [
-            "virtual_pool"
-          ]
+          "signer": true
         },
         {
           "name": "new_creator"
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3216,6 +3037,9 @@
     },
     {
       "name": "withdraw_leftover",
+      "docs": [
+        "Accepts: VirtualPool or TransferHookPool."
+      ],
       "discriminator": [
         20,
         198,
@@ -3232,10 +3056,7 @@
           "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
         },
         {
-          "name": "config",
-          "relations": [
-            "virtual_pool"
-          ]
+          "name": "config"
         },
         {
           "name": "virtual_pool",
@@ -3306,25 +3127,16 @@
           "docs": [
             "The vault token account for output token"
           ],
-          "writable": true,
-          "relations": [
-            "virtual_pool"
-          ]
+          "writable": true
         },
         {
           "name": "base_mint",
           "docs": [
             "The mint of quote token"
-          ],
-          "relations": [
-            "virtual_pool"
           ]
         },
         {
-          "name": "leftover_receiver",
-          "relations": [
-            "config"
-          ]
+          "name": "leftover_receiver"
         },
         {
           "name": "token_base_program",
@@ -3333,33 +3145,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3370,7 +3156,8 @@
     {
       "name": "withdraw_migration_fee",
       "docs": [
-        "BOTH partner and creator FUNCTIONS ///"
+        "BOTH partner and creator FUNCTIONS ///",
+        "Accepts: VirtualPool or TransferHookPool."
       ],
       "discriminator": [
         237,
@@ -3388,10 +3175,7 @@
           "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
         },
         {
-          "name": "config",
-          "relations": [
-            "virtual_pool"
-          ]
+          "name": "config"
         },
         {
           "name": "virtual_pool",
@@ -3409,18 +3193,12 @@
           "docs": [
             "The vault token account for output token"
           ],
-          "writable": true,
-          "relations": [
-            "virtual_pool"
-          ]
+          "writable": true
         },
         {
           "name": "quote_mint",
           "docs": [
             "The mint of quote token"
-          ],
-          "relations": [
-            "config"
           ]
         },
         {
@@ -3434,33 +3212,7 @@
           ]
         },
         {
-          "name": "event_authority",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
-                ]
-              }
-            ]
-          }
+          "name": "event_authority"
         },
         {
           "name": "program"
@@ -3470,6 +3222,78 @@
         {
           "name": "flag",
           "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "zap_protocol_fee",
+      "docs": [
+        "Accepts: VirtualPool only."
+      ],
+      "discriminator": [
+        213,
+        155,
+        187,
+        34,
+        56,
+        182,
+        91,
+        240
+      ],
+      "accounts": [
+        {
+          "name": "pool_authority",
+          "address": "FhVo3mqL8PW5pH5U2CN4XE33DokiyZnUwuGpH2hmHLuM"
+        },
+        {
+          "name": "config",
+          "relations": [
+            "pool"
+          ]
+        },
+        {
+          "name": "pool",
+          "writable": true
+        },
+        {
+          "name": "token_vault",
+          "writable": true
+        },
+        {
+          "name": "token_mint"
+        },
+        {
+          "name": "receiver_token",
+          "writable": true
+        },
+        {
+          "name": "operator",
+          "docs": [
+            "zap claim fee operator"
+          ]
+        },
+        {
+          "name": "signer",
+          "docs": [
+            "Operator"
+          ],
+          "signer": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program"
+          ]
+        },
+        {
+          "name": "sysvar_instructions",
+          "address": "Sysvar1nstructions1111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "max_amount",
+          "type": "u64"
         }
       ]
     }
@@ -3489,29 +3313,16 @@
       ]
     },
     {
-      "name": "Config",
+      "name": "ConfigWithTransferHook",
       "discriminator": [
-        155,
-        12,
-        170,
-        224,
-        30,
-        250,
-        204,
-        130
-      ]
-    },
-    {
-      "name": "LockEscrow",
-      "discriminator": [
-        190,
-        106,
-        121,
-        6,
-        200,
-        182,
-        21,
-        75
+        40,
+        220,
+        194,
+        251,
+        41,
+        199,
+        123,
+        253
       ]
     },
     {
@@ -3528,16 +3339,16 @@
       ]
     },
     {
-      "name": "MeteoraDammV2Metadata",
+      "name": "Operator",
       "discriminator": [
-        104,
-        221,
         219,
-        203,
-        10,
-        142,
-        250,
-        163
+        31,
+        188,
+        145,
+        69,
+        139,
+        204,
+        117
       ]
     },
     {
@@ -3564,6 +3375,19 @@
         230,
         129,
         43
+      ]
+    },
+    {
+      "name": "TransferHookPool",
+      "discriminator": [
+        237,
+        219,
+        184,
+        23,
+        42,
+        189,
+        169,
+        35
       ]
     },
     {
@@ -3608,6 +3432,19 @@
       ]
     },
     {
+      "name": "EvtClaimPoolCreationFee",
+      "discriminator": [
+        149,
+        111,
+        149,
+        44,
+        136,
+        64,
+        175,
+        62
+      ]
+    },
+    {
       "name": "EvtClaimProtocolFee",
       "discriminator": [
         186,
@@ -3618,6 +3455,19 @@
         13,
         25,
         33
+      ]
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "discriminator": [
+        187,
+        133,
+        66,
+        9,
+        205,
+        161,
+        84,
+        13
       ]
     },
     {
@@ -3686,16 +3536,16 @@
       ]
     },
     {
-      "name": "EvtCreateDammV2MigrationMetadata",
+      "name": "EvtCreateConfigV2WithTransferHook",
       "discriminator": [
-        103,
-        111,
+        182,
+        81,
+        135,
+        4,
+        39,
+        46,
         132,
-        168,
-        140,
-        253,
-        150,
-        114
+        253
       ]
     },
     {
@@ -3738,6 +3588,19 @@
       ]
     },
     {
+      "name": "EvtCurveCompleteWithTransferHook",
+      "discriminator": [
+        59,
+        47,
+        109,
+        205,
+        13,
+        31,
+        44,
+        159
+      ]
+    },
+    {
       "name": "EvtInitializePool",
       "discriminator": [
         228,
@@ -3748,6 +3611,32 @@
         66,
         134,
         37
+      ]
+    },
+    {
+      "name": "EvtInitializePoolWithTransferHook",
+      "discriminator": [
+        213,
+        137,
+        164,
+        53,
+        193,
+        74,
+        15,
+        110
+      ]
+    },
+    {
+      "name": "EvtPartnerClaimPoolCreationFee",
+      "discriminator": [
+        174,
+        223,
+        44,
+        150,
+        145,
+        98,
+        89,
+        195
       ]
     },
     {
@@ -3764,19 +3653,6 @@
       ]
     },
     {
-      "name": "EvtPartnerWithdrawMigrationFee",
-      "discriminator": [
-        181,
-        105,
-        127,
-        67,
-        8,
-        187,
-        120,
-        57
-      ]
-    },
-    {
       "name": "EvtPartnerWithdrawSurplus",
       "discriminator": [
         195,
@@ -3787,19 +3663,6 @@
         72,
         35,
         22
-      ]
-    },
-    {
-      "name": "EvtProtocolWithdrawSurplus",
-      "discriminator": [
-        109,
-        111,
-        28,
-        221,
-        134,
-        195,
-        230,
-        203
       ]
     },
     {
@@ -3826,6 +3689,19 @@
         80,
         117,
         153
+      ]
+    },
+    {
+      "name": "EvtSwap2WithTransferHook",
+      "discriminator": [
+        134,
+        59,
+        168,
+        120,
+        94,
+        51,
+        114,
+        231
       ]
     },
     {
@@ -3965,7 +3841,7 @@
     {
       "code": 6016,
       "name": "InvalidTokenDecimals",
-      "msg": "Invalid activation type"
+      "msg": "Invalid token decimals"
     },
     {
       "code": 6017,
@@ -4049,8 +3925,8 @@
     },
     {
       "code": 6033,
-      "name": "SwapAmountIsOverAThreshold",
-      "msg": "Swap amount is over a threshold"
+      "name": "InsufficientLiquidity",
+      "msg": "Liquidity in bonding curve is insufficient"
     },
     {
       "code": 6034,
@@ -4126,9 +4002,166 @@
       "code": 6048,
       "name": "NextSqrtPriceIsSmallerThanStartSqrtPrice",
       "msg": "Next sqrt price is smaller than start sqrt price"
+    },
+    {
+      "code": 6049,
+      "name": "InvalidMinBaseFee",
+      "msg": "Invalid min base fee"
+    },
+    {
+      "code": 6050,
+      "name": "AccountInvariantViolation",
+      "msg": "Account invariant violation"
+    },
+    {
+      "code": 6051,
+      "name": "InvalidPoolCreationFee",
+      "msg": "Invalid pool creation fee"
+    },
+    {
+      "code": 6052,
+      "name": "PoolCreationFeeHasBeenClaimed",
+      "msg": "Pool creation fee has been claimed"
+    },
+    {
+      "code": 6053,
+      "name": "Unauthorized",
+      "msg": "Not permit to do this action"
+    },
+    {
+      "code": 6054,
+      "name": "ZeroPoolCreationFee",
+      "msg": "Pool creation fee is zero"
+    },
+    {
+      "code": 6055,
+      "name": "InvalidMigrationLockedLiquidity",
+      "msg": "Invalid migration locked liquidity"
+    },
+    {
+      "code": 6056,
+      "name": "InvalidFeeMarketCapScheduler",
+      "msg": "Invalid fee market cap scheduler"
+    },
+    {
+      "code": 6057,
+      "name": "FirstSwapValidationFailed",
+      "msg": "Fail to validate first swap with minimum fee"
+    },
+    {
+      "code": 6058,
+      "name": "IncorrectATA",
+      "msg": "Incorrect ATA"
+    },
+    {
+      "code": 6059,
+      "name": "InsufficientPoolLamports",
+      "msg": "Pool has insufficient lamports to perform the operation"
+    },
+    {
+      "code": 6060,
+      "name": "InvalidPermission",
+      "msg": "Invalid permission"
+    },
+    {
+      "code": 6061,
+      "name": "InvalidWithdrawProtocolFeeZapAccounts",
+      "msg": "Invalid withdraw protocol fee zap accounts"
+    },
+    {
+      "code": 6062,
+      "name": "MintRestrictedFromZap",
+      "msg": "SOL,USDC protocol fee cannot be withdrawn via zap"
+    },
+    {
+      "code": 6063,
+      "name": "InvalidZapOutParameters",
+      "msg": "Invalid zap out parameters"
+    },
+    {
+      "code": 6064,
+      "name": "CpiDisabled",
+      "msg": "CPI disabled"
+    },
+    {
+      "code": 6065,
+      "name": "MissingZapOutInstruction",
+      "msg": "Missing zap out instruction"
+    },
+    {
+      "code": 6066,
+      "name": "InvalidZapAccounts",
+      "msg": "Invalid zap accounts"
+    },
+    {
+      "code": 6067,
+      "name": "InvalidCompoundingParameters",
+      "msg": "Invalid compounding parameters"
+    },
+    {
+      "code": 6068,
+      "name": "InvalidClaimProtocolFeeAccounts",
+      "msg": "Invalid claim protocol fee accounts"
+    },
+    {
+      "code": 6069,
+      "name": "InvalidInstructionsSysvar",
+      "msg": "Invalid instructions sysvar account"
+    },
+    {
+      "code": 6070,
+      "name": "InvalidRemainingAccountsLength",
+      "msg": "Invalid remaining accounts length"
+    },
+    {
+      "code": 6071,
+      "name": "MissingRemainingAccountForTransferHook",
+      "msg": "Missing remaining account for transfer hook"
+    },
+    {
+      "code": 6072,
+      "name": "NoTransferHookProgram",
+      "msg": "No transfer hook program"
+    },
+    {
+      "code": 6073,
+      "name": "DuplicatedRemainingAccountTypes",
+      "msg": "Duplicated remaining account types"
+    },
+    {
+      "code": 6074,
+      "name": "InvalidTransferHookProgram",
+      "msg": "Invalid transfer hook program"
+    },
+    {
+      "code": 6075,
+      "name": "InvalidPoolAccount",
+      "msg": "Invalid pool account"
+    },
+    {
+      "code": 6076,
+      "name": "PoolTypeMismatch",
+      "msg": "Pool type does not match instruction"
     }
   ],
   "types": [
+    {
+      "name": "AccountsType",
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "TransferHookBase"
+          },
+          {
+            "name": "TransferHookBaseReferral"
+          }
+        ]
+      }
+    },
     {
       "name": "BaseFeeConfig",
       "serialization": "bytemuck",
@@ -4311,19 +4344,19 @@
             "type": "u8"
           },
           {
-            "name": "partner_lp_percentage",
+            "name": "partner_liquidity_percentage",
             "type": "u8"
           },
           {
-            "name": "partner_locked_lp_percentage",
+            "name": "partner_permanent_locked_liquidity_percentage",
             "type": "u8"
           },
           {
-            "name": "creator_lp_percentage",
+            "name": "creator_liquidity_percentage",
             "type": "u8"
           },
           {
-            "name": "creator_locked_lp_percentage",
+            "name": "creator_permanent_locked_liquidity_percentage",
             "type": "u8"
           },
           {
@@ -4381,14 +4414,57 @@
             }
           },
           {
+            "name": "pool_creation_fee",
+            "docs": [
+              "pool creation fee in SOL lamports value"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "partner_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfoParams"
+              }
+            }
+          },
+          {
+            "name": "creator_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfoParams"
+              }
+            }
+          },
+          {
+            "name": "migrated_pool_base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "migrated_pool_market_cap_fee_scheduler_params",
+            "type": {
+              "defined": {
+                "name": "MigratedPoolMarketCapFeeSchedulerParams"
+              }
+            }
+          },
+          {
+            "name": "enable_first_swap_with_min_fee",
+            "type": "bool"
+          },
+          {
+            "name": "compounding_fee_bps",
+            "type": "u16"
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for future use"
             ],
             "type": {
               "array": [
-                "u64",
-                7
+                "u8",
+                2
               ]
             }
           },
@@ -4400,6 +4476,39 @@
                   "name": "LiquidityDistributionParameters"
                 }
               }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigWithTransferHook",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "config",
+            "type": {
+              "defined": {
+                "name": "PoolConfig"
+              }
+            }
+          },
+          {
+            "name": "transfer_hook_program",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding_0",
+            "type": {
+              "array": [
+                "u64",
+                6
+              ]
             }
           }
         ]
@@ -4582,6 +4691,26 @@
       }
     },
     {
+      "name": "EvtClaimPoolCreationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "creation_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
       "name": "EvtClaimProtocolFee",
       "type": {
         "kind": "struct",
@@ -4596,6 +4725,30 @@
           },
           {
             "name": "token_quote_amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtClaimProtocolFee2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "receiver_token_account",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
             "type": "u64"
           }
         ]
@@ -4708,19 +4861,19 @@
             "type": "u8"
           },
           {
-            "name": "partner_locked_lp_percentage",
+            "name": "partner_permanent_locked_liquidity_percentage",
             "type": "u8"
           },
           {
-            "name": "partner_lp_percentage",
+            "name": "partner_liquidity_percentage",
             "type": "u8"
           },
           {
-            "name": "creator_locked_lp_percentage",
+            "name": "creator_permanent_locked_liquidity_percentage",
             "type": "u8"
           },
           {
-            "name": "creator_lp_percentage",
+            "name": "creator_liquidity_percentage",
             "type": "u8"
           },
           {
@@ -4809,12 +4962,36 @@
       }
     },
     {
-      "name": "EvtCreateDammV2MigrationMetadata",
+      "name": "EvtCreateConfigV2WithTransferHook",
       "type": {
         "kind": "struct",
         "fields": [
           {
-            "name": "virtual_pool",
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "quote_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "fee_claimer",
+            "type": "pubkey"
+          },
+          {
+            "name": "leftover_receiver",
+            "type": "pubkey"
+          },
+          {
+            "name": "config_parameters",
+            "type": {
+              "defined": {
+                "name": "ConfigParameters"
+              }
+            }
+          },
+          {
+            "name": "transfer_hook_program",
             "type": "pubkey"
           }
         ]
@@ -4873,6 +5050,30 @@
       }
     },
     {
+      "name": "EvtCurveCompleteWithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_reserve",
+            "type": "u64"
+          },
+          {
+            "name": "quote_reserve",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
       "name": "EvtInitializePool",
       "type": {
         "kind": "struct",
@@ -4905,6 +5106,62 @@
       }
     },
     {
+      "name": "EvtInitializePoolWithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "base_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_type",
+            "type": "u8"
+          },
+          {
+            "name": "activation_point",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "EvtPartnerClaimPoolCreationFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "partner",
+            "type": "pubkey"
+          },
+          {
+            "name": "creation_fee",
+            "type": "u64"
+          },
+          {
+            "name": "fee_receiver",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
       "name": "EvtPartnerMetadata",
       "docs": [
         "Create partner metadata"
@@ -4924,39 +5181,7 @@
       }
     },
     {
-      "name": "EvtPartnerWithdrawMigrationFee",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "pool",
-            "type": "pubkey"
-          },
-          {
-            "name": "fee",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
       "name": "EvtPartnerWithdrawSurplus",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "pool",
-            "type": "pubkey"
-          },
-          {
-            "name": "surplus_amount",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "EvtProtocolWithdrawSurplus",
       "type": {
         "kind": "struct",
         "fields": [
@@ -5072,6 +5297,58 @@
       }
     },
     {
+      "name": "EvtSwap2WithTransferHook",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool",
+            "type": "pubkey"
+          },
+          {
+            "name": "config",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_direction",
+            "type": "u8"
+          },
+          {
+            "name": "has_referral",
+            "type": "bool"
+          },
+          {
+            "name": "swap_parameters",
+            "type": {
+              "defined": {
+                "name": "SwapParameters2"
+              }
+            }
+          },
+          {
+            "name": "swap_result",
+            "type": {
+              "defined": {
+                "name": "SwapResult2"
+              }
+            }
+          },
+          {
+            "name": "quote_reserve_amount",
+            "type": "u64"
+          },
+          {
+            "name": "migration_threshold",
+            "type": "u64"
+          },
+          {
+            "name": "current_timestamp",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
       "name": "EvtUpdatePoolCreator",
       "type": {
         "kind": "struct",
@@ -5093,9 +5370,6 @@
     },
     {
       "name": "EvtVirtualPoolMetadata",
-      "docs": [
-        "Create virtual pool metadata"
-      ],
       "type": {
         "kind": "struct",
         "fields": [
@@ -5202,6 +5476,79 @@
           {
             "name": "liquidity",
             "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityVestingInfo",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "is_initialized",
+            "type": "u8"
+          },
+          {
+            "name": "vesting_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "bps_per_period",
+            "type": "u16"
+          },
+          {
+            "name": "number_of_periods",
+            "type": "u16"
+          },
+          {
+            "name": "frequency",
+            "type": "u32"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityVestingInfoParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "vesting_percentage",
+            "type": "u8"
+          },
+          {
+            "name": "bps_per_period",
+            "type": "u16"
+          },
+          {
+            "name": "number_of_periods",
+            "type": "u16"
+          },
+          {
+            "name": "cliff_duration_from_migration_time",
+            "type": "u32"
+          },
+          {
+            "name": "frequency",
+            "type": "u32"
           }
         ]
       }
@@ -5336,7 +5683,7 @@
           {
             "name": "padding_0",
             "docs": [
-              "!!! BE CAREFUL to use tomestone field, previous is pool creator"
+              "!!! BE CAREFUL to use tombstone field, previous is pool creator"
             ],
             "type": {
               "array": [
@@ -5360,30 +5707,30 @@
             "type": "pubkey"
           },
           {
-            "name": "partner_locked_lp",
+            "name": "partner_locked_liquidity",
             "docs": [
-              "partner locked lp"
+              "partner locked liquidity"
             ],
             "type": "u64"
           },
           {
-            "name": "partner_lp",
+            "name": "partner_liquidity",
             "docs": [
-              "partner lp"
+              "partner liquidity"
             ],
             "type": "u64"
           },
           {
-            "name": "creator_locked_lp",
+            "name": "creator_locked_liquidity",
             "docs": [
-              "creator locked lp"
+              "creator locked liquidity"
             ],
             "type": "u64"
           },
           {
-            "name": "creator_lp",
+            "name": "creator_liquidity",
             "docs": [
-              "creator lp"
+              "creator liquidity"
             ],
             "type": "u64"
           },
@@ -5397,28 +5744,28 @@
           {
             "name": "creator_locked_status",
             "docs": [
-              "flag to check whether lp is locked for creator"
+              "flag to check whether liquidity token is locked for creator"
             ],
             "type": "u8"
           },
           {
             "name": "partner_locked_status",
             "docs": [
-              "flag to check whether lp is locked for partner"
+              "flag to check whether liquidity token is locked for partner"
             ],
             "type": "u8"
           },
           {
             "name": "creator_claim_status",
             "docs": [
-              "flag to check whether creator has claimed lp token"
+              "flag to check whether creator has claimed liquidity token"
             ],
             "type": "u8"
           },
           {
             "name": "partner_claim_status",
             "docs": [
-              "flag to check whether partner has claimed lp token"
+              "flag to check whether partner has claimed liquidity token"
             ],
             "type": "u8"
           },
@@ -5431,56 +5778,6 @@
               "array": [
                 "u8",
                 107
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "MeteoraDammV2Metadata",
-      "serialization": "bytemuck",
-      "repr": {
-        "kind": "c"
-      },
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "virtual_pool",
-            "docs": [
-              "pool"
-            ],
-            "type": "pubkey"
-          },
-          {
-            "name": "padding_0",
-            "docs": [
-              "!!! BE CAREFUL to use tomestone field, previous is pool creator"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "name": "partner",
-            "docs": [
-              "partner"
-            ],
-            "type": "pubkey"
-          },
-          {
-            "name": "_padding",
-            "docs": [
-              "Reserve"
-            ],
-            "type": {
-              "array": [
-                "u8",
-                126
               ]
             }
           }
@@ -5508,6 +5805,30 @@
       }
     },
     {
+      "name": "MigratedPoolMarketCapFeeSchedulerParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "number_of_period",
+            "type": "u16"
+          },
+          {
+            "name": "sqrt_price_step_bps",
+            "type": "u16"
+          },
+          {
+            "name": "scheduler_expiration_duration",
+            "type": "u32"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
       "name": "MigrationFee",
       "type": {
         "kind": "struct",
@@ -5519,6 +5840,35 @@
           {
             "name": "creator_fee_percentage",
             "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Operator",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "whitelisted_address",
+            "type": "pubkey"
+          },
+          {
+            "name": "permission",
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                2
+              ]
+            }
           }
         ]
       }
@@ -5616,6 +5966,41 @@
             }
           },
           {
+            "name": "partner_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfo"
+              }
+            }
+          },
+          {
+            "name": "creator_liquidity_vesting_info",
+            "type": {
+              "defined": {
+                "name": "LiquidityVestingInfo"
+              }
+            }
+          },
+          {
+            "name": "padding_0",
+            "docs": [
+              "Padding for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                14
+              ]
+            }
+          },
+          {
+            "name": "padding_1",
+            "docs": [
+              "Previously was protocol and referral fee percent. Beware of tombstone."
+            ],
+            "type": "u16"
+          },
+          {
             "name": "collect_fee_mode",
             "docs": [
               "Collect fee mode"
@@ -5665,30 +6050,30 @@
             "type": "u8"
           },
           {
-            "name": "partner_locked_lp_percentage",
+            "name": "partner_permanent_locked_liquidity_percentage",
             "docs": [
-              "partner locked lp percentage"
+              "partner locked liquidity percentage"
             ],
             "type": "u8"
           },
           {
-            "name": "partner_lp_percentage",
+            "name": "partner_liquidity_percentage",
             "docs": [
-              "partner lp percentage"
+              "partner liquidity percentage"
             ],
             "type": "u8"
           },
           {
-            "name": "creator_locked_lp_percentage",
+            "name": "creator_permanent_locked_liquidity_percentage",
             "docs": [
               "creator post migration fee percentage"
             ],
             "type": "u8"
           },
           {
-            "name": "creator_lp_percentage",
+            "name": "creator_liquidity_percentage",
             "docs": [
-              "creator lp percentage"
+              "creator liquidity percentage"
             ],
             "type": "u8"
           },
@@ -5735,10 +6120,7 @@
             "type": "u8"
           },
           {
-            "name": "_padding_0",
-            "docs": [
-              "padding 0"
-            ],
+            "name": "padding_2",
             "type": {
               "array": [
                 "u8",
@@ -5821,23 +6203,38 @@
             "type": "u16"
           },
           {
-            "name": "_padding_1",
+            "name": "migrated_pool_base_fee_mode",
+            "type": "u8"
+          },
+          {
+            "name": "enable_first_swap_with_min_fee",
+            "type": "u8"
+          },
+          {
+            "name": "migrated_compounding_fee_bps",
             "docs": [
-              "padding 1"
+              "compounding fee bps for migrated DAMM v2 pool, should only be non-zero if migrated_collect_fee_mode is 2 (Compounding)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "pool_creation_fee",
+            "docs": [
+              "pool creation fee in lamports value"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "migrated_pool_base_fee_bytes",
+            "docs": [
+              "serialized MigratedPoolMarketCapFeeSchedulerParams, only used when migrated_pool_base_fee_mode is market cap scheduler"
             ],
             "type": {
               "array": [
                 "u8",
-                12
+                16
               ]
             }
-          },
-          {
-            "name": "_padding_2",
-            "docs": [
-              "padding 2"
-            ],
-            "type": "u128"
           },
           {
             "name": "sqrt_start_price",
@@ -5951,32 +6348,6 @@
                 "name": "DynamicFeeConfig"
               }
             }
-          },
-          {
-            "name": "padding_0",
-            "type": {
-              "array": [
-                "u64",
-                5
-              ]
-            }
-          },
-          {
-            "name": "padding_1",
-            "type": {
-              "array": [
-                "u8",
-                6
-              ]
-            }
-          },
-          {
-            "name": "protocol_fee_percent",
-            "type": "u8"
-          },
-          {
-            "name": "referral_fee_percent",
-            "type": "u8"
           }
         ]
       }
@@ -6010,151 +6381,7 @@
       }
     },
     {
-      "name": "SwapParameters",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amount_in",
-            "type": "u64"
-          },
-          {
-            "name": "minimum_amount_out",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "SwapParameters2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "amount_0",
-            "docs": [
-              "When it's exact in, partial fill, this will be amount_in. When it's exact out, this will be amount_out"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "amount_1",
-            "docs": [
-              "When it's exact in, partial fill, this will be minimum_amount_out. When it's exact out, this will be maximum_amount_in"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "swap_mode",
-            "docs": [
-              "Swap mode, refer [SwapMode]"
-            ],
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "SwapResult",
-      "docs": [
-        "Encodes all results of swapping"
-      ],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "actual_input_amount",
-            "type": "u64"
-          },
-          {
-            "name": "output_amount",
-            "type": "u64"
-          },
-          {
-            "name": "next_sqrt_price",
-            "type": "u128"
-          },
-          {
-            "name": "trading_fee",
-            "type": "u64"
-          },
-          {
-            "name": "protocol_fee",
-            "type": "u64"
-          },
-          {
-            "name": "referral_fee",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "SwapResult2",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "included_fee_input_amount",
-            "type": "u64"
-          },
-          {
-            "name": "excluded_fee_input_amount",
-            "type": "u64"
-          },
-          {
-            "name": "amount_left",
-            "type": "u64"
-          },
-          {
-            "name": "output_amount",
-            "type": "u64"
-          },
-          {
-            "name": "next_sqrt_price",
-            "type": "u128"
-          },
-          {
-            "name": "trading_fee",
-            "type": "u64"
-          },
-          {
-            "name": "protocol_fee",
-            "type": "u64"
-          },
-          {
-            "name": "referral_fee",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TokenSupplyParams",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "pre_migration_token_supply",
-            "docs": [
-              "pre migration token supply"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "post_migration_token_supply",
-            "docs": [
-              "post migration token supply",
-              "becase DBC allow user to swap over the migration quote threshold, so in extreme case user may swap more than allowed buffer on curve",
-              "that result the total supply in post migration may be increased a bit (between pre_migration_token_supply and post_migration_token_supply)"
-            ],
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "VirtualPool",
+      "name": "PoolState",
       "serialization": "bytemuck",
       "repr": {
         "kind": "c"
@@ -6316,7 +6543,9 @@
           {
             "name": "migration_fee_withdraw_status",
             "docs": [
-              "migration fee withdraw status, first bit is for partner, second bit is for creator"
+              "migration fee withdraw status",
+              "bit 1 (0b010) creator",
+              "bit 2 (0b100) partner"
             ],
             "type": "u8"
           },
@@ -6353,15 +6582,291 @@
             "type": "u64"
           },
           {
+            "name": "legacy_creation_fee_bits",
+            "docs": [
+              "legacy creation fee bits, we dont use this now"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "creation_fee_bits",
+            "docs": [
+              "pool creation fee claim status"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "has_swap",
+            "docs": [
+              "Cached flag"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding_0",
+            "docs": [
+              "Padding for further use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                5
+              ]
+            }
+          },
+          {
+            "name": "protocol_liquidity_migration_fee_bps",
+            "type": "u16"
+          },
+          {
             "name": "_padding_1",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "protocol_migration_base_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_migration_quote_fee_amount",
+            "type": "u64"
+          },
+          {
+            "name": "_padding_2",
             "docs": [
               "Padding for further use"
             ],
             "type": {
               "array": [
                 "u64",
-                7
+                3
               ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RemainingAccountsSlice",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "accounts_type",
+            "type": {
+              "defined": {
+                "name": "AccountsType"
+              }
+            }
+          },
+          {
+            "name": "length",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapParameters",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_in",
+            "type": "u64"
+          },
+          {
+            "name": "minimum_amount_out",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapParameters2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amount_0",
+            "docs": [
+              "When it's exact in, partial fill, this will be amount_in. When it's exact out, this will be amount_out"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1",
+            "docs": [
+              "When it's exact in, partial fill, this will be minimum_amount_out. When it's exact out, this will be maximum_amount_in"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "swap_mode",
+            "docs": [
+              "Swap mode, refer [SwapMode]"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapResult",
+      "docs": [
+        "Encodes all results of swapping"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "actual_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "output_amount",
+            "type": "u64"
+          },
+          {
+            "name": "next_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "trading_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "referral_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapResult2",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "included_fee_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "excluded_fee_input_amount",
+            "type": "u64"
+          },
+          {
+            "name": "amount_left",
+            "type": "u64"
+          },
+          {
+            "name": "output_amount",
+            "type": "u64"
+          },
+          {
+            "name": "next_sqrt_price",
+            "type": "u128"
+          },
+          {
+            "name": "trading_fee",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "referral_fee",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TokenSupplyParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pre_migration_token_supply",
+            "docs": [
+              "pre migration token supply"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "post_migration_token_supply",
+            "docs": [
+              "post migration token supply",
+              "because DBC allow user to swap over the migration quote threshold, so in extreme case user may swap more than allowed buffer on curve",
+              "that result the total supply in post migration may be increased a bit (between pre_migration_token_supply and post_migration_token_supply)"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferHookAccountsInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "slices",
+            "type": {
+              "vec": {
+                "defined": {
+                  "name": "RemainingAccountsSlice"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TransferHookPool",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "type": {
+              "defined": {
+                "name": "PoolState"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VirtualPool",
+      "serialization": "bytemuck",
+      "repr": {
+        "kind": "c"
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "type": {
+              "defined": {
+                "name": "PoolState"
+              }
             }
           }
         ]

--- a/idl/meteora_lb_clmm.json
+++ b/idl/meteora_lb_clmm.json
@@ -9,16 +9,7 @@
   "instructions": [
     {
       "name": "add_liquidity",
-      "discriminator": [
-        181,
-        157,
-        89,
-        67,
-        143,
-        182,
-        52,
-        72
-      ],
+      "discriminator": [181, 157, 89, 67, 143, 182, 52, 72],
       "accounts": [
         {
           "name": "position",
@@ -50,28 +41,20 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "bin_array_lower",
@@ -100,23 +83,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -139,16 +107,7 @@
     },
     {
       "name": "add_liquidity2",
-      "discriminator": [
-        228,
-        162,
-        78,
-        28,
-        70,
-        219,
-        116,
-        115
-      ],
+      "discriminator": [228, 162, 78, 28, 70, 219, 116, 115],
       "accounts": [
         {
           "name": "position",
@@ -157,10 +116,7 @@
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "position",
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["position", "bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -178,28 +134,20 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "sender",
@@ -218,23 +166,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -265,16 +198,7 @@
     },
     {
       "name": "add_liquidity_by_strategy",
-      "discriminator": [
-        7,
-        3,
-        150,
-        127,
-        148,
-        40,
-        61,
-        200
-      ],
+      "discriminator": [7, 3, 150, 127, 148, 40, 61, 200],
       "accounts": [
         {
           "name": "position",
@@ -306,28 +230,20 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "bin_array_lower",
@@ -356,23 +272,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -395,16 +296,7 @@
     },
     {
       "name": "add_liquidity_by_strategy2",
-      "discriminator": [
-        3,
-        221,
-        149,
-        218,
-        111,
-        141,
-        118,
-        213
-      ],
+      "discriminator": [3, 221, 149, 218, 111, 141, 118, 213],
       "accounts": [
         {
           "name": "position",
@@ -413,10 +305,7 @@
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "position",
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["position", "bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -434,28 +323,20 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "sender",
@@ -474,23 +355,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -521,16 +387,7 @@
     },
     {
       "name": "add_liquidity_by_strategy_one_side",
-      "discriminator": [
-        41,
-        5,
-        238,
-        175,
-        100,
-        225,
-        6,
-        205
-      ],
+      "discriminator": [41, 5, 238, 175, 100, 225, 6, 205],
       "accounts": [
         {
           "name": "position",
@@ -585,23 +442,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -624,16 +466,7 @@
     },
     {
       "name": "add_liquidity_by_weight",
-      "discriminator": [
-        28,
-        140,
-        238,
-        99,
-        231,
-        162,
-        21,
-        149
-      ],
+      "discriminator": [28, 140, 238, 99, 231, 162, 21, 149],
       "accounts": [
         {
           "name": "position",
@@ -665,28 +498,20 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "bin_array_lower",
@@ -715,23 +540,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -754,16 +564,7 @@
     },
     {
       "name": "add_liquidity_by_weight2",
-      "discriminator": [
-        209,
-        59,
-        63,
-        91,
-        111,
-        200,
-        153,
-        228
-      ],
+      "discriminator": [209, 59, 63, 91, 111, 200, 153, 228],
       "accounts": [
         {
           "name": "position",
@@ -772,10 +573,7 @@
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "position",
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["position", "bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -793,28 +591,20 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "sender",
@@ -833,23 +623,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -880,16 +655,7 @@
     },
     {
       "name": "add_liquidity_one_side",
-      "discriminator": [
-        94,
-        155,
-        103,
-        151,
-        70,
-        95,
-        220,
-        165
-      ],
+      "discriminator": [94, 155, 103, 151, 70, 95, 220, 165],
       "accounts": [
         {
           "name": "position",
@@ -944,23 +710,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -983,16 +734,7 @@
     },
     {
       "name": "add_liquidity_one_side_precise",
-      "discriminator": [
-        161,
-        194,
-        103,
-        84,
-        171,
-        71,
-        250,
-        154
-      ],
+      "discriminator": [161, 194, 103, 84, 171, 71, 250, 154],
       "accounts": [
         {
           "name": "position",
@@ -1047,23 +789,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -1086,16 +813,7 @@
     },
     {
       "name": "add_liquidity_one_side_precise2",
-      "discriminator": [
-        33,
-        51,
-        163,
-        201,
-        117,
-        98,
-        125,
-        231
-      ],
+      "discriminator": [33, 51, 163, 201, 117, 98, 125, 231],
       "accounts": [
         {
           "name": "position",
@@ -1104,10 +822,7 @@
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "position",
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["position", "bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -1139,23 +854,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -1186,24 +886,12 @@
     },
     {
       "name": "cancel_limit_order",
-      "discriminator": [
-        132,
-        156,
-        132,
-        31,
-        67,
-        40,
-        232,
-        97
-      ],
+      "discriminator": [132, 156, 132, 31, 67, 40, 232, 97],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "bin_array_bitmap_extension",
-            "limit_order"
-          ]
+          "relations": ["bin_array_bitmap_extension", "limit_order"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -1213,28 +901,20 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "limit_order",
@@ -1272,23 +952,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -1317,25 +982,12 @@
     },
     {
       "name": "claim_fee",
-      "discriminator": [
-        169,
-        32,
-        79,
-        137,
-        136,
-        232,
-        70,
-        137
-      ],
+      "discriminator": [169, 32, 79, 137, 136, 232, 70, 137],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "position",
-            "bin_array_lower",
-            "bin_array_upper"
-          ]
+          "relations": ["position", "bin_array_lower", "bin_array_upper"]
         },
         {
           "name": "position",
@@ -1356,16 +1008,12 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "user_token_x",
@@ -1377,15 +1025,11 @@
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_program",
@@ -1398,23 +1042,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -1428,23 +1057,12 @@
     },
     {
       "name": "claim_fee2",
-      "discriminator": [
-        112,
-        191,
-        101,
-        171,
-        28,
-        144,
-        127,
-        187
-      ],
+      "discriminator": [112, 191, 101, 171, 28, 144, 127, 187],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "position"
-          ]
+          "relations": ["position"]
         },
         {
           "name": "position",
@@ -1457,16 +1075,12 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "user_token_x",
@@ -1478,15 +1092,11 @@
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_program_x"
@@ -1505,23 +1115,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -1552,25 +1147,12 @@
     },
     {
       "name": "claim_reward",
-      "discriminator": [
-        149,
-        95,
-        181,
-        242,
-        94,
-        90,
-        158,
-        162
-      ],
+      "discriminator": [149, 95, 181, 242, 94, 90, 158, 162],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "position",
-            "bin_array_lower",
-            "bin_array_upper"
-          ]
+          "relations": ["position", "bin_array_lower", "bin_array_upper"]
         },
         {
           "name": "position",
@@ -1610,23 +1192,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -1645,23 +1212,12 @@
     },
     {
       "name": "claim_reward2",
-      "discriminator": [
-        190,
-        3,
-        127,
-        119,
-        178,
-        87,
-        157,
-        183
-      ],
+      "discriminator": [190, 3, 127, 119, 178, 87, 157, 183],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "position"
-          ]
+          "relations": ["position"]
         },
         {
           "name": "position",
@@ -1696,23 +1252,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -1747,22 +1288,11 @@
     },
     {
       "name": "close_bin_array",
-      "discriminator": [
-        68,
-        174,
-        88,
-        80,
-        181,
-        204,
-        19,
-        224
-      ],
+      "discriminator": [68, 174, 88, 80, 181, 204, 19, 224],
       "accounts": [
         {
           "name": "lb_pair",
-          "relations": [
-            "bin_array"
-          ]
+          "relations": ["bin_array"]
         },
         {
           "name": "bin_array",
@@ -1782,16 +1312,7 @@
     },
     {
       "name": "close_claim_fee_operator_account",
-      "discriminator": [
-        184,
-        213,
-        88,
-        31,
-        179,
-        101,
-        130,
-        36
-      ],
+      "discriminator": [184, 213, 88, 31, 179, 101, 130, 36],
       "accounts": [
         {
           "name": "claim_fee_operator",
@@ -1810,16 +1331,7 @@
     },
     {
       "name": "close_limit_order_if_empty",
-      "discriminator": [
-        57,
-        124,
-        36,
-        155,
-        126,
-        249,
-        93,
-        171
-      ],
+      "discriminator": [57, 124, 36, 155, 126, 249, 93, 171],
       "accounts": [
         {
           "name": "limit_order",
@@ -1840,23 +1352,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -1870,16 +1367,7 @@
     },
     {
       "name": "close_operator_account",
-      "discriminator": [
-        171,
-        9,
-        213,
-        74,
-        120,
-        23,
-        3,
-        29
-      ],
+      "discriminator": [171, 9, 213, 74, 120, 23, 3, 29],
       "accounts": [
         {
           "name": "operator",
@@ -1898,16 +1386,7 @@
     },
     {
       "name": "close_position",
-      "discriminator": [
-        123,
-        134,
-        81,
-        0,
-        49,
-        68,
-        98,
-        98
-      ],
+      "discriminator": [123, 134, 81, 0, 49, 68, 98, 98],
       "accounts": [
         {
           "name": "position",
@@ -1940,23 +1419,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -1970,16 +1434,7 @@
     },
     {
       "name": "close_position2",
-      "discriminator": [
-        174,
-        90,
-        35,
-        115,
-        186,
-        40,
-        147,
-        226
-      ],
+      "discriminator": [174, 90, 35, 115, 186, 40, 147, 226],
       "accounts": [
         {
           "name": "position",
@@ -2000,23 +1455,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -2030,16 +1470,7 @@
     },
     {
       "name": "close_position_if_empty",
-      "discriminator": [
-        59,
-        124,
-        212,
-        118,
-        91,
-        152,
-        110,
-        157
-      ],
+      "discriminator": [59, 124, 212, 118, 91, 152, 110, 157],
       "accounts": [
         {
           "name": "position",
@@ -2060,23 +1491,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -2090,16 +1506,7 @@
     },
     {
       "name": "close_preset_parameter",
-      "discriminator": [
-        4,
-        148,
-        145,
-        100,
-        134,
-        26,
-        181,
-        61
-      ],
+      "discriminator": [4, 148, 145, 100, 134, 26, 181, 61],
       "accounts": [
         {
           "name": "preset_parameter",
@@ -2121,16 +1528,7 @@
     },
     {
       "name": "close_preset_parameter2",
-      "discriminator": [
-        39,
-        25,
-        95,
-        107,
-        116,
-        17,
-        115,
-        28
-      ],
+      "discriminator": [39, 25, 95, 107, 116, 17, 115, 28],
       "accounts": [
         {
           "name": "preset_parameter",
@@ -2152,16 +1550,7 @@
     },
     {
       "name": "close_token_badge",
-      "discriminator": [
-        108,
-        146,
-        86,
-        110,
-        179,
-        254,
-        10,
-        104
-      ],
+      "discriminator": [108, 146, 86, 110, 179, 254, 10, 104],
       "accounts": [
         {
           "name": "token_badge",
@@ -2183,16 +1572,7 @@
     },
     {
       "name": "create_operator_account",
-      "discriminator": [
-        221,
-        64,
-        246,
-        149,
-        240,
-        153,
-        229,
-        163
-      ],
+      "discriminator": [221, 64, 246, 149, 240, 153, 229, 163],
       "accounts": [
         {
           "name": "operator",
@@ -2201,16 +1581,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  111,
-                  112,
-                  101,
-                  114,
-                  97,
-                  116,
-                  111,
-                  114
-                ]
+                "value": [111, 112, 101, 114, 97, 116, 111, 114]
               },
               {
                 "kind": "account",
@@ -2245,16 +1616,7 @@
     },
     {
       "name": "decrease_position_length",
-      "discriminator": [
-        194,
-        219,
-        136,
-        32,
-        25,
-        96,
-        105,
-        37
-      ],
+      "discriminator": [194, 219, 136, 32, 25, 96, 105, 37],
       "accounts": [
         {
           "name": "rent_receiver",
@@ -2267,9 +1629,7 @@
         {
           "name": "owner",
           "signer": true,
-          "relations": [
-            "position"
-          ]
+          "relations": ["position"]
         },
         {
           "name": "system_program",
@@ -2282,23 +1642,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -2321,16 +1666,7 @@
     },
     {
       "name": "for_idl_type_generation_do_not_call",
-      "discriminator": [
-        180,
-        105,
-        69,
-        80,
-        95,
-        50,
-        73,
-        108
-      ],
+      "discriminator": [180, 105, 69, 80, 95, 50, 73, 108],
       "accounts": [
         {
           "name": "dummy_zc_account"
@@ -2349,23 +1685,12 @@
     },
     {
       "name": "fund_reward",
-      "discriminator": [
-        188,
-        50,
-        249,
-        165,
-        93,
-        151,
-        38,
-        63
-      ],
+      "discriminator": [188, 50, 249, 165, 93, 151, 38, 63],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "bin_array"
-          ]
+          "relations": ["bin_array"]
         },
         {
           "name": "reward_vault",
@@ -2396,23 +1721,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -2447,16 +1757,7 @@
     },
     {
       "name": "go_to_a_bin",
-      "discriminator": [
-        146,
-        72,
-        174,
-        224,
-        40,
-        253,
-        84,
-        174
-      ],
+      "discriminator": [146, 72, 174, 224, 40, 253, 84, 174],
       "accounts": [
         {
           "name": "lb_pair",
@@ -2486,23 +1787,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -2521,16 +1807,7 @@
     },
     {
       "name": "increase_oracle_length",
-      "discriminator": [
-        190,
-        61,
-        125,
-        87,
-        103,
-        79,
-        158,
-        173
-      ],
+      "discriminator": [190, 61, 125, 87, 103, 79, 158, 173],
       "accounts": [
         {
           "name": "oracle",
@@ -2552,23 +1829,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -2587,16 +1849,7 @@
     },
     {
       "name": "increase_position_length",
-      "discriminator": [
-        80,
-        83,
-        117,
-        211,
-        66,
-        13,
-        33,
-        149
-      ],
+      "discriminator": [80, 83, 117, 211, 66, 13, 33, 149],
       "accounts": [
         {
           "name": "funder",
@@ -2605,9 +1858,7 @@
         },
         {
           "name": "lb_pair",
-          "relations": [
-            "position"
-          ]
+          "relations": ["position"]
         },
         {
           "name": "position",
@@ -2616,9 +1867,7 @@
         {
           "name": "owner",
           "signer": true,
-          "relations": [
-            "position"
-          ]
+          "relations": ["position"]
         },
         {
           "name": "system_program",
@@ -2631,23 +1880,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -2670,16 +1904,7 @@
     },
     {
       "name": "increase_position_length2",
-      "discriminator": [
-        255,
-        210,
-        204,
-        71,
-        115,
-        137,
-        225,
-        113
-      ],
+      "discriminator": [255, 210, 204, 71, 115, 137, 225, 113],
       "accounts": [
         {
           "name": "funder",
@@ -2688,9 +1913,7 @@
         },
         {
           "name": "lb_pair",
-          "relations": [
-            "position"
-          ]
+          "relations": ["position"]
         },
         {
           "name": "position",
@@ -2699,9 +1922,7 @@
         {
           "name": "owner",
           "signer": true,
-          "relations": [
-            "position"
-          ]
+          "relations": ["position"]
         },
         {
           "name": "system_program",
@@ -2714,23 +1935,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -2749,16 +1955,7 @@
     },
     {
       "name": "initialize_bin_array",
-      "discriminator": [
-        35,
-        86,
-        19,
-        185,
-        78,
-        212,
-        75,
-        211
-      ],
+      "discriminator": [35, 86, 19, 185, 78, 212, 75, 211],
       "accounts": [
         {
           "name": "lb_pair"
@@ -2770,17 +1967,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  98,
-                  105,
-                  110,
-                  95,
-                  97,
-                  114,
-                  114,
-                  97,
-                  121
-                ]
+                "value": [98, 105, 110, 95, 97, 114, 114, 97, 121]
               },
               {
                 "kind": "account",
@@ -2812,16 +1999,7 @@
     },
     {
       "name": "initialize_bin_array_bitmap_extension",
-      "discriminator": [
-        47,
-        157,
-        226,
-        180,
-        12,
-        240,
-        33,
-        71
-      ],
+      "discriminator": [47, 157, 226, 180, 12, 240, 33, 71],
       "accounts": [
         {
           "name": "lb_pair"
@@ -2836,14 +2014,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  98,
-                  105,
-                  116,
-                  109,
-                  97,
-                  112
-                ]
+                "value": [98, 105, 116, 109, 97, 112]
               },
               {
                 "kind": "account",
@@ -2869,16 +2040,7 @@
     },
     {
       "name": "initialize_customizable_permissionless_lb_pair",
-      "discriminator": [
-        46,
-        39,
-        41,
-        135,
-        111,
-        183,
-        200,
-        64
-      ],
+      "discriminator": [46, 39, 41, 135, 111, 183, 200, 64],
       "accounts": [
         {
           "name": "lb_pair",
@@ -2892,14 +2054,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  98,
-                  105,
-                  116,
-                  109,
-                  97,
-                  112
-                ]
+                "value": [98, 105, 116, 109, 97, 112]
               },
               {
                 "kind": "account",
@@ -2953,14 +2108,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  111,
-                  114,
-                  97,
-                  99,
-                  108,
-                  101
-                ]
+                "value": [111, 114, 97, 99, 108, 101]
               },
               {
                 "kind": "account",
@@ -2995,23 +2143,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -3034,16 +2167,7 @@
     },
     {
       "name": "initialize_customizable_permissionless_lb_pair2",
-      "discriminator": [
-        243,
-        73,
-        129,
-        126,
-        51,
-        19,
-        241,
-        107
-      ],
+      "discriminator": [243, 73, 129, 126, 51, 19, 241, 107],
       "accounts": [
         {
           "name": "lb_pair",
@@ -3057,14 +2181,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  98,
-                  105,
-                  116,
-                  109,
-                  97,
-                  112
-                ]
+                "value": [98, 105, 116, 109, 97, 112]
               },
               {
                 "kind": "account",
@@ -3118,14 +2235,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  111,
-                  114,
-                  97,
-                  99,
-                  108,
-                  101
-                ]
+                "value": [111, 114, 97, 99, 108, 101]
               },
               {
                 "kind": "account",
@@ -3170,23 +2280,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -3209,16 +2304,7 @@
     },
     {
       "name": "initialize_lb_pair",
-      "discriminator": [
-        45,
-        154,
-        237,
-        210,
-        221,
-        15,
-        166,
-        92
-      ],
+      "discriminator": [45, 154, 237, 210, 221, 15, 166, 92],
       "accounts": [
         {
           "name": "lb_pair",
@@ -3232,14 +2318,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  98,
-                  105,
-                  116,
-                  109,
-                  97,
-                  112
-                ]
+                "value": [98, 105, 116, 109, 97, 112]
               },
               {
                 "kind": "account",
@@ -3293,14 +2372,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  111,
-                  114,
-                  97,
-                  99,
-                  108,
-                  101
-                ]
+                "value": [111, 114, 97, 99, 108, 101]
               },
               {
                 "kind": "account",
@@ -3335,23 +2407,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -3374,16 +2431,7 @@
     },
     {
       "name": "initialize_lb_pair2",
-      "discriminator": [
-        73,
-        59,
-        36,
-        120,
-        237,
-        83,
-        108,
-        198
-      ],
+      "discriminator": [73, 59, 36, 120, 237, 83, 108, 198],
       "accounts": [
         {
           "name": "lb_pair",
@@ -3397,14 +2445,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  98,
-                  105,
-                  116,
-                  109,
-                  97,
-                  112
-                ]
+                "value": [98, 105, 116, 109, 97, 112]
               },
               {
                 "kind": "account",
@@ -3458,14 +2499,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  111,
-                  114,
-                  97,
-                  99,
-                  108,
-                  101
-                ]
+                "value": [111, 114, 97, 99, 108, 101]
               },
               {
                 "kind": "account",
@@ -3507,23 +2541,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -3546,16 +2565,7 @@
     },
     {
       "name": "initialize_permission_lb_pair",
-      "discriminator": [
-        108,
-        102,
-        213,
-        85,
-        251,
-        3,
-        53,
-        21
-      ],
+      "discriminator": [108, 102, 213, 85, 251, 3, 53, 21],
       "accounts": [
         {
           "name": "base",
@@ -3573,14 +2583,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  98,
-                  105,
-                  116,
-                  109,
-                  97,
-                  112
-                ]
+                "value": [98, 105, 116, 109, 97, 112]
               },
               {
                 "kind": "account",
@@ -3634,14 +2637,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  111,
-                  114,
-                  97,
-                  99,
-                  108,
-                  101
-                ]
+                "value": [111, 114, 97, 99, 108, 101]
               },
               {
                 "kind": "account",
@@ -3687,23 +2683,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -3726,16 +2707,7 @@
     },
     {
       "name": "initialize_position",
-      "discriminator": [
-        219,
-        192,
-        234,
-        71,
-        190,
-        191,
-        102,
-        80
-      ],
+      "discriminator": [219, 192, 234, 71, 190, 191, 102, 80],
       "accounts": [
         {
           "name": "payer",
@@ -3768,23 +2740,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -3807,16 +2764,7 @@
     },
     {
       "name": "initialize_position2",
-      "discriminator": [
-        143,
-        19,
-        242,
-        145,
-        213,
-        15,
-        104,
-        115
-      ],
+      "discriminator": [143, 19, 242, 145, 213, 15, 104, 115],
       "accounts": [
         {
           "name": "payer",
@@ -3846,23 +2794,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -3885,16 +2818,7 @@
     },
     {
       "name": "initialize_position_by_operator",
-      "discriminator": [
-        251,
-        189,
-        190,
-        244,
-        117,
-        254,
-        35,
-        148
-      ],
+      "discriminator": [251, 189, 190, 244, 117, 254, 35, 148],
       "accounts": [
         {
           "name": "payer",
@@ -3912,16 +2836,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  112,
-                  111,
-                  115,
-                  105,
-                  116,
-                  105,
-                  111,
-                  110
-                ]
+                "value": [112, 111, 115, 105, 116, 105, 111, 110]
               },
               {
                 "kind": "account",
@@ -3950,9 +2865,7 @@
         },
         {
           "name": "operator",
-          "docs": [
-            "operator"
-          ],
+          "docs": ["operator"],
           "signer": true
         },
         {
@@ -3972,23 +2885,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -4019,16 +2917,7 @@
     },
     {
       "name": "initialize_position_pda",
-      "discriminator": [
-        46,
-        82,
-        125,
-        146,
-        85,
-        141,
-        228,
-        153
-      ],
+      "discriminator": [46, 82, 125, 146, 85, 141, 228, 153],
       "accounts": [
         {
           "name": "payer",
@@ -4046,16 +2935,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  112,
-                  111,
-                  115,
-                  105,
-                  116,
-                  105,
-                  111,
-                  110
-                ]
+                "value": [112, 111, 115, 105, 116, 105, 111, 110]
               },
               {
                 "kind": "account",
@@ -4081,9 +2961,7 @@
         },
         {
           "name": "owner",
-          "docs": [
-            "owner"
-          ],
+          "docs": ["owner"],
           "signer": true
         },
         {
@@ -4100,23 +2978,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -4139,16 +3002,7 @@
     },
     {
       "name": "initialize_preset_parameter",
-      "discriminator": [
-        66,
-        188,
-        71,
-        211,
-        98,
-        109,
-        14,
-        186
-      ],
+      "discriminator": [66, 188, 71, 211, 98, 109, 14, 186],
       "accounts": [
         {
           "name": "preset_parameter",
@@ -4158,23 +3012,8 @@
               {
                 "kind": "const",
                 "value": [
-                  112,
-                  114,
-                  101,
-                  115,
-                  101,
-                  116,
-                  95,
-                  112,
-                  97,
-                  114,
-                  97,
-                  109,
-                  101,
-                  116,
-                  101,
-                  114,
-                  50
+                  112, 114, 101, 115, 101, 116, 95, 112, 97, 114, 97, 109, 101,
+                  116, 101, 114, 50
                 ]
               },
               {
@@ -4214,16 +3053,7 @@
     },
     {
       "name": "initialize_reward",
-      "discriminator": [
-        95,
-        135,
-        192,
-        196,
-        242,
-        129,
-        230,
-        68
-      ],
+      "discriminator": [95, 135, 192, 196, 242, 129, 230, 68],
       "accounts": [
         {
           "name": "lb_pair",
@@ -4278,23 +3108,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -4321,16 +3136,7 @@
     },
     {
       "name": "initialize_token_badge",
-      "discriminator": [
-        253,
-        77,
-        205,
-        95,
-        27,
-        224,
-        89,
-        223
-      ],
+      "discriminator": [253, 77, 205, 95, 27, 224, 89, 223],
       "accounts": [
         {
           "name": "token_mint"
@@ -4342,19 +3148,7 @@
             "seeds": [
               {
                 "kind": "const",
-                "value": [
-                  116,
-                  111,
-                  107,
-                  101,
-                  110,
-                  95,
-                  98,
-                  97,
-                  100,
-                  103,
-                  101
-                ]
+                "value": [116, 111, 107, 101, 110, 95, 98, 97, 100, 103, 101]
               },
               {
                 "kind": "account",
@@ -4384,23 +3178,12 @@
     },
     {
       "name": "place_limit_order",
-      "discriminator": [
-        108,
-        176,
-        33,
-        186,
-        146,
-        229,
-        1,
-        197
-      ],
+      "discriminator": [108, 176, 33, 186, 146, 229, 1, 197],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -4449,23 +3232,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -4496,16 +3264,7 @@
     },
     {
       "name": "rebalance_liquidity",
-      "discriminator": [
-        92,
-        4,
-        176,
-        193,
-        119,
-        185,
-        83,
-        9
-      ],
+      "discriminator": [92, 4, 176, 193, 119, 185, 83, 9],
       "accounts": [
         {
           "name": "position",
@@ -4514,10 +3273,7 @@
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "position",
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["position", "bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -4535,35 +3291,25 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "owner",
           "signer": true,
-          "relations": [
-            "position"
-          ]
+          "relations": ["position"]
         },
         {
           "name": "rent_payer",
@@ -4591,23 +3337,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -4638,16 +3369,7 @@
     },
     {
       "name": "remove_all_liquidity",
-      "discriminator": [
-        10,
-        51,
-        61,
-        35,
-        112,
-        105,
-        24,
-        85
-      ],
+      "discriminator": [10, 51, 61, 35, 112, 105, 24, 85],
       "accounts": [
         {
           "name": "position",
@@ -4679,28 +3401,20 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "bin_array_lower",
@@ -4729,23 +3443,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -4759,16 +3458,7 @@
     },
     {
       "name": "remove_liquidity",
-      "discriminator": [
-        80,
-        85,
-        209,
-        72,
-        24,
-        206,
-        177,
-        108
-      ],
+      "discriminator": [80, 85, 209, 72, 24, 206, 177, 108],
       "accounts": [
         {
           "name": "position",
@@ -4800,28 +3490,20 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "bin_array_lower",
@@ -4850,23 +3532,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -4891,16 +3558,7 @@
     },
     {
       "name": "remove_liquidity2",
-      "discriminator": [
-        230,
-        215,
-        82,
-        127,
-        241,
-        101,
-        227,
-        146
-      ],
+      "discriminator": [230, 215, 82, 127, 241, 101, 227, 146],
       "accounts": [
         {
           "name": "position",
@@ -4909,10 +3567,7 @@
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "position",
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["position", "bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -4930,28 +3585,20 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "sender",
@@ -4974,23 +3621,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -5023,16 +3655,7 @@
     },
     {
       "name": "remove_liquidity_by_range",
-      "discriminator": [
-        26,
-        82,
-        102,
-        152,
-        240,
-        74,
-        105,
-        26
-      ],
+      "discriminator": [26, 82, 102, 152, 240, 74, 105, 26],
       "accounts": [
         {
           "name": "position",
@@ -5064,28 +3687,20 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "bin_array_lower",
@@ -5114,23 +3729,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -5157,16 +3757,7 @@
     },
     {
       "name": "remove_liquidity_by_range2",
-      "discriminator": [
-        204,
-        2,
-        195,
-        145,
-        53,
-        145,
-        145,
-        205
-      ],
+      "discriminator": [204, 2, 195, 145, 53, 145, 145, 205],
       "accounts": [
         {
           "name": "position",
@@ -5175,10 +3766,7 @@
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "position",
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["position", "bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -5196,28 +3784,20 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "sender",
@@ -5240,23 +3820,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -5291,16 +3856,7 @@
     },
     {
       "name": "set_activation_point",
-      "discriminator": [
-        91,
-        249,
-        15,
-        165,
-        26,
-        129,
-        254,
-        125
-      ],
+      "discriminator": [91, 249, 15, 165, 26, 129, 254, 125],
       "accounts": [
         {
           "name": "lb_pair",
@@ -5320,16 +3876,7 @@
     },
     {
       "name": "set_pair_status",
-      "discriminator": [
-        67,
-        248,
-        231,
-        137,
-        154,
-        149,
-        217,
-        174
-      ],
+      "discriminator": [67, 248, 231, 137, 154, 149, 217, 174],
       "accounts": [
         {
           "name": "lb_pair",
@@ -5352,16 +3899,7 @@
     },
     {
       "name": "set_pair_status_permissionless",
-      "discriminator": [
-        78,
-        59,
-        152,
-        211,
-        70,
-        183,
-        46,
-        208
-      ],
+      "discriminator": [78, 59, 152, 211, 70, 183, 46, 208],
       "accounts": [
         {
           "name": "lb_pair",
@@ -5381,16 +3919,7 @@
     },
     {
       "name": "set_permissionless_operation_bits",
-      "discriminator": [
-        84,
-        58,
-        203,
-        139,
-        163,
-        81,
-        190,
-        186
-      ],
+      "discriminator": [84, 58, 203, 139, 163, 81, 190, 186],
       "accounts": [
         {
           "name": "position",
@@ -5399,9 +3928,7 @@
         {
           "name": "owner",
           "signer": true,
-          "relations": [
-            "position"
-          ]
+          "relations": ["position"]
         },
         {
           "name": "event_authority",
@@ -5410,23 +3937,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -5445,16 +3957,7 @@
     },
     {
       "name": "set_pre_activation_duration",
-      "discriminator": [
-        165,
-        61,
-        201,
-        244,
-        130,
-        159,
-        22,
-        100
-      ],
+      "discriminator": [165, 61, 201, 244, 130, 159, 22, 100],
       "accounts": [
         {
           "name": "lb_pair",
@@ -5474,16 +3977,7 @@
     },
     {
       "name": "set_pre_activation_swap_address",
-      "discriminator": [
-        57,
-        139,
-        47,
-        123,
-        216,
-        80,
-        223,
-        10
-      ],
+      "discriminator": [57, 139, 47, 123, 216, 80, 223, 10],
       "accounts": [
         {
           "name": "lb_pair",
@@ -5503,23 +3997,12 @@
     },
     {
       "name": "swap",
-      "discriminator": [
-        248,
-        198,
-        158,
-        145,
-        225,
-        117,
-        135,
-        200
-      ],
+      "discriminator": [248, 198, 158, 145, 225, 117, 135, 200],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -5529,16 +4012,12 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "user_token_in",
@@ -5550,22 +4029,16 @@
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "host_fee_in",
@@ -5591,23 +4064,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -5630,23 +4088,12 @@
     },
     {
       "name": "swap2",
-      "discriminator": [
-        65,
-        75,
-        63,
-        76,
-        235,
-        91,
-        91,
-        136
-      ],
+      "discriminator": [65, 75, 63, 76, 235, 91, 91, 136],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -5656,16 +4103,12 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "user_token_in",
@@ -5677,22 +4120,16 @@
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "host_fee_in",
@@ -5720,23 +4157,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -5767,23 +4189,12 @@
     },
     {
       "name": "swap_exact_out",
-      "discriminator": [
-        250,
-        73,
-        101,
-        33,
-        38,
-        207,
-        75,
-        184
-      ],
+      "discriminator": [250, 73, 101, 33, 38, 207, 75, 184],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -5793,16 +4204,12 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "user_token_in",
@@ -5814,22 +4221,16 @@
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "host_fee_in",
@@ -5855,23 +4256,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -5894,23 +4280,12 @@
     },
     {
       "name": "swap_exact_out2",
-      "discriminator": [
-        43,
-        215,
-        247,
-        132,
-        137,
-        60,
-        243,
-        81
-      ],
+      "discriminator": [43, 215, 247, 132, 137, 60, 243, 81],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -5920,16 +4295,12 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "user_token_in",
@@ -5941,22 +4312,16 @@
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "host_fee_in",
@@ -5984,23 +4349,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -6031,23 +4381,12 @@
     },
     {
       "name": "swap_with_price_impact",
-      "discriminator": [
-        56,
-        173,
-        230,
-        208,
-        173,
-        228,
-        156,
-        205
-      ],
+      "discriminator": [56, 173, 230, 208, 173, 228, 156, 205],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -6057,16 +4396,12 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "user_token_in",
@@ -6078,22 +4413,16 @@
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "host_fee_in",
@@ -6119,23 +4448,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -6164,23 +4478,12 @@
     },
     {
       "name": "swap_with_price_impact2",
-      "discriminator": [
-        74,
-        98,
-        192,
-        214,
-        177,
-        51,
-        75,
-        51
-      ],
+      "discriminator": [74, 98, 192, 214, 177, 51, 75, 51],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "bin_array_bitmap_extension"
-          ]
+          "relations": ["bin_array_bitmap_extension"]
         },
         {
           "name": "bin_array_bitmap_extension",
@@ -6190,16 +4493,12 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "user_token_in",
@@ -6211,22 +4510,16 @@
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "oracle",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "host_fee_in",
@@ -6254,23 +4547,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -6307,16 +4585,7 @@
     },
     {
       "name": "update_base_fee_parameters",
-      "discriminator": [
-        75,
-        168,
-        223,
-        161,
-        16,
-        195,
-        3,
-        47
-      ],
+      "discriminator": [75, 168, 223, 161, 16, 195, 3, 47],
       "accounts": [
         {
           "name": "lb_pair",
@@ -6336,23 +4605,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -6375,16 +4629,7 @@
     },
     {
       "name": "update_dynamic_fee_parameters",
-      "discriminator": [
-        92,
-        161,
-        46,
-        246,
-        255,
-        189,
-        22,
-        22
-      ],
+      "discriminator": [92, 161, 46, 246, 255, 189, 22, 22],
       "accounts": [
         {
           "name": "lb_pair",
@@ -6404,23 +4649,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -6443,16 +4673,7 @@
     },
     {
       "name": "update_fees_and_reward2",
-      "discriminator": [
-        32,
-        142,
-        184,
-        154,
-        103,
-        65,
-        184,
-        88
-      ],
+      "discriminator": [32, 142, 184, 154, 103, 65, 184, 88],
       "accounts": [
         {
           "name": "position",
@@ -6461,9 +4682,7 @@
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "position"
-          ]
+          "relations": ["position"]
         },
         {
           "name": "owner",
@@ -6483,16 +4702,7 @@
     },
     {
       "name": "update_fees_and_rewards",
-      "discriminator": [
-        154,
-        230,
-        250,
-        13,
-        236,
-        209,
-        75,
-        223
-      ],
+      "discriminator": [154, 230, 250, 13, 236, 209, 75, 223],
       "accounts": [
         {
           "name": "position",
@@ -6501,11 +4711,7 @@
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "position",
-            "bin_array_lower",
-            "bin_array_upper"
-          ]
+          "relations": ["position", "bin_array_lower", "bin_array_upper"]
         },
         {
           "name": "bin_array_lower",
@@ -6524,16 +4730,7 @@
     },
     {
       "name": "update_position_operator",
-      "discriminator": [
-        202,
-        184,
-        103,
-        143,
-        180,
-        191,
-        116,
-        217
-      ],
+      "discriminator": [202, 184, 103, 143, 180, 191, 116, 217],
       "accounts": [
         {
           "name": "position",
@@ -6542,9 +4739,7 @@
         {
           "name": "owner",
           "signer": true,
-          "relations": [
-            "position"
-          ]
+          "relations": ["position"]
         },
         {
           "name": "event_authority",
@@ -6553,23 +4748,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -6588,23 +4768,12 @@
     },
     {
       "name": "update_reward_duration",
-      "discriminator": [
-        138,
-        174,
-        196,
-        169,
-        213,
-        235,
-        254,
-        107
-      ],
+      "discriminator": [138, 174, 196, 169, 213, 235, 254, 107],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "bin_array"
-          ]
+          "relations": ["bin_array"]
         },
         {
           "name": "operator"
@@ -6624,23 +4793,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -6663,16 +4817,7 @@
     },
     {
       "name": "update_reward_funder",
-      "discriminator": [
-        211,
-        28,
-        48,
-        32,
-        215,
-        160,
-        35,
-        23
-      ],
+      "discriminator": [211, 28, 48, 32, 215, 160, 35, 23],
       "accounts": [
         {
           "name": "lb_pair",
@@ -6692,23 +4837,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -6731,23 +4861,12 @@
     },
     {
       "name": "withdraw_ineligible_reward",
-      "discriminator": [
-        148,
-        206,
-        42,
-        195,
-        247,
-        49,
-        103,
-        8
-      ],
+      "discriminator": [148, 206, 42, 195, 247, 49, 103, 8],
       "accounts": [
         {
           "name": "lb_pair",
           "writable": true,
-          "relations": [
-            "bin_array"
-          ]
+          "relations": ["bin_array"]
         },
         {
           "name": "reward_vault",
@@ -6782,23 +4901,8 @@
               {
                 "kind": "const",
                 "value": [
-                  95,
-                  95,
-                  101,
-                  118,
-                  101,
-                  110,
-                  116,
-                  95,
-                  97,
-                  117,
-                  116,
-                  104,
-                  111,
-                  114,
-                  105,
-                  116,
-                  121
+                  95, 95, 101, 118, 101, 110, 116, 95, 97, 117, 116, 104, 111,
+                  114, 105, 116, 121
                 ]
               }
             ]
@@ -6825,16 +4929,7 @@
     },
     {
       "name": "withdraw_protocol_fee",
-      "discriminator": [
-        158,
-        201,
-        158,
-        189,
-        33,
-        93,
-        162,
-        103
-      ],
+      "discriminator": [158, 201, 158, 189, 33, 93, 162, 103],
       "accounts": [
         {
           "name": "lb_pair",
@@ -6843,28 +4938,20 @@
         {
           "name": "reserve_x",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "reserve_y",
           "writable": true,
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_x_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "token_y_mint",
-          "relations": [
-            "lb_pair"
-          ]
+          "relations": ["lb_pair"]
         },
         {
           "name": "receiver_token_x",
@@ -6879,9 +4966,7 @@
         },
         {
           "name": "signer",
-          "docs": [
-            "operator"
-          ],
+          "docs": ["operator"],
           "signer": true
         },
         {
@@ -6912,16 +4997,7 @@
     },
     {
       "name": "zap_protocol_fee",
-      "discriminator": [
-        213,
-        155,
-        187,
-        34,
-        56,
-        182,
-        91,
-        240
-      ],
+      "discriminator": [213, 155, 187, 34, 56, 182, 91, 240],
       "accounts": [
         {
           "name": "lb_pair",
@@ -6943,9 +5019,7 @@
         },
         {
           "name": "signer",
-          "docs": [
-            "operator"
-          ],
+          "docs": ["operator"],
           "signer": true
         },
         {
@@ -6975,551 +5049,173 @@
   "accounts": [
     {
       "name": "BinArray",
-      "discriminator": [
-        92,
-        142,
-        92,
-        220,
-        5,
-        148,
-        70,
-        181
-      ]
+      "discriminator": [92, 142, 92, 220, 5, 148, 70, 181]
     },
     {
       "name": "BinArrayBitmapExtension",
-      "discriminator": [
-        80,
-        111,
-        124,
-        113,
-        55,
-        237,
-        18,
-        5
-      ]
+      "discriminator": [80, 111, 124, 113, 55, 237, 18, 5]
     },
     {
       "name": "ClaimFeeOperator",
-      "discriminator": [
-        166,
-        48,
-        134,
-        86,
-        34,
-        200,
-        188,
-        150
-      ]
+      "discriminator": [166, 48, 134, 86, 34, 200, 188, 150]
     },
     {
       "name": "DummyZcAccount",
-      "discriminator": [
-        94,
-        107,
-        238,
-        80,
-        208,
-        48,
-        180,
-        8
-      ]
+      "discriminator": [94, 107, 238, 80, 208, 48, 180, 8]
     },
     {
       "name": "LbPair",
-      "discriminator": [
-        33,
-        11,
-        49,
-        98,
-        181,
-        101,
-        177,
-        13
-      ]
+      "discriminator": [33, 11, 49, 98, 181, 101, 177, 13]
     },
     {
       "name": "LimitOrder",
-      "discriminator": [
-        137,
-        183,
-        212,
-        91,
-        115,
-        29,
-        141,
-        227
-      ]
+      "discriminator": [137, 183, 212, 91, 115, 29, 141, 227]
     },
     {
       "name": "Operator",
-      "discriminator": [
-        219,
-        31,
-        188,
-        145,
-        69,
-        139,
-        204,
-        117
-      ]
+      "discriminator": [219, 31, 188, 145, 69, 139, 204, 117]
     },
     {
       "name": "Oracle",
-      "discriminator": [
-        139,
-        194,
-        131,
-        179,
-        140,
-        179,
-        229,
-        244
-      ]
+      "discriminator": [139, 194, 131, 179, 140, 179, 229, 244]
     },
     {
       "name": "PositionV2",
-      "discriminator": [
-        117,
-        176,
-        212,
-        199,
-        245,
-        180,
-        133,
-        182
-      ]
+      "discriminator": [117, 176, 212, 199, 245, 180, 133, 182]
     },
     {
       "name": "PresetParameter",
-      "discriminator": [
-        242,
-        62,
-        244,
-        34,
-        181,
-        112,
-        58,
-        170
-      ]
+      "discriminator": [242, 62, 244, 34, 181, 112, 58, 170]
     },
     {
       "name": "PresetParameter2",
-      "discriminator": [
-        171,
-        236,
-        148,
-        115,
-        162,
-        113,
-        222,
-        174
-      ]
+      "discriminator": [171, 236, 148, 115, 162, 113, 222, 174]
     },
     {
       "name": "TokenBadge",
-      "discriminator": [
-        116,
-        219,
-        204,
-        229,
-        249,
-        116,
-        255,
-        150
-      ]
+      "discriminator": [116, 219, 204, 229, 249, 116, 255, 150]
     }
   ],
   "events": [
     {
       "name": "AddLiquidity",
-      "discriminator": [
-        31,
-        94,
-        125,
-        90,
-        227,
-        52,
-        61,
-        186
-      ]
+      "discriminator": [31, 94, 125, 90, 227, 52, 61, 186]
     },
     {
       "name": "CancelLimitOrderEvt",
-      "discriminator": [
-        131,
-        234,
-        194,
-        133,
-        9,
-        14,
-        189,
-        209
-      ]
+      "discriminator": [131, 234, 194, 133, 9, 14, 189, 209]
     },
     {
       "name": "ClaimFee",
-      "discriminator": [
-        75,
-        122,
-        154,
-        48,
-        140,
-        74,
-        123,
-        163
-      ]
+      "discriminator": [75, 122, 154, 48, 140, 74, 123, 163]
     },
     {
       "name": "ClaimFee2",
-      "discriminator": [
-        232,
-        171,
-        242,
-        97,
-        58,
-        77,
-        35,
-        45
-      ]
+      "discriminator": [232, 171, 242, 97, 58, 77, 35, 45]
     },
     {
       "name": "ClaimReward",
-      "discriminator": [
-        148,
-        116,
-        134,
-        204,
-        22,
-        171,
-        85,
-        95
-      ]
+      "discriminator": [148, 116, 134, 204, 22, 171, 85, 95]
     },
     {
       "name": "ClaimReward2",
-      "discriminator": [
-        27,
-        143,
-        244,
-        33,
-        80,
-        43,
-        110,
-        146
-      ]
+      "discriminator": [27, 143, 244, 33, 80, 43, 110, 146]
     },
     {
       "name": "CloseLimitOrderEvt",
-      "discriminator": [
-        142,
-        135,
-        8,
-        76,
-        92,
-        63,
-        118,
-        83
-      ]
+      "discriminator": [142, 135, 8, 76, 92, 63, 118, 83]
     },
     {
       "name": "CompositionFee",
-      "discriminator": [
-        128,
-        151,
-        123,
-        106,
-        17,
-        102,
-        113,
-        142
-      ]
+      "discriminator": [128, 151, 123, 106, 17, 102, 113, 142]
     },
     {
       "name": "DecreasePositionLength",
-      "discriminator": [
-        52,
-        118,
-        235,
-        85,
-        172,
-        169,
-        15,
-        128
-      ]
+      "discriminator": [52, 118, 235, 85, 172, 169, 15, 128]
     },
     {
       "name": "DynamicFeeParameterUpdate",
-      "discriminator": [
-        88,
-        88,
-        178,
-        135,
-        194,
-        146,
-        91,
-        243
-      ]
+      "discriminator": [88, 88, 178, 135, 194, 146, 91, 243]
     },
     {
       "name": "FeeParameterUpdate",
-      "discriminator": [
-        48,
-        76,
-        241,
-        117,
-        144,
-        215,
-        242,
-        44
-      ]
+      "discriminator": [48, 76, 241, 117, 144, 215, 242, 44]
     },
     {
       "name": "FundReward",
-      "discriminator": [
-        246,
-        228,
-        58,
-        130,
-        145,
-        170,
-        79,
-        204
-      ]
+      "discriminator": [246, 228, 58, 130, 145, 170, 79, 204]
     },
     {
       "name": "GoToABin",
-      "discriminator": [
-        59,
-        138,
-        76,
-        68,
-        138,
-        131,
-        176,
-        67
-      ]
+      "discriminator": [59, 138, 76, 68, 138, 131, 176, 67]
     },
     {
       "name": "IncreaseObservation",
-      "discriminator": [
-        99,
-        249,
-        17,
-        121,
-        166,
-        156,
-        207,
-        215
-      ]
+      "discriminator": [99, 249, 17, 121, 166, 156, 207, 215]
     },
     {
       "name": "IncreasePositionLength",
-      "discriminator": [
-        157,
-        239,
-        42,
-        204,
-        30,
-        56,
-        223,
-        46
-      ]
+      "discriminator": [157, 239, 42, 204, 30, 56, 223, 46]
     },
     {
       "name": "InitializeReward",
-      "discriminator": [
-        211,
-        153,
-        88,
-        62,
-        149,
-        60,
-        177,
-        70
-      ]
+      "discriminator": [211, 153, 88, 62, 149, 60, 177, 70]
     },
     {
       "name": "LbPairCreate",
-      "discriminator": [
-        185,
-        74,
-        252,
-        125,
-        27,
-        215,
-        188,
-        111
-      ]
+      "discriminator": [185, 74, 252, 125, 27, 215, 188, 111]
     },
     {
       "name": "PlaceLimitOrderEvt",
-      "discriminator": [
-        43,
-        79,
-        27,
-        169,
-        244,
-        28,
-        225,
-        63
-      ]
+      "discriminator": [43, 79, 27, 169, 244, 28, 225, 63]
     },
     {
       "name": "PositionClose",
-      "discriminator": [
-        255,
-        196,
-        16,
-        107,
-        28,
-        202,
-        53,
-        128
-      ]
+      "discriminator": [255, 196, 16, 107, 28, 202, 53, 128]
     },
     {
       "name": "PositionCreate",
-      "discriminator": [
-        144,
-        142,
-        252,
-        84,
-        157,
-        53,
-        37,
-        121
-      ]
+      "discriminator": [144, 142, 252, 84, 157, 53, 37, 121]
     },
     {
       "name": "Rebalancing",
-      "discriminator": [
-        0,
-        109,
-        117,
-        179,
-        61,
-        91,
-        199,
-        200
-      ]
+      "discriminator": [0, 109, 117, 179, 61, 91, 199, 200]
     },
     {
       "name": "RemoveLiquidity",
-      "discriminator": [
-        116,
-        244,
-        97,
-        232,
-        103,
-        31,
-        152,
-        58
-      ]
+      "discriminator": [116, 244, 97, 232, 103, 31, 152, 58]
     },
     {
       "name": "SetPositionPermissionlessOperationBitsEvt",
-      "discriminator": [
-        195,
-        229,
-        147,
-        245,
-        29,
-        125,
-        48,
-        168
-      ]
+      "discriminator": [195, 229, 147, 245, 29, 125, 48, 168]
     },
     {
       "name": "Swap",
-      "discriminator": [
-        81,
-        108,
-        227,
-        190,
-        205,
-        208,
-        10,
-        196
-      ]
+      "discriminator": [81, 108, 227, 190, 205, 208, 10, 196]
     },
     {
       "name": "Swap2Evt",
-      "discriminator": [
-        46,
-        116,
-        82,
-        215,
-        148,
-        27,
-        84,
-        77
-      ]
+      "discriminator": [46, 116, 82, 215, 148, 27, 84, 77]
     },
     {
       "name": "UpdatePositionLockReleasePoint",
-      "discriminator": [
-        133,
-        214,
-        66,
-        224,
-        64,
-        12,
-        7,
-        191
-      ]
+      "discriminator": [133, 214, 66, 224, 64, 12, 7, 191]
     },
     {
       "name": "UpdatePositionOperator",
-      "discriminator": [
-        39,
-        115,
-        48,
-        204,
-        246,
-        47,
-        66,
-        57
-      ]
+      "discriminator": [39, 115, 48, 204, 246, 47, 66, 57]
     },
     {
       "name": "UpdateRewardDuration",
-      "discriminator": [
-        223,
-        245,
-        224,
-        153,
-        49,
-        29,
-        163,
-        172
-      ]
+      "discriminator": [223, 245, 224, 153, 49, 29, 163, 172]
     },
     {
       "name": "UpdateRewardFunder",
-      "discriminator": [
-        224,
-        178,
-        174,
-        74,
-        252,
-        165,
-        85,
-        180
-      ]
+      "discriminator": [224, 178, 174, 74, 252, 165, 85, 180]
     },
     {
       "name": "WithdrawIneligibleReward",
-      "discriminator": [
-        231,
-        189,
-        65,
-        149,
-        102,
-        215,
-        154,
-        244
-      ]
+      "discriminator": [231, 189, 65, 149, 102, 215, 154, 244]
     }
   ],
   "errors": [
@@ -8096,9 +5792,7 @@
           },
           {
             "name": "TransferHookMultiReward",
-            "fields": [
-              "u8"
-            ]
+            "fields": ["u8"]
           },
           {
             "name": "TransferHookReferral"
@@ -8108,9 +5802,7 @@
     },
     {
       "name": "ActivationType",
-      "docs": [
-        "Type of the activation"
-      ],
+      "docs": ["Type of the activation"],
       "repr": {
         "kind": "rust"
       },
@@ -8146,10 +5838,7 @@
           {
             "name": "amounts",
             "type": {
-              "array": [
-                "u64",
-                2
-              ]
+              "array": ["u64", 2]
             }
           },
           {
@@ -8199,10 +5888,7 @@
           {
             "name": "padding",
             "type": {
-              "array": [
-                "u8",
-                16
-              ]
+              "array": ["u8", 16]
             }
           }
         ]
@@ -8270,16 +5956,12 @@
           },
           {
             "name": "base_factor",
-            "docs": [
-              "Base factor for base fee rate"
-            ],
+            "docs": ["Base factor for base fee rate"],
             "type": "u16"
           },
           {
             "name": "base_fee_power_factor",
-            "docs": [
-              "Base fee power factor"
-            ],
+            "docs": ["Base fee power factor"],
             "type": "u8"
           }
         ]
@@ -8310,72 +5992,52 @@
           },
           {
             "name": "price",
-            "docs": [
-              "Bin price"
-            ],
+            "docs": ["Bin price"],
             "type": "u128"
           },
           {
             "name": "liquidity_supply",
-            "docs": [
-              "Bin MM liquidity supply."
-            ],
+            "docs": ["Bin MM liquidity supply."],
             "type": "u128"
           },
           {
             "name": "fulfilled_order_amount_x",
-            "docs": [
-              "Total fulfilled order amount x"
-            ],
+            "docs": ["Total fulfilled order amount x"],
             "type": "u64"
           },
           {
             "name": "fulfilled_order_amount_y",
-            "docs": [
-              "Total fulfilled order amount y"
-            ],
+            "docs": ["Total fulfilled order amount y"],
             "type": "u64"
           },
           {
             "name": "limit_order_fee_ask_side",
-            "docs": [
-              "Limit order fee collected by ask side orders"
-            ],
+            "docs": ["Limit order fee collected by ask side orders"],
             "type": "u64"
           },
           {
             "name": "limit_order_fee_bid_side",
-            "docs": [
-              "Limit order fee collected by bid side orders"
-            ],
+            "docs": ["Limit order fee collected by bid side orders"],
             "type": "u64"
           },
           {
             "name": "fee_amount_x_per_token_stored",
-            "docs": [
-              "Swap fee amount of token X per liquidity deposited."
-            ],
+            "docs": ["Swap fee amount of token X per liquidity deposited."],
             "type": "u128"
           },
           {
             "name": "fee_amount_y_per_token_stored",
-            "docs": [
-              "Swap fee amount of token Y per liquidity deposited."
-            ],
+            "docs": ["Swap fee amount of token Y per liquidity deposited."],
             "type": "u128"
           },
           {
             "name": "open_order_amount",
-            "docs": [
-              "Pending open limit orders amount in the bin."
-            ],
+            "docs": ["Pending open limit orders amount in the bin."],
             "type": "u64"
           },
           {
             "name": "total_processing_order_amount",
-            "docs": [
-              "Total processing order amount"
-            ],
+            "docs": ["Total processing order amount"],
             "type": "u64"
           },
           {
@@ -8387,28 +6049,19 @@
           },
           {
             "name": "order_age",
-            "docs": [
-              "Age"
-            ],
+            "docs": ["Age"],
             "type": "u32"
           },
           {
             "name": "limit_order_ask_side",
-            "docs": [
-              "limit order flag"
-            ],
+            "docs": ["limit order flag"],
             "type": "u8"
           },
           {
             "name": "_padding_1",
-            "docs": [
-              "padding"
-            ],
+            "docs": ["padding"],
             "type": {
-              "array": [
-                "u8",
-                3
-              ]
+              "array": ["u8", 3]
             }
           }
         ]
@@ -8440,10 +6093,7 @@
           {
             "name": "_padding_1",
             "type": {
-              "array": [
-                "u8",
-                7
-              ]
+              "array": ["u8", 7]
             }
           },
           {
@@ -8487,10 +6137,7 @@
             "type": {
               "array": [
                 {
-                  "array": [
-                    "u64",
-                    8
-                  ]
+                  "array": ["u64", 8]
                 },
                 12
               ]
@@ -8504,10 +6151,7 @@
             "type": {
               "array": [
                 {
-                  "array": [
-                    "u64",
-                    8
-                  ]
+                  "array": ["u64", 8]
                 },
                 12
               ]
@@ -8539,9 +6183,7 @@
         "fields": [
           {
             "name": "bin_id",
-            "docs": [
-              "Define the bin ID wish to deposit to."
-            ],
+            "docs": ["Define the bin ID wish to deposit to."],
             "type": "i32"
           },
           {
@@ -8568,16 +6210,12 @@
         "fields": [
           {
             "name": "bin_id",
-            "docs": [
-              "Define the bin ID wish to deposit to."
-            ],
+            "docs": ["Define the bin ID wish to deposit to."],
             "type": "i32"
           },
           {
             "name": "weight",
-            "docs": [
-              "weight of liquidity distributed for this bin id"
-            ],
+            "docs": ["weight of liquidity distributed for this bin id"],
             "type": "u16"
           }
         ]
@@ -8619,10 +6257,7 @@
           {
             "name": "amounts",
             "type": {
-              "array": [
-                "u64",
-                2
-              ]
+              "array": ["u64", 2]
             }
           },
           {
@@ -8700,9 +6335,7 @@
     },
     {
       "name": "ClaimFeeOperator",
-      "docs": [
-        "Parameter that set by the protocol"
-      ],
+      "docs": ["Parameter that set by the protocol"],
       "serialization": "bytemuck",
       "repr": {
         "kind": "c"
@@ -8712,21 +6345,14 @@
         "fields": [
           {
             "name": "operator",
-            "docs": [
-              "operator"
-            ],
+            "docs": ["operator"],
             "type": "pubkey"
           },
           {
             "name": "_padding",
-            "docs": [
-              "Reserve"
-            ],
+            "docs": ["Reserve"],
             "type": {
-              "array": [
-                "u8",
-                128
-              ]
+              "array": ["u8", 128]
             }
           }
         ]
@@ -8867,23 +6493,17 @@
         "fields": [
           {
             "name": "active_id",
-            "docs": [
-              "Pool price"
-            ],
+            "docs": ["Pool price"],
             "type": "i32"
           },
           {
             "name": "bin_step",
-            "docs": [
-              "Bin step"
-            ],
+            "docs": ["Bin step"],
             "type": "u16"
           },
           {
             "name": "base_factor",
-            "docs": [
-              "Base factor"
-            ],
+            "docs": ["Base factor"],
             "type": "u16"
           },
           {
@@ -8895,16 +6515,12 @@
           },
           {
             "name": "has_alpha_vault",
-            "docs": [
-              "Whether the pool has an alpha vault"
-            ],
+            "docs": ["Whether the pool has an alpha vault"],
             "type": "bool"
           },
           {
             "name": "activation_point",
-            "docs": [
-              "Decide when does the pool start trade. None = Now"
-            ],
+            "docs": ["Decide when does the pool start trade. None = Now"],
             "type": {
               "option": "u64"
             }
@@ -8918,35 +6534,24 @@
           },
           {
             "name": "base_fee_power_factor",
-            "docs": [
-              "Base fee power factor"
-            ],
+            "docs": ["Base fee power factor"],
             "type": "u8"
           },
           {
             "name": "concrete_function_type",
-            "docs": [
-              "Concrete function type"
-            ],
+            "docs": ["Concrete function type"],
             "type": "u8"
           },
           {
             "name": "collect_fee_mode",
-            "docs": [
-              "Collect fee mode"
-            ],
+            "docs": ["Collect fee mode"],
             "type": "u8"
           },
           {
             "name": "padding",
-            "docs": [
-              "Padding, for future use"
-            ],
+            "docs": ["Padding, for future use"],
             "type": {
-              "array": [
-                "u8",
-                60
-              ]
+              "array": ["u8", 60]
             }
           }
         ]
@@ -9345,9 +6950,7 @@
           },
           {
             "name": "bin_step",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
+            "docs": ["Bin step. Represent the price increment / decrement."],
             "type": "u16"
           },
           {
@@ -9401,23 +7004,17 @@
           },
           {
             "name": "base_fee_power_factor",
-            "docs": [
-              "Base fee power factor"
-            ],
+            "docs": ["Base fee power factor"],
             "type": "u8"
           },
           {
             "name": "concrete_function_type",
-            "docs": [
-              "function type"
-            ],
+            "docs": ["function type"],
             "type": "u8"
           },
           {
             "name": "collect_fee_mode",
-            "docs": [
-              "collect fee mode"
-            ],
+            "docs": ["collect fee mode"],
             "type": "u8"
           }
         ]
@@ -9430,21 +7027,14 @@
         "fields": [
           {
             "name": "active_id",
-            "docs": [
-              "Pool price"
-            ],
+            "docs": ["Pool price"],
             "type": "i32"
           },
           {
             "name": "padding",
-            "docs": [
-              "Padding, for future use"
-            ],
+            "docs": ["Padding, for future use"],
             "type": {
-              "array": [
-                "u8",
-                96
-              ]
+              "array": ["u8", 96]
             }
           }
         ]
@@ -9506,76 +7096,51 @@
           {
             "name": "bump_seed",
             "type": {
-              "array": [
-                "u8",
-                1
-              ]
+              "array": ["u8", 1]
             }
           },
           {
             "name": "bin_step_seed",
-            "docs": [
-              "Bin step signer seed"
-            ],
+            "docs": ["Bin step signer seed"],
             "type": {
-              "array": [
-                "u8",
-                2
-              ]
+              "array": ["u8", 2]
             }
           },
           {
             "name": "pair_type",
-            "docs": [
-              "Type of the pair"
-            ],
+            "docs": ["Type of the pair"],
             "type": "u8"
           },
           {
             "name": "active_id",
-            "docs": [
-              "Active bin id"
-            ],
+            "docs": ["Active bin id"],
             "type": "i32"
           },
           {
             "name": "bin_step",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
+            "docs": ["Bin step. Represent the price increment / decrement."],
             "type": "u16"
           },
           {
             "name": "status",
-            "docs": [
-              "Status of the pair. Check PairStatus enum."
-            ],
+            "docs": ["Status of the pair. Check PairStatus enum."],
             "type": "u8"
           },
           {
             "name": "require_base_factor_seed",
-            "docs": [
-              "Require base factor seed"
-            ],
+            "docs": ["Require base factor seed"],
             "type": "u8"
           },
           {
             "name": "base_factor_seed",
-            "docs": [
-              "Base factor seed"
-            ],
+            "docs": ["Base factor seed"],
             "type": {
-              "array": [
-                "u8",
-                2
-              ]
+              "array": ["u8", 2]
             }
           },
           {
             "name": "activation_type",
-            "docs": [
-              "Activation type"
-            ],
+            "docs": ["Activation type"],
             "type": "u8"
           },
           {
@@ -9587,37 +7152,27 @@
           },
           {
             "name": "token_x_mint",
-            "docs": [
-              "Token X mint"
-            ],
+            "docs": ["Token X mint"],
             "type": "pubkey"
           },
           {
             "name": "token_y_mint",
-            "docs": [
-              "Token Y mint"
-            ],
+            "docs": ["Token Y mint"],
             "type": "pubkey"
           },
           {
             "name": "reserve_x",
-            "docs": [
-              "LB token X vault"
-            ],
+            "docs": ["LB token X vault"],
             "type": "pubkey"
           },
           {
             "name": "reserve_y",
-            "docs": [
-              "LB token Y vault"
-            ],
+            "docs": ["LB token Y vault"],
             "type": "pubkey"
           },
           {
             "name": "protocol_fee",
-            "docs": [
-              "Uncollected protocol fee"
-            ],
+            "docs": ["Uncollected protocol fee"],
             "type": {
               "defined": {
                 "name": "ProtocolFee"
@@ -9626,21 +7181,14 @@
           },
           {
             "name": "_padding_1",
-            "docs": [
-              "padding 1"
-            ],
+            "docs": ["padding 1"],
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           },
           {
             "name": "reward_infos",
-            "docs": [
-              "Farming reward information"
-            ],
+            "docs": ["Farming reward information"],
             "type": {
               "array": [
                 {
@@ -9654,40 +7202,26 @@
           },
           {
             "name": "oracle",
-            "docs": [
-              "Oracle pubkey"
-            ],
+            "docs": ["Oracle pubkey"],
             "type": "pubkey"
           },
           {
             "name": "bin_array_bitmap",
-            "docs": [
-              "Packed initialized bin array state"
-            ],
+            "docs": ["Packed initialized bin array state"],
             "type": {
-              "array": [
-                "u64",
-                16
-              ]
+              "array": ["u64", 16]
             }
           },
           {
             "name": "last_updated_at",
-            "docs": [
-              "Last time the pool fee parameter was updated"
-            ],
+            "docs": ["Last time the pool fee parameter was updated"],
             "type": "i64"
           },
           {
             "name": "_padding_2",
-            "docs": [
-              "_padding_2"
-            ],
+            "docs": ["_padding_2"],
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "array": ["u8", 32]
             }
           },
           {
@@ -9699,9 +7233,7 @@
           },
           {
             "name": "base_key",
-            "docs": [
-              "Base keypair. Only required for permission pair"
-            ],
+            "docs": ["Base keypair. Only required for permission pair"],
             "type": "pubkey"
           },
           {
@@ -9720,61 +7252,41 @@
           },
           {
             "name": "_padding_3",
-            "docs": [
-              "_padding 3"
-            ],
+            "docs": ["_padding 3"],
             "type": {
-              "array": [
-                "u8",
-                8
-              ]
+              "array": ["u8", 8]
             }
           },
           {
             "name": "_padding_4",
-            "docs": [
-              "_padding_4"
-            ],
+            "docs": ["_padding_4"],
             "type": "u64"
           },
           {
             "name": "creator",
-            "docs": [
-              "Pool creator"
-            ],
+            "docs": ["Pool creator"],
             "type": "pubkey"
           },
           {
             "name": "token_mint_x_program_flag",
-            "docs": [
-              "token_mint_x_program_flag"
-            ],
+            "docs": ["token_mint_x_program_flag"],
             "type": "u8"
           },
           {
             "name": "token_mint_y_program_flag",
-            "docs": [
-              "token_mint_y_program_flag"
-            ],
+            "docs": ["token_mint_y_program_flag"],
             "type": "u8"
           },
           {
             "name": "version",
-            "docs": [
-              "version to know whether we have reset tombstone fields"
-            ],
+            "docs": ["version to know whether we have reset tombstone fields"],
             "type": "u8"
           },
           {
             "name": "_reserved",
-            "docs": [
-              "Reserved space for future use"
-            ],
+            "docs": ["Reserved space for future use"],
             "type": {
-              "array": [
-                "u8",
-                21
-              ]
+              "array": ["u8", 21]
             }
           }
         ]
@@ -9815,9 +7327,7 @@
         "fields": [
           {
             "name": "lb_pair",
-            "docs": [
-              "The LB pair of this LO"
-            ],
+            "docs": ["The LB pair of this LO"],
             "type": "pubkey"
           },
           {
@@ -9829,33 +7339,21 @@
           },
           {
             "name": "bin_count",
-            "docs": [
-              "Bin count"
-            ],
+            "docs": ["Bin count"],
             "type": "u16"
           },
           {
             "name": "_padding_0",
-            "docs": [
-              "Padding"
-            ],
+            "docs": ["Padding"],
             "type": {
-              "array": [
-                "u8",
-                14
-              ]
+              "array": ["u8", 14]
             }
           },
           {
             "name": "padding_1",
-            "docs": [
-              "Reserved space for future use"
-            ],
+            "docs": ["Reserved space for future use"],
             "type": {
-              "array": [
-                "u64",
-                4
-              ]
+              "array": ["u64", 4]
             }
           }
         ]
@@ -9881,10 +7379,7 @@
           {
             "name": "_padding_0",
             "type": {
-              "array": [
-                "u8",
-                4
-              ]
+              "array": ["u8", 4]
             }
           },
           {
@@ -9898,10 +7393,7 @@
           {
             "name": "_padding_1",
             "type": {
-              "array": [
-                "u8",
-                11
-              ]
+              "array": ["u8", 11]
             }
           }
         ]
@@ -9914,30 +7406,22 @@
         "fields": [
           {
             "name": "amount",
-            "docs": [
-              "Amount of X token or Y token to deposit"
-            ],
+            "docs": ["Amount of X token or Y token to deposit"],
             "type": "u64"
           },
           {
             "name": "active_id",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
+            "docs": ["Active bin that integrator observe off-chain"],
             "type": "i32"
           },
           {
             "name": "max_active_bin_slippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
+            "docs": ["max active bin slippage allowed"],
             "type": "i32"
           },
           {
             "name": "bin_liquidity_dist",
-            "docs": [
-              "Liquidity distribution to each bins"
-            ],
+            "docs": ["Liquidity distribution to each bins"],
             "type": {
               "vec": {
                 "defined": {
@@ -9956,23 +7440,17 @@
         "fields": [
           {
             "name": "amount_x",
-            "docs": [
-              "Amount of X token to deposit"
-            ],
+            "docs": ["Amount of X token to deposit"],
             "type": "u64"
           },
           {
             "name": "amount_y",
-            "docs": [
-              "Amount of Y token to deposit"
-            ],
+            "docs": ["Amount of Y token to deposit"],
             "type": "u64"
           },
           {
             "name": "bin_liquidity_dist",
-            "docs": [
-              "Liquidity distribution to each bins"
-            ],
+            "docs": ["Liquidity distribution to each bins"],
             "type": {
               "vec": {
                 "defined": {
@@ -9991,37 +7469,27 @@
         "fields": [
           {
             "name": "amount_x",
-            "docs": [
-              "Amount of X token to deposit"
-            ],
+            "docs": ["Amount of X token to deposit"],
             "type": "u64"
           },
           {
             "name": "amount_y",
-            "docs": [
-              "Amount of Y token to deposit"
-            ],
+            "docs": ["Amount of Y token to deposit"],
             "type": "u64"
           },
           {
             "name": "active_id",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
+            "docs": ["Active bin that integrator observe off-chain"],
             "type": "i32"
           },
           {
             "name": "max_active_bin_slippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
+            "docs": ["max active bin slippage allowed"],
             "type": "i32"
           },
           {
             "name": "strategy_parameters",
-            "docs": [
-              "strategy parameters"
-            ],
+            "docs": ["strategy parameters"],
             "type": {
               "defined": {
                 "name": "StrategyParameters"
@@ -10038,30 +7506,22 @@
         "fields": [
           {
             "name": "amount",
-            "docs": [
-              "Amount of X token or Y token to deposit"
-            ],
+            "docs": ["Amount of X token or Y token to deposit"],
             "type": "u64"
           },
           {
             "name": "active_id",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
+            "docs": ["Active bin that integrator observe off-chain"],
             "type": "i32"
           },
           {
             "name": "max_active_bin_slippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
+            "docs": ["max active bin slippage allowed"],
             "type": "i32"
           },
           {
             "name": "strategy_parameters",
-            "docs": [
-              "strategy parameters"
-            ],
+            "docs": ["strategy parameters"],
             "type": {
               "defined": {
                 "name": "StrategyParameters"
@@ -10078,37 +7538,27 @@
         "fields": [
           {
             "name": "amount_x",
-            "docs": [
-              "Amount of X token to deposit"
-            ],
+            "docs": ["Amount of X token to deposit"],
             "type": "u64"
           },
           {
             "name": "amount_y",
-            "docs": [
-              "Amount of Y token to deposit"
-            ],
+            "docs": ["Amount of Y token to deposit"],
             "type": "u64"
           },
           {
             "name": "active_id",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
+            "docs": ["Active bin that integrator observe off-chain"],
             "type": "i32"
           },
           {
             "name": "max_active_bin_slippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
+            "docs": ["max active bin slippage allowed"],
             "type": "i32"
           },
           {
             "name": "bin_liquidity_dist",
-            "docs": [
-              "Liquidity distribution to each bins"
-            ],
+            "docs": ["Liquidity distribution to each bins"],
             "type": {
               "vec": {
                 "defined": {
@@ -10140,10 +7590,7 @@
           {
             "name": "padding",
             "type": {
-              "array": [
-                "u64",
-                2
-              ]
+              "array": ["u64", 2]
             }
           }
         ]
@@ -10160,9 +7607,7 @@
         "fields": [
           {
             "name": "idx",
-            "docs": [
-              "Index of latest observation"
-            ],
+            "docs": ["Index of latest observation"],
             "type": "u64"
           },
           {
@@ -10174,9 +7619,7 @@
           },
           {
             "name": "length",
-            "docs": [
-              "Number of observations"
-            ],
+            "docs": ["Number of observations"],
             "type": "u64"
           }
         ]
@@ -10276,10 +7719,7 @@
           {
             "name": "padding",
             "type": {
-              "array": [
-                "u8",
-                16
-              ]
+              "array": ["u8", 16]
             }
           },
           {
@@ -10384,9 +7824,7 @@
         "fields": [
           {
             "name": "lb_pair",
-            "docs": [
-              "The LB pair of this position"
-            ],
+            "docs": ["The LB pair of this position"],
             "type": "pubkey"
           },
           {
@@ -10402,17 +7840,12 @@
               "Liquidity shares of this position in bins (lower_bin_id <-> upper_bin_id). This is the same as LP concept."
             ],
             "type": {
-              "array": [
-                "u128",
-                70
-              ]
+              "array": ["u128", 70]
             }
           },
           {
             "name": "reward_infos",
-            "docs": [
-              "Farming reward information"
-            ],
+            "docs": ["Farming reward information"],
             "type": {
               "array": [
                 {
@@ -10426,9 +7859,7 @@
           },
           {
             "name": "fee_infos",
-            "docs": [
-              "Swap fee to claim information"
-            ],
+            "docs": ["Swap fee to claim information"],
             "type": {
               "array": [
                 {
@@ -10442,63 +7873,44 @@
           },
           {
             "name": "lower_bin_id",
-            "docs": [
-              "Lower bin ID"
-            ],
+            "docs": ["Lower bin ID"],
             "type": "i32"
           },
           {
             "name": "upper_bin_id",
-            "docs": [
-              "Upper bin ID"
-            ],
+            "docs": ["Upper bin ID"],
             "type": "i32"
           },
           {
             "name": "last_updated_at",
-            "docs": [
-              "Last updated timestamp"
-            ],
+            "docs": ["Last updated timestamp"],
             "type": "i64"
           },
           {
             "name": "total_claimed_fee_x_amount",
-            "docs": [
-              "Total claimed token fee X"
-            ],
+            "docs": ["Total claimed token fee X"],
             "type": "u64"
           },
           {
             "name": "total_claimed_fee_y_amount",
-            "docs": [
-              "Total claimed token fee Y"
-            ],
+            "docs": ["Total claimed token fee Y"],
             "type": "u64"
           },
           {
             "name": "total_claimed_rewards",
-            "docs": [
-              "Total claimed rewards"
-            ],
+            "docs": ["Total claimed rewards"],
             "type": {
-              "array": [
-                "u64",
-                2
-              ]
+              "array": ["u64", 2]
             }
           },
           {
             "name": "operator",
-            "docs": [
-              "Operator of position"
-            ],
+            "docs": ["Operator of position"],
             "type": "pubkey"
           },
           {
             "name": "lock_release_point",
-            "docs": [
-              "Time point which the locked liquidity can be withdraw"
-            ],
+            "docs": ["Time point which the locked liquidity can be withdraw"],
             "type": "u64"
           },
           {
@@ -10517,9 +7929,7 @@
           },
           {
             "name": "version",
-            "docs": [
-              "version to know whether we have reset tombstone fields"
-            ],
+            "docs": ["version to know whether we have reset tombstone fields"],
             "type": "u8"
           },
           {
@@ -10528,14 +7938,9 @@
           },
           {
             "name": "_reserved",
-            "docs": [
-              "Reserved space for future use"
-            ],
+            "docs": ["Reserved space for future use"],
             "type": {
-              "array": [
-                "u8",
-                85
-              ]
+              "array": ["u8", 85]
             }
           }
         ]
@@ -10548,9 +7953,7 @@
         "fields": [
           {
             "name": "bin_step",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
+            "docs": ["Bin step. Represent the price increment / decrement."],
             "type": "u16"
           },
           {
@@ -10630,9 +8033,7 @@
         "fields": [
           {
             "name": "bin_step",
-            "docs": [
-              "Bin step. Represent the price increment / decrement."
-            ],
+            "docs": ["Bin step. Represent the price increment / decrement."],
             "type": "u16"
           },
           {
@@ -10686,16 +8087,12 @@
           },
           {
             "name": "index",
-            "docs": [
-              "index"
-            ],
+            "docs": ["index"],
             "type": "u16"
           },
           {
             "name": "base_fee_power_factor",
-            "docs": [
-              "Base fee power factor"
-            ],
+            "docs": ["Base fee power factor"],
             "type": "u8"
           },
           {
@@ -10707,30 +8104,20 @@
           },
           {
             "name": "collect_fee_mode",
-            "docs": [
-              "collect fee mode"
-            ],
+            "docs": ["collect fee mode"],
             "type": "u8"
           },
           {
             "name": "padding_0",
             "type": {
-              "array": [
-                "u8",
-                7
-              ]
+              "array": ["u8", 7]
             }
           },
           {
             "name": "padding_1",
-            "docs": [
-              "Padding 1 for future use"
-            ],
+            "docs": ["Padding 1 for future use"],
             "type": {
-              "array": [
-                "u64",
-                19
-              ]
+              "array": ["u64", 19]
             }
           }
         ]
@@ -10763,23 +8150,17 @@
         "fields": [
           {
             "name": "active_id",
-            "docs": [
-              "active id"
-            ],
+            "docs": ["active id"],
             "type": "i32"
           },
           {
             "name": "max_active_bin_slippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
+            "docs": ["max active bin slippage allowed"],
             "type": "u16"
           },
           {
             "name": "should_claim_fee",
-            "docs": [
-              "a flag to indicate that whether fee should be harvested"
-            ],
+            "docs": ["a flag to indicate that whether fee should be harvested"],
             "type": "bool"
           },
           {
@@ -10791,56 +8172,39 @@
           },
           {
             "name": "min_withdraw_x_amount",
-            "docs": [
-              "threshold for withdraw token x"
-            ],
+            "docs": ["threshold for withdraw token x"],
             "type": "u64"
           },
           {
             "name": "max_deposit_x_amount",
-            "docs": [
-              "threshold for deposit token x"
-            ],
+            "docs": ["threshold for deposit token x"],
             "type": "u64"
           },
           {
             "name": "min_withdraw_y_amount",
-            "docs": [
-              "threshold for withdraw token y"
-            ],
+            "docs": ["threshold for withdraw token y"],
             "type": "u64"
           },
           {
             "name": "max_deposit_y_amount",
-            "docs": [
-              "threshold for deposit token y"
-            ],
+            "docs": ["threshold for deposit token y"],
             "type": "u64"
           },
           {
             "name": "shrink_mode",
-            "docs": [
-              "shrink mode"
-            ],
+            "docs": ["shrink mode"],
             "type": "u8"
           },
           {
             "name": "padding",
-            "docs": [
-              "padding 32 bytes for future usage"
-            ],
+            "docs": ["padding 32 bytes for future usage"],
             "type": {
-              "array": [
-                "u8",
-                31
-              ]
+              "array": ["u8", 31]
             }
           },
           {
             "name": "removes",
-            "docs": [
-              "removes"
-            ],
+            "docs": ["removes"],
             "type": {
               "vec": {
                 "defined": {
@@ -10851,9 +8215,7 @@
           },
           {
             "name": "adds",
-            "docs": [
-              "adds"
-            ],
+            "docs": ["adds"],
             "type": {
               "vec": {
                 "defined": {
@@ -10929,10 +8291,7 @@
           {
             "name": "rewards",
             "type": {
-              "array": [
-                "u64",
-                2
-              ]
+              "array": ["u64", 2]
             }
           }
         ]
@@ -10945,16 +8304,12 @@
         "fields": [
           {
             "name": "active_id",
-            "docs": [
-              "Active bin that integrator observe off-chain"
-            ],
+            "docs": ["Active bin that integrator observe off-chain"],
             "type": "i32"
           },
           {
             "name": "max_active_bin_slippage",
-            "docs": [
-              "max active bin slippage allowed"
-            ],
+            "docs": ["max active bin slippage allowed"],
             "type": "i32"
           }
         ]
@@ -11018,10 +8373,7 @@
           {
             "name": "amounts",
             "type": {
-              "array": [
-                "u64",
-                2
-              ]
+              "array": ["u64", 2]
             }
           },
           {
@@ -11055,10 +8407,7 @@
           {
             "name": "padding",
             "type": {
-              "array": [
-                "u8",
-                16
-              ]
+              "array": ["u8", 16]
             }
           }
         ]
@@ -11066,9 +8415,7 @@
     },
     {
       "name": "ResizeSide",
-      "docs": [
-        "Side of resize, 0 for lower and 1 for upper"
-      ],
+      "docs": ["Side of resize, 0 for lower and 1 for upper"],
       "repr": {
         "kind": "rust"
       },
@@ -11098,51 +8445,37 @@
         "fields": [
           {
             "name": "mint",
-            "docs": [
-              "Reward token mint."
-            ],
+            "docs": ["Reward token mint."],
             "type": "pubkey"
           },
           {
             "name": "vault",
-            "docs": [
-              "Reward vault token account."
-            ],
+            "docs": ["Reward vault token account."],
             "type": "pubkey"
           },
           {
             "name": "funder",
-            "docs": [
-              "Authority account that allows to fund rewards"
-            ],
+            "docs": ["Authority account that allows to fund rewards"],
             "type": "pubkey"
           },
           {
             "name": "reward_duration",
-            "docs": [
-              "LM reward duration in seconds."
-            ],
+            "docs": ["LM reward duration in seconds."],
             "type": "u64"
           },
           {
             "name": "reward_duration_end",
-            "docs": [
-              "LM reward duration end time."
-            ],
+            "docs": ["LM reward duration end time."],
             "type": "u64"
           },
           {
             "name": "reward_rate",
-            "docs": [
-              "LM reward rate"
-            ],
+            "docs": ["LM reward rate"],
             "type": "u128"
           },
           {
             "name": "last_update_time",
-            "docs": [
-              "The last time reward states were updated."
-            ],
+            "docs": ["The last time reward states were updated."],
             "type": "u64"
           },
           {
@@ -11195,9 +8528,7 @@
     },
     {
       "name": "StaticParameters",
-      "docs": [
-        "Parameter that set by the protocol"
-      ],
+      "docs": ["Parameter that set by the protocol"],
       "serialization": "bytemuck",
       "repr": {
         "kind": "c"
@@ -11270,35 +8601,24 @@
           },
           {
             "name": "base_fee_power_factor",
-            "docs": [
-              "Base fee power factor"
-            ],
+            "docs": ["Base fee power factor"],
             "type": "u8"
           },
           {
             "name": "function_type",
-            "docs": [
-              "function type"
-            ],
+            "docs": ["function type"],
             "type": "u8"
           },
           {
             "name": "collect_fee_mode",
-            "docs": [
-              "Collect fee mode"
-            ],
+            "docs": ["Collect fee mode"],
             "type": "u8"
           },
           {
             "name": "_padding",
-            "docs": [
-              "Padding for bytemuck safe alignment"
-            ],
+            "docs": ["Padding for bytemuck safe alignment"],
             "type": {
-              "array": [
-                "u8",
-                3
-              ]
+              "array": ["u8", 3]
             }
           }
         ]
@@ -11311,23 +8631,17 @@
         "fields": [
           {
             "name": "min_bin_id",
-            "docs": [
-              "min bin id"
-            ],
+            "docs": ["min bin id"],
             "type": "i32"
           },
           {
             "name": "max_bin_id",
-            "docs": [
-              "max bin id"
-            ],
+            "docs": ["max bin id"],
             "type": "i32"
           },
           {
             "name": "strategy_type",
-            "docs": [
-              "strategy type"
-            ],
+            "docs": ["strategy type"],
             "type": {
               "defined": {
                 "name": "StrategyType"
@@ -11336,14 +8650,9 @@
           },
           {
             "name": "parameteres",
-            "docs": [
-              "parameters"
-            ],
+            "docs": ["parameters"],
             "type": {
-              "array": [
-                "u8",
-                64
-              ]
+              "array": ["u8", 64]
             }
           }
         ]
@@ -11467,65 +8776,47 @@
           },
           {
             "name": "amount_in",
-            "docs": [
-              "Total amount, user transfer out"
-            ],
+            "docs": ["Total amount, user transfer out"],
             "type": "u64"
           },
           {
             "name": "amount_left",
-            "docs": [
-              "Leftover amount"
-            ],
+            "docs": ["Leftover amount"],
             "type": "u64"
           },
           {
             "name": "amount_out",
-            "docs": [
-              "Total amount transfer to user, including transfer fee"
-            ],
+            "docs": ["Total amount transfer to user, including transfer fee"],
             "type": "u64"
           },
           {
             "name": "mm_fee",
-            "docs": [
-              "Market maker fee"
-            ],
+            "docs": ["Market maker fee"],
             "type": "u64"
           },
           {
             "name": "protocol_fee",
-            "docs": [
-              "Total protocol fee"
-            ],
+            "docs": ["Total protocol fee"],
             "type": "u64"
           },
           {
             "name": "limit_order_fee",
-            "docs": [
-              "Total limit order fee"
-            ],
+            "docs": ["Total limit order fee"],
             "type": "u64"
           },
           {
             "name": "host_fee",
-            "docs": [
-              "Total host fee"
-            ],
+            "docs": ["Total host fee"],
             "type": "u64"
           },
           {
             "name": "fees_on_input",
-            "docs": [
-              "check if fees on input"
-            ],
+            "docs": ["check if fees on input"],
             "type": "bool"
           },
           {
             "name": "fees_on_token_x",
-            "docs": [
-              "check if fees is on token x"
-            ],
+            "docs": ["check if fees is on token x"],
             "type": "bool"
           }
         ]
@@ -11533,9 +8824,7 @@
     },
     {
       "name": "TokenBadge",
-      "docs": [
-        "Parameter that set by the protocol"
-      ],
+      "docs": ["Parameter that set by the protocol"],
       "serialization": "bytemuck",
       "repr": {
         "kind": "c"
@@ -11545,21 +8834,14 @@
         "fields": [
           {
             "name": "token_mint",
-            "docs": [
-              "token mint"
-            ],
+            "docs": ["token mint"],
             "type": "pubkey"
           },
           {
             "name": "_padding",
-            "docs": [
-              "Reserve"
-            ],
+            "docs": ["Reserve"],
             "type": {
-              "array": [
-                "u8",
-                128
-              ]
+              "array": ["u8", 128]
             }
           }
         ]
@@ -11690,19 +8972,13 @@
           {
             "name": "reward_per_token_completes",
             "type": {
-              "array": [
-                "u128",
-                2
-              ]
+              "array": ["u128", 2]
             }
           },
           {
             "name": "reward_pendings",
             "type": {
-              "array": [
-                "u64",
-                2
-              ]
+              "array": ["u64", 2]
             }
           }
         ]
@@ -11710,9 +8986,7 @@
     },
     {
       "name": "VariableParameters",
-      "docs": [
-        "Parameters that changes based on dynamic of the market"
-      ],
+      "docs": ["Parameters that changes based on dynamic of the market"],
       "serialization": "bytemuck",
       "repr": {
         "kind": "c"
@@ -11737,40 +9011,26 @@
           },
           {
             "name": "index_reference",
-            "docs": [
-              "Active bin id of last swap."
-            ],
+            "docs": ["Active bin id of last swap."],
             "type": "i32"
           },
           {
             "name": "_padding",
-            "docs": [
-              "Padding for bytemuck safe alignment"
-            ],
+            "docs": ["Padding for bytemuck safe alignment"],
             "type": {
-              "array": [
-                "u8",
-                4
-              ]
+              "array": ["u8", 4]
             }
           },
           {
             "name": "last_update_timestamp",
-            "docs": [
-              "Last timestamp the variable parameters was updated"
-            ],
+            "docs": ["Last timestamp the variable parameters was updated"],
             "type": "i64"
           },
           {
             "name": "_padding_1",
-            "docs": [
-              "Padding for bytemuck safe alignment"
-            ],
+            "docs": ["Padding for bytemuck safe alignment"],
             "type": {
-              "array": [
-                "u8",
-                8
-              ]
+              "array": ["u8", 8]
             }
           }
         ]
@@ -11840,9 +9100,7 @@
     },
     {
       "name": "HOST_FEE_BPS",
-      "docs": [
-        "Host fee. 20%"
-      ],
+      "docs": ["Host fee. 20%"],
       "type": "u16",
       "value": "2000"
     },
@@ -11858,9 +9116,7 @@
     },
     {
       "name": "MAX_BASE_FEE",
-      "docs": [
-        "Maximum base fee, base_fee / 10^9 = fee_in_percentage"
-      ],
+      "docs": ["Maximum base fee, base_fee / 10^9 = fee_in_percentage"],
       "type": "u128",
       "value": "100000000"
     },
@@ -11884,25 +9140,19 @@
     },
     {
       "name": "MAX_BIN_STEP",
-      "docs": [
-        "Maximum bin step"
-      ],
+      "docs": ["Maximum bin step"],
       "type": "u16",
       "value": "400"
     },
     {
       "name": "MAX_FEE_RATE",
-      "docs": [
-        "Maximum fee rate. 10%"
-      ],
+      "docs": ["Maximum fee rate. 10%"],
       "type": "u64",
       "value": "100000000"
     },
     {
       "name": "MAX_PROTOCOL_SHARE",
-      "docs": [
-        "Maximum protocol share of the fee. 25%"
-      ],
+      "docs": ["Maximum protocol share of the fee. 25%"],
       "type": "u16",
       "value": "2500"
     },
@@ -11928,9 +9178,7 @@
     },
     {
       "name": "MIN_BASE_FEE",
-      "docs": [
-        "Minimum base fee"
-      ],
+      "docs": ["Minimum base fee"],
       "type": "u128",
       "value": "100000"
     },

--- a/idl/orca_whirlpool.json
+++ b/idl/orca_whirlpool.json
@@ -1,804 +1,5067 @@
 {
-    "version": "0.1.0",
-    "name": "whirlpool",
+    "address": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",
+    "metadata": {
+        "name": "whirlpool",
+        "version": "0.9.0",
+        "spec": "0.1.0"
+    },
     "instructions": [
         {
-            "name": "initializeConfig",
+            "name": "close_bundled_position",
+            "docs": [
+                "Close a bundled position in a Whirlpool.",
+                "",
+                "### Authority",
+                "- `position_bundle_authority` - authority that owns the token corresponding to this desired position bundle.",
+                "",
+                "### Parameters",
+                "- `bundle_index` - The bundle index that we'd like to close.",
+                "",
+                "#### Special Errors",
+                "- `InvalidBundleIndex` - If the provided bundle index is out of bounds.",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                41,
+                36,
+                216,
+                245,
+                27,
+                85,
+                103,
+                67
+            ],
             "accounts": [
                 {
-                    "name": "config",
-                    "isMut": true,
-                    "isSigner": true
-                },
-                {
-                    "name": "funder",
-                    "isMut": true,
-                    "isSigner": true
-                },
-                {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
-                }
-            ],
-            "args": [
-                {
-                    "name": "feeAuthority",
-                    "type": "publicKey"
-                },
-                {
-                    "name": "collectProtocolFeesAuthority",
-                    "type": "publicKey"
-                },
-                {
-                    "name": "rewardEmissionsSuperAuthority",
-                    "type": "publicKey"
-                },
-                {
-                    "name": "defaultProtocolFeeRate",
-                    "type": "u16"
-                }
-            ]
-        },
-        {
-            "name": "initializePool",
-            "accounts": [
-                {
-                    "name": "whirlpoolsConfig",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenMintA",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenMintB",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "funder",
-                    "isMut": true,
-                    "isSigner": true
-                },
-                {
-                    "name": "whirlpool",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenVaultA",
-                    "isMut": true,
-                    "isSigner": true
-                },
-                {
-                    "name": "tokenVaultB",
-                    "isMut": true,
-                    "isSigner": true
-                },
-                {
-                    "name": "feeTier",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "rent",
-                    "isMut": false,
-                    "isSigner": false
-                }
-            ],
-            "args": [
-                {
-                    "name": "bumps",
-                    "type": {
-                        "defined": "WhirlpoolBumps"
+                    "name": "bundled_position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101,
+                                    100,
+                                    95,
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle.position_bundle_mint",
+                                "account": "PositionBundle"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "bundle_index"
+                            }
+                        ]
                     }
                 },
                 {
-                    "name": "tickSpacing",
-                    "type": "u16"
+                    "name": "position_bundle",
+                    "writable": true
                 },
                 {
-                    "name": "initialSqrtPrice",
-                    "type": "u128"
-                }
-            ]
-        },
-        {
-            "name": "initializeTickArray",
-            "accounts": [
-                {
-                    "name": "whirlpool",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "position_bundle_token_account"
                 },
                 {
-                    "name": "funder",
-                    "isMut": true,
-                    "isSigner": true
+                    "name": "position_bundle_authority",
+                    "signer": true
                 },
                 {
-                    "name": "tickArray",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "receiver",
+                    "writable": true
                 }
             ],
             "args": [
                 {
-                    "name": "startTickIndex",
-                    "type": "i32"
-                }
-            ]
-        },
-        {
-            "name": "initializeFeeTier",
-            "accounts": [
-                {
-                    "name": "config",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "feeTier",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "funder",
-                    "isMut": true,
-                    "isSigner": true
-                },
-                {
-                    "name": "feeAuthority",
-                    "isMut": false,
-                    "isSigner": true
-                },
-                {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
-                }
-            ],
-            "args": [
-                {
-                    "name": "tickSpacing",
-                    "type": "u16"
-                },
-                {
-                    "name": "defaultFeeRate",
+                    "name": "bundle_index",
                     "type": "u16"
                 }
             ]
         },
         {
-            "name": "initializeReward",
-            "accounts": [
-                {
-                    "name": "rewardAuthority",
-                    "isMut": false,
-                    "isSigner": true
-                },
-                {
-                    "name": "funder",
-                    "isMut": true,
-                    "isSigner": true
-                },
-                {
-                    "name": "whirlpool",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "rewardMint",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "rewardVault",
-                    "isMut": true,
-                    "isSigner": true
-                },
-                {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "rent",
-                    "isMut": false,
-                    "isSigner": false
-                }
+            "name": "close_position",
+            "docs": [
+                "Close a position in a Whirlpool. Burns the position token in the owner's wallet.",
+                "",
+                "### Authority",
+                "- \"position_authority\" - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
             ],
-            "args": [
-                {
-                    "name": "rewardIndex",
-                    "type": "u8"
-                }
-            ]
-        },
-        {
-            "name": "setRewardEmissions",
-            "accounts": [
-                {
-                    "name": "whirlpool",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "rewardAuthority",
-                    "isMut": false,
-                    "isSigner": true
-                },
-                {
-                    "name": "rewardVault",
-                    "isMut": false,
-                    "isSigner": false
-                }
+            "discriminator": [
+                123,
+                134,
+                81,
+                0,
+                49,
+                68,
+                98,
+                98
             ],
-            "args": [
-                {
-                    "name": "rewardIndex",
-                    "type": "u8"
-                },
-                {
-                    "name": "emissionsPerSecondX64",
-                    "type": "u128"
-                }
-            ]
-        },
-        {
-            "name": "openPosition",
             "accounts": [
                 {
-                    "name": "funder",
-                    "isMut": true,
-                    "isSigner": true
+                    "name": "position_authority",
+                    "signer": true
                 },
                 {
-                    "name": "owner",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "receiver",
+                    "writable": true
                 },
                 {
                     "name": "position",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "positionMint",
-                    "isMut": true,
-                    "isSigner": true
-                },
-                {
-                    "name": "positionTokenAccount",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "whirlpool",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "rent",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "associatedTokenProgram",
-                    "isMut": false,
-                    "isSigner": false
-                }
-            ],
-            "args": [
-                {
-                    "name": "bumps",
-                    "type": {
-                        "defined": "OpenPositionBumps"
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
                     }
                 },
                 {
-                    "name": "tickLowerIndex",
-                    "type": "i32"
+                    "name": "position_mint",
+                    "writable": true
                 },
                 {
-                    "name": "tickUpperIndex",
-                    "type": "i32"
-                }
-            ]
-        },
-        {
-            "name": "openPositionWithMetadata",
-            "accounts": [
-                {
-                    "name": "funder",
-                    "isMut": true,
-                    "isSigner": true
+                    "name": "position_token_account",
+                    "writable": true
                 },
                 {
-                    "name": "owner",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "position",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "positionMint",
-                    "isMut": true,
-                    "isSigner": true
-                },
-                {
-                    "name": "positionMetadataAccount",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "positionTokenAccount",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "whirlpool",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "systemProgram",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "rent",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "associatedTokenProgram",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "metadataProgram",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "metadataUpdateAuth",
-                    "isMut": false,
-                    "isSigner": false
-                }
-            ],
-            "args": [
-                {
-                    "name": "bumps",
-                    "type": {
-                        "defined": "OpenPositionWithMetadataBumps"
-                    }
-                },
-                {
-                    "name": "tickLowerIndex",
-                    "type": "i32"
-                },
-                {
-                    "name": "tickUpperIndex",
-                    "type": "i32"
-                }
-            ]
-        },
-        {
-            "name": "increaseLiquidity",
-            "accounts": [
-                {
-                    "name": "whirlpool",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "positionAuthority",
-                    "isMut": false,
-                    "isSigner": true
-                },
-                {
-                    "name": "position",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "positionTokenAccount",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenOwnerAccountA",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenOwnerAccountB",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenVaultA",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenVaultB",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tickArrayLower",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tickArrayUpper",
-                    "isMut": true,
-                    "isSigner": false
-                }
-            ],
-            "args": [
-                {
-                    "name": "liquidityAmount",
-                    "type": "u128"
-                },
-                {
-                    "name": "tokenMaxA",
-                    "type": "u64"
-                },
-                {
-                    "name": "tokenMaxB",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "decreaseLiquidity",
-            "accounts": [
-                {
-                    "name": "whirlpool",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "positionAuthority",
-                    "isMut": false,
-                    "isSigner": true
-                },
-                {
-                    "name": "position",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "positionTokenAccount",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenOwnerAccountA",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenOwnerAccountB",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenVaultA",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenVaultB",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tickArrayLower",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tickArrayUpper",
-                    "isMut": true,
-                    "isSigner": false
-                }
-            ],
-            "args": [
-                {
-                    "name": "liquidityAmount",
-                    "type": "u128"
-                },
-                {
-                    "name": "tokenMinA",
-                    "type": "u64"
-                },
-                {
-                    "name": "tokenMinB",
-                    "type": "u64"
-                }
-            ]
-        },
-        {
-            "name": "updateFeesAndRewards",
-            "accounts": [
-                {
-                    "name": "whirlpool",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "position",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tickArrayLower",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "tickArrayUpper",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
                 }
             ],
             "args": []
         },
         {
-            "name": "collectFees",
+            "name": "close_position_with_token_extensions",
+            "docs": [
+                "Close a position in a Whirlpool. Burns the position token in the owner's wallet.",
+                "Mint and TokenAccount are based on Token-2022. And Mint accout will be also closed.",
+                "",
+                "### Authority",
+                "- \"position_authority\" - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                1,
+                182,
+                135,
+                59,
+                155,
+                25,
+                99,
+                223
+            ],
             "accounts": [
                 {
-                    "name": "whirlpool",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "position_authority",
+                    "signer": true
                 },
                 {
-                    "name": "positionAuthority",
-                    "isMut": false,
-                    "isSigner": true
+                    "name": "receiver",
+                    "writable": true
                 },
                 {
                     "name": "position",
-                    "isMut": true,
-                    "isSigner": false
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
                 },
                 {
-                    "name": "positionTokenAccount",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "position_mint",
+                    "writable": true
                 },
                 {
-                    "name": "tokenOwnerAccountA",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "position_token_account",
+                    "writable": true
                 },
                 {
-                    "name": "tokenVaultA",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenOwnerAccountB",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenVaultB",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
                 }
             ],
             "args": []
         },
         {
-            "name": "collectReward",
+            "name": "collect_fees",
+            "docs": [
+                "Collect fees accrued for this position.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                164,
+                152,
+                207,
+                99,
+                30,
+                186,
+                19,
+                182
+            ],
             "accounts": [
                 {
                     "name": "whirlpool",
-                    "isMut": false,
-                    "isSigner": false
+                    "relations": [
+                        "position"
+                    ]
                 },
                 {
-                    "name": "positionAuthority",
-                    "isMut": false,
-                    "isSigner": true
+                    "name": "position_authority",
+                    "signer": true
                 },
                 {
                     "name": "position",
-                    "isMut": true,
-                    "isSigner": false
+                    "writable": true
                 },
                 {
-                    "name": "positionTokenAccount",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "position_token_account"
                 },
                 {
-                    "name": "rewardOwnerAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "token_owner_account_a",
+                    "writable": true
                 },
                 {
-                    "name": "rewardVault",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "token_vault_a",
+                    "writable": true
                 },
                 {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_fees_v2",
+            "docs": [
+                "Collect fees accrued for this position.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                207,
+                117,
+                95,
+                191,
+                229,
+                180,
+                226,
+                15
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
                 }
             ],
             "args": [
                 {
-                    "name": "rewardIndex",
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "collect_protocol_fees",
+            "docs": [
+                "Collect the protocol fees accrued in this Whirlpool",
+                "",
+                "### Authority",
+                "- `collect_protocol_fees_authority` - assigned authority in the WhirlpoolConfig that can collect protocol fees"
+            ],
+            "discriminator": [
+                22,
+                67,
+                23,
+                98,
+                150,
+                178,
+                70,
+                220
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_protocol_fees_v2",
+            "docs": [
+                "Collect the protocol fees accrued in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `collect_protocol_fees_authority` - assigned authority in the WhirlpoolConfig that can collect protocol fees"
+            ],
+            "discriminator": [
+                103,
+                128,
+                222,
+                134,
+                114,
+                200,
+                22,
+                200
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "collect_reward",
+            "docs": [
+                "Collect rewards accrued for this position.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                70,
+                5,
+                132,
+                87,
+                86,
+                235,
+                177,
+                34
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "reward_owner_account",
+                    "writable": true
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
                     "type": "u8"
                 }
             ]
         },
         {
-            "name": "collectProtocolFees",
+            "name": "collect_reward_v2",
+            "docs": [
+                "Collect rewards accrued for this position.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                177,
+                107,
+                37,
+                180,
+                160,
+                19,
+                49,
+                209
+            ],
             "accounts": [
                 {
-                    "name": "whirlpoolsConfig",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "reward_owner_account",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true
+                },
+                {
+                    "name": "reward_token_program"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "decrease_liquidity",
+            "docs": [
+                "Withdraw liquidity from a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user desires to withdraw.",
+                "- `token_min_a` - The minimum amount of tokenA the user is willing to withdraw.",
+                "- `token_min_b` - The minimum amount of tokenB the user is willing to withdraw.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount."
+            ],
+            "discriminator": [
+                160,
+                38,
+                208,
+                111,
+                104,
+                91,
+                44,
+                1
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_min_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_min_b",
+                    "type": "u64"
+                }
+            ]
+        },
+        {
+            "name": "decrease_liquidity_v2",
+            "docs": [
+                "Withdraw liquidity from a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user desires to withdraw.",
+                "- `token_min_a` - The minimum amount of tokenA the user is willing to withdraw.",
+                "- `token_min_b` - The minimum amount of tokenB the user is willing to withdraw.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount."
+            ],
+            "discriminator": [
+                58,
+                127,
+                188,
+                62,
+                79,
+                82,
+                196,
+                96
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_min_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_min_b",
+                    "type": "u64"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "delete_position_bundle",
+            "docs": [
+                "Delete a PositionBundle account. Burns the position bundle token in the owner's wallet.",
+                "",
+                "### Authority",
+                "- `position_bundle_owner` - The owner that owns the position bundle token.",
+                "",
+                "### Special Errors",
+                "- `PositionBundleNotDeletable` - The provided position bundle has open positions."
+            ],
+            "discriminator": [
+                100,
+                25,
+                99,
+                2,
+                217,
+                239,
+                124,
+                173
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_owner",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "delete_token_badge",
+            "docs": [
+                "Delete a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                53,
+                146,
+                68,
+                8,
+                18,
+                117,
+                17,
+                185
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension",
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint"
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "idl_include",
+            "discriminator": [
+                223,
+                253,
+                121,
+                121,
+                60,
+                193,
+                129,
+                31
+            ],
+            "accounts": [
+                {
+                    "name": "tick_array"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "increase_liquidity",
+            "docs": [
+                "Add liquidity to a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                46,
+                156,
+                243,
+                118,
+                13,
+                205,
+                251,
+                178
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_max_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_max_b",
+                    "type": "u64"
+                }
+            ]
+        },
+        {
+            "name": "increase_liquidity_by_token_amounts_v2",
+            "docs": [
+                "Add liquidity to a position by specifying token maxima, not liquidity.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "NOTE: This instruction is only implemented in Pinocchio, not Anchor.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "- `min_sqrt_price` - The minimum sqrt price allowed.",
+                "- `max_sqrt_price` - The maximum sqrt price allowed.",
+                "",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Computed liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Computed liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                239,
+                251,
+                9,
+                124,
+                210,
+                198,
+                53,
+                43
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "method",
+                    "type": {
+                        "defined": {
+                            "name": "IncreaseLiquidityMethod"
+                        }
+                    }
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "increase_liquidity_v2",
+            "docs": [
+                "Add liquidity to a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                133,
+                29,
+                89,
+                223,
+                69,
+                238,
+                176,
+                10
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_max_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_max_b",
+                    "type": "u64"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "initialize_adaptive_fee_tier",
+            "docs": [
+                "Initializes an adaptive_fee_tier account usable by Whirlpools in a WhirlpoolConfig space.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `fee_tier_index` - The index of the fee-tier that this adaptive fee tier will be initialized.",
+                "- `tick_spacing` - The tick-spacing that this fee-tier suggests the default_fee_rate for.",
+                "- `initialize_pool_authority` - The authority that can initialize pools with this adaptive fee-tier.",
+                "- `delegated_fee_authority` - The authority that can set the base fee rate for pools using this adaptive fee-tier.",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickSpacing` - If the provided tick_spacing is 0.",
+                "- `InvalidFeeTierIndex` - If the provided fee_tier_index is same to tick_spacing.",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE.",
+                "- `InvalidAdaptiveFeeConstants` - If the provided adaptive fee constants are invalid."
+            ],
+            "discriminator": [
+                77,
+                99,
+                208,
+                200,
+                141,
+                123,
+                117,
+                48
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config"
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    102,
+                                    101,
+                                    101,
+                                    95,
+                                    116,
+                                    105,
+                                    101,
+                                    114
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "fee_tier_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_tier_index",
+                    "type": "u16"
+                },
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initialize_pool_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "delegated_fee_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "default_base_fee_rate",
+                    "type": "u16"
+                },
+                {
+                    "name": "filter_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "decay_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": "u16"
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": "u32"
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": "u32"
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": "u16"
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_config",
+            "docs": [
+                "Initializes a WhirlpoolsConfig account that hosts info & authorities",
+                "required to govern a set of Whirlpools.",
+                "",
+                "### Authority",
+                "- \"authority\" - Set authority that is one of ADMINS.",
+                "",
+                "### Parameters",
+                "- `fee_authority` - Authority authorized to initialize fee-tiers and set customs fees.",
+                "- `collect_protocol_fees_authority` - Authority authorized to collect protocol fees.",
+                "- `reward_emissions_super_authority` - Authority authorized to set reward authorities in pools."
+            ],
+            "discriminator": [
+                208,
+                127,
+                21,
+                1,
+                194,
+                190,
+                196,
+                70
+            ],
+            "accounts": [
+                {
+                    "name": "config",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "default_protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_config_extension",
+            "docs": [
+                "Initializes a WhirlpoolConfigExtension account that hosts info & authorities.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                55,
+                9,
+                53,
+                9,
+                114,
+                57,
+                209,
+                52
+            ],
+            "accounts": [
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "config_extension",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    99,
+                                    111,
+                                    110,
+                                    102,
+                                    105,
+                                    103,
+                                    95,
+                                    101,
+                                    120,
+                                    116,
+                                    101,
+                                    110,
+                                    115,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "config"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_dynamic_tick_array",
+            "docs": [
+                "Initialize a variable-length tick array for a Whirlpool.",
+                "",
+                "### Parameters",
+                "- `start_tick_index` - The starting tick index for this tick-array.",
+                "Has to be a multiple of TickArray size & the tick spacing of this pool.",
+                "- `idempotent` - If true, the instruction will not fail if the tick array already exists.",
+                "Note: The idempotent option exits successfully if a FixedTickArray is present as well as a DynamicTickArray.",
+                "",
+                "#### Special Errors",
+                "- `InvalidStartTick` - if the provided start tick is out of bounds or is not a multiple of",
+                "TICK_ARRAY_SIZE * tick spacing."
+            ],
+            "discriminator": [
+                41,
+                33,
+                165,
+                200,
+                120,
+                231,
+                142,
+                50
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "tick_array",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    105,
+                                    99,
+                                    107,
+                                    95,
+                                    97,
+                                    114,
+                                    114,
+                                    97,
+                                    121
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "start_tick_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "start_tick_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "idempotent",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "initialize_fee_tier",
+            "docs": [
+                "Initializes a fee_tier account usable by Whirlpools in a WhirlpoolConfig space.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `tick_spacing` - The tick-spacing that this fee-tier suggests the default_fee_rate for.",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickSpacing` - If the provided tick_spacing is 0.",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                183,
+                74,
+                156,
+                160,
+                112,
+                2,
+                42,
+                30
+            ],
+            "accounts": [
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "fee_tier",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    102,
+                                    101,
+                                    101,
+                                    95,
+                                    116,
+                                    105,
+                                    101,
+                                    114
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "config"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "default_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool",
+            "docs": [
+                "Initializes a Whirlpool account.",
+                "Fee rate is set to the default values on the config and supplied fee_tier.",
+                "",
+                "### Parameters",
+                "- `bumps` - The bump value when deriving the PDA of the Whirlpool address.",
+                "- `tick_spacing` - The desired tick spacing for this pool.",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                ""
+            ],
+            "discriminator": [
+                95,
+                180,
+                10,
+                172,
+                84,
+                174,
+                232,
+                40
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
                 },
                 {
                     "name": "whirlpool",
-                    "isMut": true,
-                    "isSigner": false
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
                 },
                 {
-                    "name": "collectProtocolFeesAuthority",
-                    "isMut": false,
-                    "isSigner": true
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
                 },
                 {
-                    "name": "tokenVaultA",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
                 },
                 {
-                    "name": "tokenVaultB",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "fee_tier"
                 },
                 {
-                    "name": "tokenDestinationA",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
                 },
                 {
-                    "name": "tokenDestinationB",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
                 },
                 {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "WhirlpoolBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool_v2",
+            "docs": [
+                "Initializes a Whirlpool account.",
+                "This instruction works with both Token and Token-2022.",
+                "Fee rate is set to the default values on the config and supplied fee_tier.",
+                "",
+                "### Parameters",
+                "- `bumps` - The bump value when deriving the PDA of the Whirlpool address.",
+                "- `tick_spacing` - The desired tick spacing for this pool.",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                ""
+            ],
+            "discriminator": [
+                207,
+                45,
+                87,
+                242,
+                27,
+                63,
+                204,
+                67
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_badge_a",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_badge_b",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_tier"
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool_with_adaptive_fee",
+            "docs": [
+                "Initializes a Whirlpool account and Oracle account with adaptive fee.",
+                "",
+                "### Parameters",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "- `trade_enable_timestamp` - The timestamp when trading is enabled for this pool (within 72 hours)",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                "`InvalidTradeEnableTimestamp` - provided trade_enable_timestamp is not within 72 hours or the adaptive fee-tier is permission-less",
+                "`UnsupportedTokenMint` - The provided token mint is not supported by the program (e.g. it has risky token extensions)",
+                ""
+            ],
+            "discriminator": [
+                143,
+                94,
+                96,
+                76,
+                172,
+                124,
+                119,
+                199
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_badge_a",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_badge_b",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "initialize_pool_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "adaptive_fee_tier.fee_tier_index",
+                                "account": "AdaptiveFeeTier"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "adaptive_fee_tier"
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                },
+                {
+                    "name": "trade_enable_timestamp",
+                    "type": {
+                        "option": "u64"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "initialize_position_bundle",
+            "docs": [
+                "Initializes a PositionBundle account that bundles several positions.",
+                "A unique token will be minted to represent the position bundle in the users wallet."
+            ],
+            "discriminator": [
+                117,
+                45,
+                241,
+                149,
+                24,
+                18,
+                194,
+                65
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110,
+                                    95,
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "position_bundle_owner"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_position_bundle_with_metadata",
+            "docs": [
+                "Initializes a PositionBundle account that bundles several positions.",
+                "A unique token will be minted to represent the position bundle in the users wallet.",
+                "Additional Metaplex metadata is appended to identify the token."
+            ],
+            "discriminator": [
+                93,
+                124,
+                16,
+                179,
+                249,
+                131,
+                115,
+                245
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110,
+                                    95,
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_bundle_metadata",
+                    "docs": [
+                        "https://github.com/metaplex-foundation/metaplex-program-library/blob/773a574c4b34e5b9f248a81306ec24db064e255f/token-metadata/program/src/utils/metadata.rs#L100"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "position_bundle_owner"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_program",
+                    "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_reward",
+            "docs": [
+                "Initialize reward for a Whirlpool. A pool can only support up to a set number of rewards.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index that we'd like to initialize. (0 <= index <= NUM_REWARDS)",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                95,
+                135,
+                192,
+                196,
+                242,
+                129,
+                230,
+                68
+            ],
+            "accounts": [
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "initialize_reward_v2",
+            "docs": [
+                "Initialize reward for a Whirlpool. A pool can only support up to a set number of rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index that we'd like to initialize. (0 <= index <= NUM_REWARDS)",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                91,
+                1,
+                77,
+                50,
+                235,
+                229,
+                133,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_token_badge",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool.whirlpools_config",
+                                "account": "Whirlpool"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "reward_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "reward_token_program"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "initialize_tick_array",
+            "docs": [
+                "Initializes a fixed-length tick_array account to represent a tick-range in a Whirlpool.",
+                "",
+                "### Parameters",
+                "- `start_tick_index` - The starting tick index for this tick-array.",
+                "Has to be a multiple of TickArray size & the tick spacing of this pool.",
+                "",
+                "#### Special Errors",
+                "- `InvalidStartTick` - if the provided start tick is out of bounds or is not a multiple of",
+                "TICK_ARRAY_SIZE * tick spacing."
+            ],
+            "discriminator": [
+                11,
+                188,
+                193,
+                214,
+                141,
+                91,
+                149,
+                184
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "tick_array",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    105,
+                                    99,
+                                    107,
+                                    95,
+                                    97,
+                                    114,
+                                    114,
+                                    97,
+                                    121
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "start_tick_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "start_tick_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "initialize_token_badge",
+            "docs": [
+                "Initialize a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                253,
+                77,
+                205,
+                95,
+                27,
+                224,
+                89,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint"
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "lock_position",
+            "docs": [
+                "Lock the position to prevent any liquidity changes.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `PositionAlreadyLocked` - The provided position is already locked.",
+                "- `PositionNotLockable` - The provided position is not lockable (e.g. An empty position)."
+            ],
+            "discriminator": [
+                227,
+                62,
+                2,
+                252,
+                247,
+                10,
+                171,
+                185
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint"
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "lock_config",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    108,
+                                    111,
+                                    99,
+                                    107,
+                                    95,
+                                    99,
+                                    111,
+                                    110,
+                                    102,
+                                    105,
+                                    103
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "lock_type",
+                    "type": {
+                        "defined": {
+                            "name": "LockType"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "migrate_repurpose_reward_authority_space",
+            "docs": [
+                "Migration instruction to repurpose the reward authority space in the Whirlpool.",
+                "TODO: This instruction should be removed once all pools have been migrated."
+            ],
+            "discriminator": [
+                214,
+                161,
+                248,
+                79,
+                152,
+                98,
+                172,
+                231
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "open_bundled_position",
+            "docs": [
+                "Open a bundled position in a Whirlpool. No new tokens are issued",
+                "because the owner of the position bundle becomes the owner of the position.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Authority",
+                "- `position_bundle_authority` - authority that owns the token corresponding to this desired position bundle.",
+                "",
+                "### Parameters",
+                "- `bundle_index` - The bundle index that we'd like to open.",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidBundleIndex` - If the provided bundle index is out of bounds.",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                169,
+                113,
+                126,
+                171,
+                213,
+                172,
+                212,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "bundled_position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101,
+                                    100,
+                                    95,
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle.position_bundle_mint",
+                                "account": "PositionBundle"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "bundle_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account"
+                },
+                {
+                    "name": "position_bundle_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bundle_index",
+                    "type": "u16"
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                135,
+                128,
+                47,
+                77,
+                15,
+                152,
+                240,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "OpenPositionBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position_with_metadata",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. Additional Metaplex metadata is appended to identify the token.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                242,
+                29,
+                134,
+                48,
+                58,
+                110,
+                14,
+                60
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_metadata_account",
+                    "docs": [
+                        "https://github.com/metaplex-foundation/mpl-token-metadata/blob/master/programs/token-metadata/program/src/utils/metadata.rs#L78"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_program",
+                    "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "OpenPositionWithMetadataBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position_with_token_extensions",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. Additional TokenMetadata extension is initialized to identify the token.",
+                "Mint and TokenAccount are based on Token-2022.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "- `with_token_metadata_extension` - If true, the token metadata extension will be initialized.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                212,
+                47,
+                95,
+                92,
+                114,
+                102,
+                131,
+                250
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "with_token_metadata_extension",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "reposition_liquidity_v2",
+            "docs": [
+                "An atomic instruction that repositions liquidity for a position through the following steps:",
+                "- Withdraws liquidity from the current position range",
+                "- Resets the position to a new tick range",
+                "- Adds liquidity to the new position range",
+                "- Restores fees and rewards",
+                "",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `new_tick_lower_index` - The new tick index for the lower end of the position range.",
+                "- `new_tick_upper_index` - The new tick index for the upper end of the position range.",
+                "- `new_liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `existing_range_token_min_a` - The minimum amount of tokenA the user is willing to withdraw from the existing range.",
+                "- `existing_range_token_min_b` - The minimum amount of tokenB the user is willing to withdraw from the existing range.",
+                "- `new_range_token_max_a` - The maximum amount of tokenA the user is willing to deposit into the new range.",
+                "- `new_range_token_max_b` - The maximum amount of tokenB the user is willing to deposit into the new range.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount.",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool.",
+                "- `SameTickRangeNotAllowed` - The provided tick range is the same as the current tick range."
+            ],
+            "discriminator": [
+                191,
+                169,
+                224,
+                11,
+                131,
+                19,
+                158,
+                253
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "existing_tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "existing_tick_array_upper",
+                    "writable": true
+                },
+                {
+                    "name": "new_tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "new_tick_array_upper",
+                    "writable": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "new_tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "new_tick_upper_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "method",
+                    "type": {
+                        "defined": {
+                            "name": "RepositionLiquidityMethod"
+                        }
+                    }
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "reset_position_range",
+            "docs": [
+                "Reset the position range to a new range.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token.",
+                "",
+                "### Parameters",
+                "- `new_tick_lower_index` - The new tick specifying the lower end of the position range.",
+                "- `new_tick_upper_index` - The new tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool.",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty.",
+                "- `SameTickRangeNotAllowed` - The provided tick range is the same as the current tick range."
+            ],
+            "discriminator": [
+                164,
+                123,
+                180,
+                141,
+                194,
+                100,
+                160,
+                175
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "new_tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "new_tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "set_adaptive_fee_constants",
+            "docs": [
+                "Sets specific adaptive fee constants for a pool. Only the provided constants will be updated,",
+                "others remain unchanged. Caller should avoid invoking this instruction when a pool's adaptive",
+                "fee is high to prevent LP revenue loss",
+                "",
+                "### Authority",
+                "- `fee_authority` - Set authority in the WhirlpoolsConfig",
+                "",
+                "### Parameters",
+                "All parameters are optional. Only provided values will be updated.",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap.",
+                "",
+                "#### Special Errors",
+                "- `InvalidAdaptiveFeeConstants` - If the resulting constants are invalid for the pool's tick_spacing.",
+                "- `AdaptiveFeeConstantsUnchanged` - If the provided adaptive fee constants are unchanged from the existing constants."
+            ],
+            "discriminator": [
+                133,
+                158,
+                212,
+                189,
+                237,
+                12,
+                73,
+                39
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "oracle"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "oracle",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "filter_period",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "decay_period",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": {
+                        "option": "u32"
+                    }
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": {
+                        "option": "u32"
+                    }
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": {
+                        "option": "u16"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_collect_protocol_fees_authority",
+            "docs": [
+                "Sets the fee authority to collect protocol fees for a WhirlpoolConfig.",
+                "Only the current collect protocol fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can collect protocol fees in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                34,
+                150,
+                93,
+                244,
+                139,
+                225,
+                233,
+                67
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_collect_protocol_fees_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_config_extension_authority",
+            "docs": [
+                "Sets the config extension authority for a WhirlpoolsConfigExtension.",
+                "Only the current config extension authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"config_extension_authority\" - Set authority in the WhirlpoolConfigExtension"
+            ],
+            "discriminator": [
+                44,
+                94,
+                241,
+                116,
+                24,
+                188,
+                60,
+                143
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension",
+                    "writable": true
+                },
+                {
+                    "name": "config_extension_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_config_extension_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_config_feature_flag",
+            "docs": [
+                "Sets the feature flag for a WhirlpoolConfig.",
+                "",
+                "### Authority",
+                "- \"authority\" - Set authority that is one of ADMINS.",
+                "",
+                "### Parameters",
+                "- `feature_flag` - The feature flag that the WhirlpoolConfig will use."
+            ],
+            "discriminator": [
+                71,
+                173,
+                228,
+                18,
+                67,
+                247,
+                210,
+                57
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "feature_flag",
+                    "type": {
+                        "defined": {
+                            "name": "ConfigFeatureFlag"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_default_base_fee_rate",
+            "docs": [
+                "Set the default_base_fee_rate for an AdaptiveFeeTier",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_base_fee_rate` - The default base fee rate that a pool will use if the pool uses this",
+                "adaptive fee-tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                229,
+                66,
+                84,
+                251,
+                164,
+                134,
+                183,
+                7
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_base_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_default_fee_rate",
+            "docs": [
+                "Set the default_fee_rate for a FeeTier",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                118,
+                215,
+                214,
+                157,
+                182,
+                229,
+                208,
+                228
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_default_protocol_fee_rate",
+            "docs": [
+                "Sets the default protocol fee rate for a WhirlpoolConfig",
+                "Protocol fee rate is represented as a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_protocol_fee_rate` - Rate that is referenced during the initialization of a Whirlpool using this config.",
+                "",
+                "#### Special Errors",
+                "- `ProtocolFeeRateMaxExceeded` - If the provided default_protocol_fee_rate exceeds MAX_PROTOCOL_FEE_RATE."
+            ],
+            "discriminator": [
+                107,
+                205,
+                249,
+                226,
+                151,
+                35,
+                86,
+                0
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_delegated_fee_authority",
+            "docs": [
+                "Sets the delegated fee authority for an AdaptiveFeeTier.",
+                "The delegated fee authority can set the fee rate for individual pools initialized with the adaptive fee-tier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                193,
+                234,
+                231,
+                147,
+                138,
+                57,
+                3,
+                122
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_delegated_fee_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_fee_authority",
+            "docs": [
+                "Sets the fee authority for a WhirlpoolConfig.",
+                "The fee authority can set the fee & protocol fee rate for individual pools or",
+                "set the default fee rate for newly minted pools.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                31,
+                1,
+                50,
+                87,
+                237,
+                101,
+                97,
+                132
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_fee_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_fee_rate",
+            "docs": [
+                "Sets the fee rate for a Whirlpool.",
+                "Fee rate is represented as hundredths of a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `fee_rate` - The rate that the pool will use to calculate fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                53,
+                243,
+                137,
+                65,
+                8,
+                140,
+                158,
+                6
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_fee_rate_by_delegated_fee_authority",
+            "docs": [
+                "Sets the fee rate for a Whirlpool by the delegated fee authority in AdaptiveFeeTier.",
+                "Fee rate is represented as hundredths of a basis point.",
+                "",
+                "### Authority",
+                "- \"delegated_fee_authority\" - Set authority that can modify pool fees in the AdaptiveFeeTier",
+                "",
+                "### Parameters",
+                "- `fee_rate` - The rate that the pool will use to calculate fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                121,
+                121,
+                54,
+                114,
+                131,
+                230,
+                162,
+                104
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "adaptive_fee_tier"
+                },
+                {
+                    "name": "delegated_fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_initialize_pool_authority",
+            "docs": [
+                "Sets the initialize pool authority for an AdaptiveFeeTier.",
+                "Only the initialize pool authority can initialize pools with the adaptive fee-tier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                125,
+                43,
+                127,
+                235,
+                149,
+                26,
+                106,
+                236
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_initialize_pool_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_preset_adaptive_fee_constants",
+            "docs": [
+                "Sets the adaptive fee constants for an AdaptiveFeeTier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap."
+            ],
+            "discriminator": [
+                132,
+                185,
+                66,
+                148,
+                83,
+                88,
+                134,
+                198
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "filter_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "decay_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": "u16"
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": "u32"
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": "u32"
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": "u16"
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_protocol_fee_rate",
+            "docs": [
+                "Sets the protocol fee rate for a Whirlpool.",
+                "Protocol fee rate is represented as a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `protocol_fee_rate` - The rate that the pool will use to calculate protocol fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `ProtocolFeeRateMaxExceeded` - If the provided default_protocol_fee_rate exceeds MAX_PROTOCOL_FEE_RATE."
+            ],
+            "discriminator": [
+                95,
+                7,
+                4,
+                50,
+                154,
+                79,
+                156,
+                131
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_authority",
+            "docs": [
+                "Set the whirlpool reward authority at the provided `reward_index`.",
+                "Only the current reward authority for this reward index has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - Set authority that can control reward emission for this particular reward.",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                34,
+                39,
+                183,
+                252,
+                83,
+                28,
+                85,
+                127
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_authority"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_authority_by_super_authority",
+            "docs": [
+                "Set the whirlpool reward authority at the provided `reward_index`.",
+                "Only the current reward super authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - Set authority that can control reward emission for this particular reward.",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                240,
+                154,
+                201,
+                198,
+                148,
+                93,
+                56,
+                25
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_authority"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_emissions",
+            "docs": [
+                "Set the reward emissions for a reward in a Whirlpool.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index (0 <= index <= NUM_REWARDS) that we'd like to modify.",
+                "- `emissions_per_second_x64` - The amount of rewards emitted in this pool.",
+                "",
+                "#### Special Errors",
+                "- `RewardVaultAmountInsufficient` - The amount of rewards in the reward vault cannot emit",
+                "more than a day of desired emissions.",
+                "- `InvalidTimestamp` - Provided timestamp is not in order with the previous timestamp.",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                13,
+                197,
+                86,
+                168,
+                109,
+                176,
+                27,
+                244
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "reward_vault"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "emissions_per_second_x64",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_emissions_super_authority",
+            "docs": [
+                "Set the whirlpool reward super authority for a WhirlpoolConfig",
+                "Only the current reward super authority has permission to invoke this instruction.",
+                "This instruction will not change the authority on any `WhirlpoolRewardInfo` whirlpool rewards.",
+                "",
+                "### Authority",
+                "- \"reward_emissions_super_authority\" - Set authority that can control reward authorities for all pools in this config space."
+            ],
+            "discriminator": [
+                207,
+                5,
+                200,
+                209,
+                122,
+                56,
+                82,
+                183
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_emissions_super_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_reward_emissions_v2",
+            "docs": [
+                "Set the reward emissions for a reward in a Whirlpool.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index (0 <= index <= NUM_REWARDS) that we'd like to modify.",
+                "- `emissions_per_second_x64` - The amount of rewards emitted in this pool.",
+                "",
+                "#### Special Errors",
+                "- `RewardVaultAmountInsufficient` - The amount of rewards in the reward vault cannot emit",
+                "more than a day of desired emissions.",
+                "- `InvalidTimestamp` - Provided timestamp is not in order with the previous timestamp.",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                114,
+                228,
+                72,
+                32,
+                193,
+                48,
+                160,
+                102
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "reward_vault"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "emissions_per_second_x64",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "set_token_badge_attribute",
+            "docs": [
+                "Set an attribute on a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Parameters",
+                "- `attribute` - The attribute to set on the TokenBadge account.",
+                "",
+                "#### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                224,
+                88,
+                65,
+                33,
+                138,
+                147,
+                246,
+                137
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension",
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint",
+                    "relations": [
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "attribute",
+                    "type": {
+                        "defined": {
+                            "name": "TokenBadgeAttribute"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_token_badge_authority",
+            "docs": [
+                "Sets the token badge authority for a WhirlpoolsConfigExtension.",
+                "Only the config extension authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"config_extension_authority\" - Set authority in the WhirlpoolConfigExtension"
+            ],
+            "discriminator": [
+                207,
+                202,
+                4,
+                32,
+                205,
+                79,
+                13,
+                178
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension",
+                    "writable": true
+                },
+                {
+                    "name": "config_extension_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_token_badge_authority"
                 }
             ],
             "args": []
         },
         {
             "name": "swap",
+            "docs": [
+                "Perform a swap in this Whirlpool",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `sqrt_price_limit` - The maximum/minimum price the swap will swap to.",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b` - The direction of the swap. True if swapping from A to B. False if swapping from B to A.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0."
+            ],
+            "discriminator": [
+                248,
+                198,
+                158,
+                145,
+                225,
+                117,
+                135,
+                200
+            ],
             "accounts": [
                 {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
                 },
                 {
-                    "name": "tokenAuthority",
-                    "isMut": false,
-                    "isSigner": true
+                    "name": "token_authority",
+                    "signer": true
                 },
                 {
                     "name": "whirlpool",
-                    "isMut": true,
-                    "isSigner": false
+                    "writable": true
                 },
                 {
-                    "name": "tokenOwnerAccountA",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "token_owner_account_a",
+                    "writable": true
                 },
                 {
-                    "name": "tokenVaultA",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "token_vault_a",
+                    "writable": true
                 },
                 {
-                    "name": "tokenOwnerAccountB",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "token_owner_account_b",
+                    "writable": true
                 },
                 {
-                    "name": "tokenVaultB",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "token_vault_b",
+                    "writable": true
                 },
                 {
-                    "name": "tickArray0",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "tick_array_0",
+                    "writable": true
                 },
                 {
-                    "name": "tickArray1",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "tick_array_1",
+                    "writable": true
                 },
                 {
-                    "name": "tickArray2",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "tick_array_2",
+                    "writable": true
                 },
                 {
                     "name": "oracle",
-                    "isMut": false,
-                    "isSigner": false
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
                 }
             ],
             "args": [
@@ -807,274 +5070,680 @@
                     "type": "u64"
                 },
                 {
-                    "name": "otherAmountThreshold",
+                    "name": "other_amount_threshold",
                     "type": "u64"
                 },
                 {
-                    "name": "sqrtPriceLimit",
+                    "name": "sqrt_price_limit",
                     "type": "u128"
                 },
                 {
-                    "name": "amountSpecifiedIsInput",
+                    "name": "amount_specified_is_input",
                     "type": "bool"
                 },
                 {
-                    "name": "aToB",
+                    "name": "a_to_b",
                     "type": "bool"
                 }
             ]
         },
         {
-            "name": "closePosition",
+            "name": "swap_v2",
+            "docs": [
+                "Perform a swap in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `sqrt_price_limit` - The maximum/minimum price the swap will swap to.",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b` - The direction of the swap. True if swapping from A to B. False if swapping from B to A.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0."
+            ],
+            "discriminator": [
+                43,
+                4,
+                237,
+                11,
+                26,
+                201,
+                30,
+                98
+            ],
             "accounts": [
                 {
-                    "name": "positionAuthority",
-                    "isMut": false,
-                    "isSigner": true
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "sqrt_price_limit",
+                    "type": "u128"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b",
+                    "type": "bool"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "transfer_locked_position",
+            "docs": [
+                "Transfer a locked position to a different token account.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token."
+            ],
+            "discriminator": [
+                179,
+                121,
+                229,
+                46,
+                67,
+                138,
+                194,
+                138
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
                 },
                 {
                     "name": "receiver",
-                    "isMut": true,
-                    "isSigner": false
+                    "writable": true
                 },
                 {
                     "name": "position",
-                    "isMut": true,
-                    "isSigner": false
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    },
+                    "relations": [
+                        "lock_config"
+                    ]
                 },
                 {
-                    "name": "positionMint",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "position_mint"
                 },
                 {
-                    "name": "positionTokenAccount",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "position_token_account",
+                    "writable": true
                 },
                 {
-                    "name": "tokenProgram",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "destination_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "lock_config",
+                    "writable": true
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
                 }
             ],
             "args": []
         },
         {
-            "name": "setDefaultFeeRate",
+            "name": "two_hop_swap",
+            "docs": [
+                "Perform a two-hop swap in this Whirlpool",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b_one` - The direction of the swap of hop one. True if swapping from A to B. False if swapping from B to A.",
+                "- `a_to_b_two` - The direction of the swap of hop two. True if swapping from A to B. False if swapping from B to A.",
+                "- `sqrt_price_limit_one` - The maximum/minimum price the swap will swap to in the first hop.",
+                "- `sqrt_price_limit_two` - The maximum/minimum price the swap will swap to in the second hop.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0.",
+                "- `InvalidIntermediaryMint` - Error if the intermediary mint between hop one and two do not equal.",
+                "- `DuplicateTwoHopPool` - Error if whirlpool one & two are the same pool."
+            ],
+            "discriminator": [
+                195,
+                96,
+                237,
+                108,
+                68,
+                162,
+                219,
+                230
+            ],
             "accounts": [
                 {
-                    "name": "whirlpoolsConfig",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
                 },
                 {
-                    "name": "feeTier",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "token_authority",
+                    "signer": true
                 },
                 {
-                    "name": "feeAuthority",
-                    "isMut": false,
-                    "isSigner": true
+                    "name": "whirlpool_one",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool_two",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_one_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_one_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_two_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_two_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_2",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle_one",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_one"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle_two",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_two"
+                            }
+                        ]
+                    }
                 }
             ],
             "args": [
                 {
-                    "name": "defaultFeeRate",
-                    "type": "u16"
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_one",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_two",
+                    "type": "bool"
+                },
+                {
+                    "name": "sqrt_price_limit_one",
+                    "type": "u128"
+                },
+                {
+                    "name": "sqrt_price_limit_two",
+                    "type": "u128"
                 }
             ]
         },
         {
-            "name": "setDefaultProtocolFeeRate",
+            "name": "two_hop_swap_v2",
+            "docs": [
+                "Perform a two-hop swap in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b_one` - The direction of the swap of hop one. True if swapping from A to B. False if swapping from B to A.",
+                "- `a_to_b_two` - The direction of the swap of hop two. True if swapping from A to B. False if swapping from B to A.",
+                "- `sqrt_price_limit_one` - The maximum/minimum price the swap will swap to in the first hop.",
+                "- `sqrt_price_limit_two` - The maximum/minimum price the swap will swap to in the second hop.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0.",
+                "- `InvalidIntermediaryMint` - Error if the intermediary mint between hop one and two do not equal.",
+                "- `DuplicateTwoHopPool` - Error if whirlpool one & two are the same pool."
+            ],
+            "discriminator": [
+                186,
+                143,
+                209,
+                29,
+                254,
+                2,
+                194,
+                117
+            ],
             "accounts": [
                 {
-                    "name": "whirlpoolsConfig",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "whirlpool_one",
+                    "writable": true
                 },
                 {
-                    "name": "feeAuthority",
-                    "isMut": false,
-                    "isSigner": true
+                    "name": "whirlpool_two",
+                    "writable": true
+                },
+                {
+                    "name": "token_mint_input"
+                },
+                {
+                    "name": "token_mint_intermediate"
+                },
+                {
+                    "name": "token_mint_output"
+                },
+                {
+                    "name": "token_program_input"
+                },
+                {
+                    "name": "token_program_intermediate"
+                },
+                {
+                    "name": "token_program_output"
+                },
+                {
+                    "name": "token_owner_account_input",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_input",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_intermediate",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_intermediate",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_output",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_output",
+                    "writable": true
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "tick_array_one_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_2",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle_one",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_one"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle_two",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_two"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
                 }
             ],
             "args": [
                 {
-                    "name": "defaultProtocolFeeRate",
-                    "type": "u16"
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_one",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_two",
+                    "type": "bool"
+                },
+                {
+                    "name": "sqrt_price_limit_one",
+                    "type": "u128"
+                },
+                {
+                    "name": "sqrt_price_limit_two",
+                    "type": "u128"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
                 }
             ]
         },
         {
-            "name": "setFeeRate",
+            "name": "update_fees_and_rewards",
+            "docs": [
+                "Update the accrued fees and rewards for a position.",
+                "",
+                "#### Special Errors",
+                "- `TickNotFound` - Provided tick array account does not contain the tick for this position.",
+                "- `LiquidityZero` - Position has zero liquidity and therefore already has the most updated fees and reward values."
+            ],
+            "discriminator": [
+                154,
+                230,
+                250,
+                13,
+                236,
+                209,
+                75,
+                223
+            ],
             "accounts": [
-                {
-                    "name": "whirlpoolsConfig",
-                    "isMut": false,
-                    "isSigner": false
-                },
                 {
                     "name": "whirlpool",
-                    "isMut": true,
-                    "isSigner": false
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
                 },
                 {
-                    "name": "feeAuthority",
-                    "isMut": false,
-                    "isSigner": true
-                }
-            ],
-            "args": [
-                {
-                    "name": "feeRate",
-                    "type": "u16"
-                }
-            ]
-        },
-        {
-            "name": "setProtocolFeeRate",
-            "accounts": [
-                {
-                    "name": "whirlpoolsConfig",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "position",
+                    "writable": true
                 },
                 {
-                    "name": "whirlpool",
-                    "isMut": true,
-                    "isSigner": false
+                    "name": "tick_array_lower"
                 },
                 {
-                    "name": "feeAuthority",
-                    "isMut": false,
-                    "isSigner": true
-                }
-            ],
-            "args": [
-                {
-                    "name": "protocolFeeRate",
-                    "type": "u16"
-                }
-            ]
-        },
-        {
-            "name": "setFeeAuthority",
-            "accounts": [
-                {
-                    "name": "whirlpoolsConfig",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "feeAuthority",
-                    "isMut": false,
-                    "isSigner": true
-                },
-                {
-                    "name": "newFeeAuthority",
-                    "isMut": false,
-                    "isSigner": false
-                }
-            ],
-            "args": []
-        },
-        {
-            "name": "setCollectProtocolFeesAuthority",
-            "accounts": [
-                {
-                    "name": "whirlpoolsConfig",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "collectProtocolFeesAuthority",
-                    "isMut": false,
-                    "isSigner": true
-                },
-                {
-                    "name": "newCollectProtocolFeesAuthority",
-                    "isMut": false,
-                    "isSigner": false
-                }
-            ],
-            "args": []
-        },
-        {
-            "name": "setRewardAuthority",
-            "accounts": [
-                {
-                    "name": "whirlpool",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "rewardAuthority",
-                    "isMut": false,
-                    "isSigner": true
-                },
-                {
-                    "name": "newRewardAuthority",
-                    "isMut": false,
-                    "isSigner": false
-                }
-            ],
-            "args": [
-                {
-                    "name": "rewardIndex",
-                    "type": "u8"
-                }
-            ]
-        },
-        {
-            "name": "setRewardAuthorityBySuperAuthority",
-            "accounts": [
-                {
-                    "name": "whirlpoolsConfig",
-                    "isMut": false,
-                    "isSigner": false
-                },
-                {
-                    "name": "whirlpool",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "rewardEmissionsSuperAuthority",
-                    "isMut": false,
-                    "isSigner": true
-                },
-                {
-                    "name": "newRewardAuthority",
-                    "isMut": false,
-                    "isSigner": false
-                }
-            ],
-            "args": [
-                {
-                    "name": "rewardIndex",
-                    "type": "u8"
-                }
-            ]
-        },
-        {
-            "name": "setRewardEmissionsSuperAuthority",
-            "accounts": [
-                {
-                    "name": "whirlpoolsConfig",
-                    "isMut": true,
-                    "isSigner": false
-                },
-                {
-                    "name": "rewardEmissionsSuperAuthority",
-                    "isMut": false,
-                    "isSigner": true
-                },
-                {
-                    "name": "newRewardEmissionsSuperAuthority",
-                    "isMut": false,
-                    "isSigner": false
+                    "name": "tick_array_upper"
                 }
             ],
             "args": []
@@ -1082,399 +5751,240 @@
     ],
     "accounts": [
         {
-            "name": "WhirlpoolsConfig",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "feeAuthority",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "collectProtocolFeesAuthority",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "rewardEmissionsSuperAuthority",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "defaultProtocolFeeRate",
-                        "type": "u16"
-                    }
-                ]
-            }
+            "name": "AdaptiveFeeTier",
+            "discriminator": [
+                147,
+                16,
+                144,
+                116,
+                47,
+                146,
+                149,
+                46
+            ]
+        },
+        {
+            "name": "DynamicTickArray",
+            "discriminator": [
+                17,
+                216,
+                246,
+                142,
+                225,
+                199,
+                218,
+                56
+            ]
         },
         {
             "name": "FeeTier",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "whirlpoolsConfig",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "tickSpacing",
-                        "type": "u16"
-                    },
-                    {
-                        "name": "defaultFeeRate",
-                        "type": "u16"
-                    }
-                ]
-            }
+            "discriminator": [
+                56,
+                75,
+                159,
+                76,
+                142,
+                68,
+                190,
+                105
+            ]
+        },
+        {
+            "name": "LockConfig",
+            "discriminator": [
+                106,
+                47,
+                238,
+                159,
+                124,
+                12,
+                160,
+                192
+            ]
+        },
+        {
+            "name": "Oracle",
+            "discriminator": [
+                139,
+                194,
+                131,
+                179,
+                140,
+                179,
+                229,
+                244
+            ]
         },
         {
             "name": "Position",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "whirlpool",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "positionMint",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "liquidity",
-                        "type": "u128"
-                    },
-                    {
-                        "name": "tickLowerIndex",
-                        "type": "i32"
-                    },
-                    {
-                        "name": "tickUpperIndex",
-                        "type": "i32"
-                    },
-                    {
-                        "name": "feeGrowthCheckpointA",
-                        "type": "u128"
-                    },
-                    {
-                        "name": "feeOwedA",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "feeGrowthCheckpointB",
-                        "type": "u128"
-                    },
-                    {
-                        "name": "feeOwedB",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "rewardInfos",
-                        "type": {
-                            "array": [
-                                {
-                                    "defined": "PositionRewardInfo"
-                                },
-                                3
-                            ]
-                        }
-                    }
-                ]
-            }
+            "discriminator": [
+                170,
+                188,
+                143,
+                228,
+                122,
+                64,
+                247,
+                208
+            ]
+        },
+        {
+            "name": "PositionBundle",
+            "discriminator": [
+                129,
+                169,
+                175,
+                65,
+                185,
+                95,
+                32,
+                100
+            ]
         },
         {
             "name": "TickArray",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "startTickIndex",
-                        "type": "i32"
-                    },
-                    {
-                        "name": "ticks",
-                        "type": {
-                            "array": [
-                                {
-                                    "defined": "Tick"
-                                },
-                                88
-                            ]
-                        }
-                    },
-                    {
-                        "name": "whirlpool",
-                        "type": "publicKey"
-                    }
-                ]
-            }
+            "discriminator": [
+                69,
+                97,
+                189,
+                190,
+                110,
+                7,
+                66,
+                187
+            ]
+        },
+        {
+            "name": "TokenBadge",
+            "discriminator": [
+                116,
+                219,
+                204,
+                229,
+                249,
+                116,
+                255,
+                150
+            ]
         },
         {
             "name": "Whirlpool",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "whirlpoolsConfig",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "whirlpoolBump",
-                        "type": {
-                            "array": [
-                                "u8",
-                                1
-                            ]
-                        }
-                    },
-                    {
-                        "name": "tickSpacing",
-                        "type": "u16"
-                    },
-                    {
-                        "name": "tickSpacingSeed",
-                        "type": {
-                            "array": [
-                                "u8",
-                                2
-                            ]
-                        }
-                    },
-                    {
-                        "name": "feeRate",
-                        "type": "u16"
-                    },
-                    {
-                        "name": "protocolFeeRate",
-                        "type": "u16"
-                    },
-                    {
-                        "name": "liquidity",
-                        "type": "u128"
-                    },
-                    {
-                        "name": "sqrtPrice",
-                        "type": "u128"
-                    },
-                    {
-                        "name": "tickCurrentIndex",
-                        "type": "i32"
-                    },
-                    {
-                        "name": "protocolFeeOwedA",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "protocolFeeOwedB",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "tokenMintA",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "tokenVaultA",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "feeGrowthGlobalA",
-                        "type": "u128"
-                    },
-                    {
-                        "name": "tokenMintB",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "tokenVaultB",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "feeGrowthGlobalB",
-                        "type": "u128"
-                    },
-                    {
-                        "name": "rewardLastUpdatedTimestamp",
-                        "type": "u64"
-                    },
-                    {
-                        "name": "rewardInfos",
-                        "type": {
-                            "array": [
-                                {
-                                    "defined": "WhirlpoolRewardInfo"
-                                },
-                                3
-                            ]
-                        }
-                    }
-                ]
-            }
+            "discriminator": [
+                63,
+                149,
+                209,
+                12,
+                225,
+                128,
+                99,
+                9
+            ]
+        },
+        {
+            "name": "WhirlpoolsConfig",
+            "discriminator": [
+                157,
+                20,
+                49,
+                224,
+                217,
+                87,
+                193,
+                254
+            ]
+        },
+        {
+            "name": "WhirlpoolsConfigExtension",
+            "discriminator": [
+                2,
+                99,
+                215,
+                163,
+                240,
+                26,
+                153,
+                58
+            ]
         }
     ],
-    "types": [
+    "events": [
         {
-            "name": "OpenPositionBumps",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "positionBump",
-                        "type": "u8"
-                    }
-                ]
-            }
+            "name": "LiquidityDecreased",
+            "discriminator": [
+                166,
+                1,
+                36,
+                71,
+                112,
+                202,
+                181,
+                171
+            ]
         },
         {
-            "name": "OpenPositionWithMetadataBumps",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "positionBump",
-                        "type": "u8"
-                    },
-                    {
-                        "name": "metadataBump",
-                        "type": "u8"
-                    }
-                ]
-            }
+            "name": "LiquidityIncreased",
+            "discriminator": [
+                30,
+                7,
+                144,
+                181,
+                102,
+                254,
+                155,
+                161
+            ]
         },
         {
-            "name": "PositionRewardInfo",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "growthInsideCheckpoint",
-                        "type": "u128"
-                    },
-                    {
-                        "name": "amountOwed",
-                        "type": "u64"
-                    }
-                ]
-            }
+            "name": "LiquidityRepositioned",
+            "discriminator": [
+                95,
+                130,
+                181,
+                132,
+                251,
+                50,
+                195,
+                38
+            ]
         },
         {
-            "name": "Tick",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "initialized",
-                        "type": "bool"
-                    },
-                    {
-                        "name": "liquidityNet",
-                        "type": "i128"
-                    },
-                    {
-                        "name": "liquidityGross",
-                        "type": "u128"
-                    },
-                    {
-                        "name": "feeGrowthOutsideA",
-                        "type": "u128"
-                    },
-                    {
-                        "name": "feeGrowthOutsideB",
-                        "type": "u128"
-                    },
-                    {
-                        "name": "rewardGrowthsOutside",
-                        "type": {
-                            "array": [
-                                "u128",
-                                3
-                            ]
-                        }
-                    }
-                ]
-            }
+            "name": "PoolInitialized",
+            "discriminator": [
+                100,
+                118,
+                173,
+                87,
+                12,
+                198,
+                254,
+                229
+            ]
         },
         {
-            "name": "WhirlpoolRewardInfo",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "mint",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "vault",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "authority",
-                        "type": "publicKey"
-                    },
-                    {
-                        "name": "emissionsPerSecondX64",
-                        "type": "u128"
-                    },
-                    {
-                        "name": "growthGlobalX64",
-                        "type": "u128"
-                    }
-                ]
-            }
+            "name": "PositionOpened",
+            "discriminator": [
+                237,
+                175,
+                243,
+                230,
+                147,
+                117,
+                101,
+                121
+            ]
         },
         {
-            "name": "WhirlpoolBumps",
-            "type": {
-                "kind": "struct",
-                "fields": [
-                    {
-                        "name": "whirlpoolBump",
-                        "type": "u8"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "CurrIndex",
-            "type": {
-                "kind": "enum",
-                "variants": [
-                    {
-                        "name": "Below"
-                    },
-                    {
-                        "name": "Inside"
-                    },
-                    {
-                        "name": "Above"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "TickLabel",
-            "type": {
-                "kind": "enum",
-                "variants": [
-                    {
-                        "name": "Upper"
-                    },
-                    {
-                        "name": "Lower"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "Direction",
-            "type": {
-                "kind": "enum",
-                "variants": [
-                    {
-                        "name": "Left"
-                    },
-                    {
-                        "name": "Right"
-                    }
-                ]
-            }
+            "name": "Traded",
+            "discriminator": [
+                225,
+                202,
+                73,
+                175,
+                147,
+                43,
+                160,
+                150
+            ]
         }
     ],
     "errors": [
@@ -1682,6 +6192,1417 @@
             "code": 6040,
             "name": "AmountRemainingOverflow",
             "msg": "Amount remaining overflows"
+        },
+        {
+            "code": 6041,
+            "name": "InvalidIntermediaryMint",
+            "msg": "Invalid intermediary mint"
+        },
+        {
+            "code": 6042,
+            "name": "DuplicateTwoHopPool",
+            "msg": "Duplicate two hop pool"
+        },
+        {
+            "code": 6043,
+            "name": "InvalidBundleIndex",
+            "msg": "Bundle index is out of bounds"
+        },
+        {
+            "code": 6044,
+            "name": "BundledPositionAlreadyOpened",
+            "msg": "Position has already been opened"
+        },
+        {
+            "code": 6045,
+            "name": "BundledPositionAlreadyClosed",
+            "msg": "Position has already been closed"
+        },
+        {
+            "code": 6046,
+            "name": "PositionBundleNotDeletable",
+            "msg": "Unable to delete PositionBundle with open positions"
+        },
+        {
+            "code": 6047,
+            "name": "UnsupportedTokenMint",
+            "msg": "Token mint has unsupported attributes"
+        },
+        {
+            "code": 6048,
+            "name": "RemainingAccountsInvalidSlice",
+            "msg": "Invalid remaining accounts"
+        },
+        {
+            "code": 6049,
+            "name": "RemainingAccountsInsufficient",
+            "msg": "Insufficient remaining accounts"
+        },
+        {
+            "code": 6050,
+            "name": "NoExtraAccountsForTransferHook",
+            "msg": "Unable to call transfer hook without extra accounts"
+        },
+        {
+            "code": 6051,
+            "name": "IntermediateTokenAmountMismatch",
+            "msg": "Output and input amount mismatch"
+        },
+        {
+            "code": 6052,
+            "name": "TransferFeeCalculationError",
+            "msg": "Transfer fee calculation failed"
+        },
+        {
+            "code": 6053,
+            "name": "RemainingAccountsDuplicatedAccountsType",
+            "msg": "Same accounts type is provided more than once"
+        },
+        {
+            "code": 6054,
+            "name": "FullRangeOnlyPool",
+            "msg": "This whirlpool only supports full-range positions"
+        },
+        {
+            "code": 6055,
+            "name": "TooManySupplementalTickArrays",
+            "msg": "Too many supplemental tick arrays provided"
+        },
+        {
+            "code": 6056,
+            "name": "DifferentWhirlpoolTickArrayAccount",
+            "msg": "TickArray account for different whirlpool provided"
+        },
+        {
+            "code": 6057,
+            "name": "PartialFillError",
+            "msg": "Trade resulted in partial fill"
+        },
+        {
+            "code": 6058,
+            "name": "PositionNotLockable",
+            "msg": "Position is not lockable"
+        },
+        {
+            "code": 6059,
+            "name": "OperationNotAllowedOnLockedPosition",
+            "msg": "Operation not allowed on locked position"
+        },
+        {
+            "code": 6060,
+            "name": "SameTickRangeNotAllowed",
+            "msg": "Cannot reset position range with same tick range"
+        },
+        {
+            "code": 6061,
+            "name": "InvalidAdaptiveFeeConstants",
+            "msg": "Invalid adaptive fee constants"
+        },
+        {
+            "code": 6062,
+            "name": "InvalidFeeTierIndex",
+            "msg": "Invalid fee tier index"
+        },
+        {
+            "code": 6063,
+            "name": "InvalidTradeEnableTimestamp",
+            "msg": "Invalid trade enable timestamp"
+        },
+        {
+            "code": 6064,
+            "name": "TradeIsNotEnabled",
+            "msg": "Trade is not enabled yet"
+        },
+        {
+            "code": 6065,
+            "name": "RentCalculationError",
+            "msg": "Rent calculation error"
+        },
+        {
+            "code": 6066,
+            "name": "FeatureIsNotEnabled",
+            "msg": "Feature is not enabled"
+        },
+        {
+            "code": 6067,
+            "name": "PositionWithTokenExtensionsRequired",
+            "msg": "This whirlpool only supports open_position_with_token_extensions instruction"
+        },
+        {
+            "code": 6068,
+            "name": "AdaptiveFeeConstantsUnchanged",
+            "msg": "Provided adaptive fee constants are unchanged"
+        },
+        {
+            "code": 6069,
+            "name": "PriceSlippageOutOfBounds",
+            "msg": "Price outside slippage bounds"
+        }
+    ],
+    "types": [
+        {
+            "name": "AccountsType",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "TransferHookA"
+                    },
+                    {
+                        "name": "TransferHookB"
+                    },
+                    {
+                        "name": "TransferHookReward"
+                    },
+                    {
+                        "name": "TransferHookInput"
+                    },
+                    {
+                        "name": "TransferHookIntermediate"
+                    },
+                    {
+                        "name": "TransferHookOutput"
+                    },
+                    {
+                        "name": "SupplementalTickArrays"
+                    },
+                    {
+                        "name": "SupplementalTickArraysOne"
+                    },
+                    {
+                        "name": "SupplementalTickArraysTwo"
+                    },
+                    {
+                        "name": "TransferHookDepositA"
+                    },
+                    {
+                        "name": "TransferHookDepositB"
+                    },
+                    {
+                        "name": "TransferHookWithdrawalA"
+                    },
+                    {
+                        "name": "TransferHookWithdrawalB"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeConstants",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "adaptive_fee_control_factor",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_size",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "major_swap_threshold_ticks",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                16
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeTier",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_tier_index",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "initialize_pool_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "delegated_fee_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "default_base_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "adaptive_fee_control_factor",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_size",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "major_swap_threshold_ticks",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeVariables",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "last_reference_update_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "last_major_swap_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "volatility_reference",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_index_reference",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                16
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "ConfigFeatureFlag",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "TokenBadge",
+                        "fields": [
+                            "bool"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTick",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Uninitialized"
+                    },
+                    {
+                        "name": "Initialized",
+                        "fields": [
+                            {
+                                "defined": {
+                                    "name": "DynamicTickData"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTickArray",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "start_tick_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_bitmap",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "ticks",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "DynamicTick"
+                                    }
+                                },
+                                88
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTickData",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "liquidity_net",
+                        "type": "i128"
+                    },
+                    {
+                        "name": "liquidity_gross",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_growths_outside",
+                        "type": {
+                            "array": [
+                                "u128",
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "FeeTier",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "default_fee_rate",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "IncreaseLiquidityMethod",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "ByTokenAmounts",
+                        "fields": [
+                            {
+                                "name": "token_max_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "token_max_b",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "min_sqrt_price",
+                                "type": "u128"
+                            },
+                            {
+                                "name": "max_sqrt_price",
+                                "type": "u128"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityDecreased",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityIncreased",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityRepositioned",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "existing_range_tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "existing_range_tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "new_range_tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "new_range_tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "existing_range_liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "new_range_liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "existing_range_token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "existing_range_token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "new_range_token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "new_range_token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "is_token_a_transfer_from_owner",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "token_b_transfer_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "is_token_b_transfer_from_owner",
+                        "type": "bool"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockConfig",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_owner",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "locked_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "lock_type",
+                        "type": {
+                            "defined": {
+                                "name": "LockTypeLabel"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockType",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Permanent"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockTypeLabel",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Permanent"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "OpenPositionBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "OpenPositionWithMetadataBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bump",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "metadata_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Oracle",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "trade_enable_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "adaptive_fee_constants",
+                        "type": {
+                            "defined": {
+                                "name": "AdaptiveFeeConstants"
+                            }
+                        }
+                    },
+                    {
+                        "name": "adaptive_fee_variables",
+                        "type": {
+                            "defined": {
+                                "name": "AdaptiveFeeVariables"
+                            }
+                        }
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                128
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PoolInitialized",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "token_program_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_program_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "decimals_a",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "decimals_b",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "initial_sqrt_price",
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Position",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "fee_growth_checkpoint_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_owed_a",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "fee_growth_checkpoint_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_owed_b",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_infos",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "PositionRewardInfo"
+                                    }
+                                },
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionBundle",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bundle_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_bitmap",
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionOpened",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionRewardInfo",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "growth_inside_checkpoint",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "amount_owed",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RemainingAccountsInfo",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "slices",
+                        "type": {
+                            "vec": {
+                                "defined": {
+                                    "name": "RemainingAccountsSlice"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RemainingAccountsSlice",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "accounts_type",
+                        "type": {
+                            "defined": {
+                                "name": "AccountsType"
+                            }
+                        }
+                    },
+                    {
+                        "name": "length",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RepositionLiquidityMethod",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "ByLiquidity",
+                        "fields": [
+                            {
+                                "name": "new_liquidity_amount",
+                                "type": "u128"
+                            },
+                            {
+                                "name": "existing_range_token_min_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "existing_range_token_min_b",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "new_range_token_max_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "new_range_token_max_b",
+                                "type": "u64"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Tick",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "initialized",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "liquidity_net",
+                        "type": "i128"
+                    },
+                    {
+                        "name": "liquidity_gross",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_growths_outside",
+                        "type": {
+                            "array": [
+                                "u128",
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TickArray",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "start_tick_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "ticks",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "Tick"
+                                    }
+                                },
+                                88
+                            ]
+                        }
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TokenBadge",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "attribute_require_non_transferable_position",
+                        "type": "bool"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TokenBadgeAttribute",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "RequireNonTransferablePosition",
+                        "fields": [
+                            "bool"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Traded",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "a_to_b",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "pre_sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "post_sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "input_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "output_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "input_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "output_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "lp_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Whirlpool",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpool_bump",
+                        "type": {
+                            "array": [
+                                "u8",
+                                1
+                            ]
+                        }
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "fee_tier_index_seed",
+                        "type": {
+                            "array": [
+                                "u8",
+                                2
+                            ]
+                        }
+                    },
+                    {
+                        "name": "fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "protocol_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "tick_current_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "protocol_fee_owed_a",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_fee_owed_b",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_mint_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_vault_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_growth_global_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_mint_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_vault_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_growth_global_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_last_updated_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_infos",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "WhirlpoolRewardInfo"
+                                    }
+                                },
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolRewardInfo",
+            "docs": [
+                "Stores the state relevant for tracking liquidity mining rewards at the `Whirlpool` level.",
+                "These values are used in conjunction with `PositionRewardInfo`, `Tick.reward_growths_outside`,",
+                "and `Whirlpool.reward_last_updated_timestamp` to determine how many rewards are earned by open",
+                "positions."
+            ],
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "mint",
+                        "docs": [
+                            "Reward token mint."
+                        ],
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "vault",
+                        "docs": [
+                            "Reward vault token account."
+                        ],
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "extension",
+                        "docs": [
+                            "reward_infos[0]: Authority account that has permission to initialize the reward and set emissions.",
+                            "reward_infos[1]: used for a struct that contains fields for extending the functionality of Whirlpool.",
+                            "reward_infos[2]: reserved for future use.",
+                            "",
+                            "Historical notes:",
+                            "Originally, this was a field named \"authority\", but it was found that there was no opportunity",
+                            "to set different authorities for the three rewards. Therefore, the use of this field was changed for Whirlpool's future extensibility."
+                        ],
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    },
+                    {
+                        "name": "emissions_per_second_x64",
+                        "docs": [
+                            "Q64.64 number that indicates how many tokens per second are earned per unit of liquidity."
+                        ],
+                        "type": "u128"
+                    },
+                    {
+                        "name": "growth_global_x64",
+                        "docs": [
+                            "Q64.64 number that tracks the total tokens earned per unit of liquidity since the reward",
+                            "emissions were turned on."
+                        ],
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolsConfig",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "fee_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "collect_protocol_fees_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "reward_emissions_super_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "default_protocol_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "feature_flags",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolsConfigExtension",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "config_extension_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_badge_authority",
+                        "type": "pubkey"
+                    }
+                ]
+            }
         }
     ]
 }

--- a/idl/orca_whirlpool_v2.json
+++ b/idl/orca_whirlpool_v2.json
@@ -1,4326 +1,7608 @@
 {
-  "version": "0.3.6",
-  "name": "whirlpool",
-  "instructions": [
-    {
-      "name": "initializeConfig",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "rewardEmissionsSuperAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "defaultProtocolFeeRate",
-          "type": "u16"
-        }
-      ]
+    "address": "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",
+    "metadata": {
+        "name": "whirlpool",
+        "version": "0.9.0",
+        "spec": "0.1.0"
     },
-    {
-      "name": "initializePool",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bumps",
-          "type": {
-            "defined": "WhirlpoolBumps"
-          }
-        },
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "initializeTickArray",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tickArray",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "startTickIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "initializeFeeTier",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "feeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "defaultFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "initializeReward",
-      "accounts": [
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardEmissions",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        },
-        {
-          "name": "emissionsPerSecondX64",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "openPosition",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bumps",
-          "type": {
-            "defined": "OpenPositionBumps"
-          }
-        },
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "openPositionWithMetadata",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionMetadataAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataUpdateAuth",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bumps",
-          "type": {
-            "defined": "OpenPositionWithMetadataBumps"
-          }
-        },
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "increaseLiquidity",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMaxA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMaxB",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "decreaseLiquidity",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMinA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMinB",
-          "type": "u64"
-        }
-      ]
-    },
-    {
-      "name": "updateFeesAndRewards",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "collectFees",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "collectReward",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardOwnerAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "collectProtocolFees",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "swap",
-      "accounts": [
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "sqrtPriceLimit",
-          "type": "u128"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToB",
-          "type": "bool"
-        }
-      ]
-    },
-    {
-      "name": "closePosition",
-      "accounts": [
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setDefaultFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "feeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "defaultFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setDefaultProtocolFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "defaultProtocolFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "feeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setProtocolFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "protocolFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setFeeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newFeeAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setCollectProtocolFeesAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newCollectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setRewardAuthority",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newRewardAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardAuthorityBySuperAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardEmissionsSuperAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newRewardAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardEmissionsSuperAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardEmissionsSuperAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newRewardEmissionsSuperAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "twoHopSwap",
-      "accounts": [
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpoolOne",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolTwo",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountOneA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountOneB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountTwoA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountTwoB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracleOne",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "oracleTwo",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToBOne",
-          "type": "bool"
-        },
-        {
-          "name": "aToBTwo",
-          "type": "bool"
-        },
-        {
-          "name": "sqrtPriceLimitOne",
-          "type": "u128"
-        },
-        {
-          "name": "sqrtPriceLimitTwo",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "initializePositionBundle",
-      "accounts": [
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializePositionBundleWithMetadata",
-      "accounts": [
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionBundleMetadata",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleOwner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "metadataUpdateAuth",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "deletePositionBundle",
-      "accounts": [
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleOwner",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "openBundledPosition",
-      "accounts": [
-        {
-          "name": "bundledPosition",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bundleIndex",
-          "type": "u16"
-        },
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "closeBundledPosition",
-      "accounts": [
-        {
-          "name": "bundledPosition",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionBundleAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "bundleIndex",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "openPositionWithTokenExtensions",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "metadataUpdateAuth",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "tickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "tickUpperIndex",
-          "type": "i32"
-        },
-        {
-          "name": "withTokenMetadataExtension",
-          "type": "bool"
-        }
-      ]
-    },
-    {
-      "name": "closePositionWithTokenExtensions",
-      "accounts": [
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "lockPosition",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lockConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "lockType",
-          "type": {
-            "defined": "LockType"
-          }
-        }
-      ]
-    },
-    {
-      "name": "resetPositionRange",
-      "accounts": [
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "newTickLowerIndex",
-          "type": "i32"
-        },
-        {
-          "name": "newTickUpperIndex",
-          "type": "i32"
-        }
-      ]
-    },
-    {
-      "name": "transferLockedPosition",
-      "accounts": [
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "position",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "destinationTokenAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "lockConfig",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "token2022Program",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializeAdaptiveFeeTier",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "feeTierIndex",
-          "type": "u16"
-        },
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "initializePoolAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "delegatedFeeAuthority",
-          "type": "publicKey"
-        },
-        {
-          "name": "defaultBaseFeeRate",
-          "type": "u16"
-        },
-        {
-          "name": "filterPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "decayPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "reductionFactor",
-          "type": "u16"
-        },
-        {
-          "name": "adaptiveFeeControlFactor",
-          "type": "u32"
-        },
-        {
-          "name": "maxVolatilityAccumulator",
-          "type": "u32"
-        },
-        {
-          "name": "tickGroupSize",
-          "type": "u16"
-        },
-        {
-          "name": "majorSwapThresholdTicks",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setDefaultBaseFeeRate",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "defaultBaseFeeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "setDelegatedFeeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newDelegatedFeeAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setInitializePoolAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newInitializePoolAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setPresetAdaptiveFeeConstants",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "filterPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "decayPeriod",
-          "type": "u16"
-        },
-        {
-          "name": "reductionFactor",
-          "type": "u16"
-        },
-        {
-          "name": "adaptiveFeeControlFactor",
-          "type": "u32"
-        },
-        {
-          "name": "maxVolatilityAccumulator",
-          "type": "u32"
-        },
-        {
-          "name": "tickGroupSize",
-          "type": "u16"
-        },
-        {
-          "name": "majorSwapThresholdTicks",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "initializePoolWithAdaptiveFee",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "initializePoolAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128"
-        },
-        {
-          "name": "tradeEnableTimestamp",
-          "type": {
-            "option": "u64"
-          }
-        }
-      ]
-    },
-    {
-      "name": "setFeeRateByDelegatedFeeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "adaptiveFeeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "delegatedFeeAuthority",
-          "isMut": false,
-          "isSigner": true
-        }
-      ],
-      "args": [
-        {
-          "name": "feeRate",
-          "type": "u16"
-        }
-      ]
-    },
-    {
-      "name": "collectFeesV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "collectProtocolFeesV2",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "collectProtocolFeesAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenDestinationB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "collectRewardV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardOwnerAccount",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "decreaseLiquidityV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMinA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMinB",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "increaseLiquidityV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "positionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "position",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "positionTokenAccount",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayLower",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayUpper",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "liquidityAmount",
-          "type": "u128"
-        },
-        {
-          "name": "tokenMaxA",
-          "type": "u64"
-        },
-        {
-          "name": "tokenMaxB",
-          "type": "u64"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializePoolV2",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeTier",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "tickSpacing",
-          "type": "u16"
-        },
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "initializeRewardV2",
-      "accounts": [
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardTokenBadge",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rewardVault",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "rewardTokenProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "rent",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        }
-      ]
-    },
-    {
-      "name": "setRewardEmissionsV2",
-      "accounts": [
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "rewardAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "rewardVault",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "rewardIndex",
-          "type": "u8"
-        },
-        {
-          "name": "emissionsPerSecondX64",
-          "type": "u128"
-        }
-      ]
-    },
-    {
-      "name": "swapV2",
-      "accounts": [
-        {
-          "name": "tokenProgramA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "whirlpool",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintA",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintB",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultA",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultB",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArray2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracle",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "sqrtPriceLimit",
-          "type": "u128"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToB",
-          "type": "bool"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "twoHopSwapV2",
-      "accounts": [
-        {
-          "name": "whirlpoolOne",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolTwo",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintInput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintIntermediate",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenMintOutput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramInput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramIntermediate",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenProgramOutput",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountInput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneInput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultOneIntermediate",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoIntermediate",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenVaultTwoOutput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenOwnerAccountOutput",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tokenAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tickArrayOne0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayOne2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo0",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo1",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "tickArrayTwo2",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracleOne",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "oracleTwo",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": [
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "otherAmountThreshold",
-          "type": "u64"
-        },
-        {
-          "name": "amountSpecifiedIsInput",
-          "type": "bool"
-        },
-        {
-          "name": "aToBOne",
-          "type": "bool"
-        },
-        {
-          "name": "aToBTwo",
-          "type": "bool"
-        },
-        {
-          "name": "sqrtPriceLimitOne",
-          "type": "u128"
-        },
-        {
-          "name": "sqrtPriceLimitTwo",
-          "type": "u128"
-        },
-        {
-          "name": "remainingAccountsInfo",
-          "type": {
-            "option": {
-              "defined": "RemainingAccountsInfo"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "name": "initializeConfigExtension",
-      "accounts": [
-        {
-          "name": "config",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "configExtension",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "feeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setConfigExtensionAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "configExtensionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newConfigExtensionAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "setTokenBadgeAuthority",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "configExtensionAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "newTokenBadgeAuthority",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "initializeTokenBadge",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "funder",
-          "isMut": true,
-          "isSigner": true
-        },
-        {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    },
-    {
-      "name": "deleteTokenBadge",
-      "accounts": [
-        {
-          "name": "whirlpoolsConfig",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "whirlpoolsConfigExtension",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadgeAuthority",
-          "isMut": false,
-          "isSigner": true
-        },
-        {
-          "name": "tokenMint",
-          "isMut": false,
-          "isSigner": false
-        },
-        {
-          "name": "tokenBadge",
-          "isMut": true,
-          "isSigner": false
-        },
-        {
-          "name": "receiver",
-          "isMut": true,
-          "isSigner": false
-        }
-      ],
-      "args": []
-    }
-  ],
-  "accounts": [
-    {
-      "name": "AdaptiveFeeTier",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "feeTierIndex",
-            "type": "u16"
-          },
-          {
-            "name": "tickSpacing",
-            "type": "u16"
-          },
-          {
-            "name": "initializePoolAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "delegatedFeeAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "defaultBaseFeeRate",
-            "type": "u16"
-          },
-          {
-            "name": "filterPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "type": "u16"
-          },
-          {
-            "name": "adaptiveFeeControlFactor",
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "type": "u32"
-          },
-          {
-            "name": "tickGroupSize",
-            "type": "u16"
-          },
-          {
-            "name": "majorSwapThresholdTicks",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolsConfig",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "feeAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "collectProtocolFeesAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "rewardEmissionsSuperAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "defaultProtocolFeeRate",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolsConfigExtension",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "configExtensionAuthority",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenBadgeAuthority",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "FeeTier",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "tickSpacing",
-            "type": "u16"
-          },
-          {
-            "name": "defaultFeeRate",
-            "type": "u16"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LockConfig",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "position",
-            "type": "publicKey"
-          },
-          {
-            "name": "positionOwner",
-            "type": "publicKey"
-          },
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          },
-          {
-            "name": "lockedTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "lockType",
-            "type": {
-              "defined": "LockTypeLabel"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Oracle",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          },
-          {
-            "name": "tradeEnableTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "adaptiveFeeConstants",
-            "type": {
-              "defined": "AdaptiveFeeConstants"
-            }
-          },
-          {
-            "name": "adaptiveFeeVariables",
-            "type": {
-              "defined": "AdaptiveFeeVariables"
-            }
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                128
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "Position",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          },
-          {
-            "name": "positionMint",
-            "type": "publicKey"
-          },
-          {
-            "name": "liquidity",
-            "type": "u128"
-          },
-          {
-            "name": "tickLowerIndex",
-            "type": "i32"
-          },
-          {
-            "name": "tickUpperIndex",
-            "type": "i32"
-          },
-          {
-            "name": "feeGrowthCheckpointA",
-            "type": "u128"
-          },
-          {
-            "name": "feeOwedA",
-            "type": "u64"
-          },
-          {
-            "name": "feeGrowthCheckpointB",
-            "type": "u128"
-          },
-          {
-            "name": "feeOwedB",
-            "type": "u64"
-          },
-          {
-            "name": "rewardInfos",
-            "type": {
-              "array": [
+    "instructions": [
+        {
+            "name": "close_bundled_position",
+            "docs": [
+                "Close a bundled position in a Whirlpool.",
+                "",
+                "### Authority",
+                "- `position_bundle_authority` - authority that owns the token corresponding to this desired position bundle.",
+                "",
+                "### Parameters",
+                "- `bundle_index` - The bundle index that we'd like to close.",
+                "",
+                "#### Special Errors",
+                "- `InvalidBundleIndex` - If the provided bundle index is out of bounds.",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                41,
+                36,
+                216,
+                245,
+                27,
+                85,
+                103,
+                67
+            ],
+            "accounts": [
                 {
-                  "defined": "PositionRewardInfo"
+                    "name": "bundled_position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101,
+                                    100,
+                                    95,
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle.position_bundle_mint",
+                                "account": "PositionBundle"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "bundle_index"
+                            }
+                        ]
+                    }
                 },
-                3
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "PositionBundle",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "positionBundleMint",
-            "type": "publicKey"
-          },
-          {
-            "name": "positionBitmap",
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "TickArray",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "startTickIndex",
-            "type": "i32"
-          },
-          {
-            "name": "ticks",
-            "type": {
-              "array": [
                 {
-                  "defined": "Tick"
+                    "name": "position_bundle",
+                    "writable": true
                 },
-                88
-              ]
-            }
-          },
-          {
-            "name": "whirlpool",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TokenBadge",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenMint",
-            "type": "publicKey"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Whirlpool",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolsConfig",
-            "type": "publicKey"
-          },
-          {
-            "name": "whirlpoolBump",
-            "type": {
-              "array": [
-                "u8",
+                {
+                    "name": "position_bundle_token_account"
+                },
+                {
+                    "name": "position_bundle_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "bundle_index",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "close_position",
+            "docs": [
+                "Close a position in a Whirlpool. Burns the position token in the owner's wallet.",
+                "",
+                "### Authority",
+                "- \"position_authority\" - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                123,
+                134,
+                81,
+                0,
+                49,
+                68,
+                98,
+                98
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "close_position_with_token_extensions",
+            "docs": [
+                "Close a position in a Whirlpool. Burns the position token in the owner's wallet.",
+                "Mint and TokenAccount are based on Token-2022. And Mint accout will be also closed.",
+                "",
+                "### Authority",
+                "- \"position_authority\" - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty."
+            ],
+            "discriminator": [
+                1,
+                182,
+                135,
+                59,
+                155,
+                25,
+                99,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_fees",
+            "docs": [
+                "Collect fees accrued for this position.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                164,
+                152,
+                207,
+                99,
+                30,
+                186,
+                19,
+                182
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_fees_v2",
+            "docs": [
+                "Collect fees accrued for this position.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                207,
+                117,
+                95,
+                191,
+                229,
+                180,
+                226,
+                15
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "collect_protocol_fees",
+            "docs": [
+                "Collect the protocol fees accrued in this Whirlpool",
+                "",
+                "### Authority",
+                "- `collect_protocol_fees_authority` - assigned authority in the WhirlpoolConfig that can collect protocol fees"
+            ],
+            "discriminator": [
+                22,
+                67,
+                23,
+                98,
+                150,
+                178,
+                70,
+                220
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "collect_protocol_fees_v2",
+            "docs": [
+                "Collect the protocol fees accrued in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `collect_protocol_fees_authority` - assigned authority in the WhirlpoolConfig that can collect protocol fees"
+            ],
+            "discriminator": [
+                103,
+                128,
+                222,
+                134,
+                114,
+                200,
+                22,
+                200
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_destination_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "collect_reward",
+            "docs": [
+                "Collect rewards accrued for this position.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                70,
+                5,
+                132,
+                87,
+                86,
+                235,
+                177,
+                34
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "reward_owner_account",
+                    "writable": true
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "collect_reward_v2",
+            "docs": [
+                "Collect rewards accrued for this position.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position."
+            ],
+            "discriminator": [
+                177,
+                107,
+                37,
+                180,
+                160,
+                19,
+                49,
+                209
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "reward_owner_account",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true
+                },
+                {
+                    "name": "reward_token_program"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "decrease_liquidity",
+            "docs": [
+                "Withdraw liquidity from a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user desires to withdraw.",
+                "- `token_min_a` - The minimum amount of tokenA the user is willing to withdraw.",
+                "- `token_min_b` - The minimum amount of tokenB the user is willing to withdraw.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount."
+            ],
+            "discriminator": [
+                160,
+                38,
+                208,
+                111,
+                104,
+                91,
+                44,
                 1
-              ]
-            }
-          },
-          {
-            "name": "tickSpacing",
-            "type": "u16"
-          },
-          {
-            "name": "feeTierIndexSeed",
-            "type": {
-              "array": [
-                "u8",
-                2
-              ]
-            }
-          },
-          {
-            "name": "feeRate",
-            "type": "u16"
-          },
-          {
-            "name": "protocolFeeRate",
-            "type": "u16"
-          },
-          {
-            "name": "liquidity",
-            "type": "u128"
-          },
-          {
-            "name": "sqrtPrice",
-            "type": "u128"
-          },
-          {
-            "name": "tickCurrentIndex",
-            "type": "i32"
-          },
-          {
-            "name": "protocolFeeOwedA",
-            "type": "u64"
-          },
-          {
-            "name": "protocolFeeOwedB",
-            "type": "u64"
-          },
-          {
-            "name": "tokenMintA",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenVaultA",
-            "type": "publicKey"
-          },
-          {
-            "name": "feeGrowthGlobalA",
-            "type": "u128"
-          },
-          {
-            "name": "tokenMintB",
-            "type": "publicKey"
-          },
-          {
-            "name": "tokenVaultB",
-            "type": "publicKey"
-          },
-          {
-            "name": "feeGrowthGlobalB",
-            "type": "u128"
-          },
-          {
-            "name": "rewardLastUpdatedTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "rewardInfos",
-            "type": {
-              "array": [
+            ],
+            "accounts": [
                 {
-                  "defined": "WhirlpoolRewardInfo"
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
                 },
-                3
-              ]
-            }
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "LockType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Permanent"
-          }
-        ]
-      }
-    },
-    {
-      "name": "LockTypeLabel",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "Permanent"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AdaptiveFeeConstants",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "filterPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "decayPeriod",
-            "type": "u16"
-          },
-          {
-            "name": "reductionFactor",
-            "type": "u16"
-          },
-          {
-            "name": "adaptiveFeeControlFactor",
-            "type": "u32"
-          },
-          {
-            "name": "maxVolatilityAccumulator",
-            "type": "u32"
-          },
-          {
-            "name": "tickGroupSize",
-            "type": "u16"
-          },
-          {
-            "name": "majorSwapThresholdTicks",
-            "type": "u16"
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                16
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "AdaptiveFeeVariables",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "lastReferenceUpdateTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "lastMajorSwapTimestamp",
-            "type": "u64"
-          },
-          {
-            "name": "volatilityReference",
-            "type": "u32"
-          },
-          {
-            "name": "tickGroupIndexReference",
-            "type": "i32"
-          },
-          {
-            "name": "volatilityAccumulator",
-            "type": "u32"
-          },
-          {
-            "name": "reserved",
-            "type": {
-              "array": [
-                "u8",
-                16
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "OpenPositionBumps",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "positionBump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "OpenPositionWithMetadataBumps",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "positionBump",
-            "type": "u8"
-          },
-          {
-            "name": "metadataBump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "PositionRewardInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "growthInsideCheckpoint",
-            "type": "u128"
-          },
-          {
-            "name": "amountOwed",
-            "type": "u64"
-          }
-        ]
-      }
-    },
-    {
-      "name": "Tick",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "initialized",
-            "type": "bool"
-          },
-          {
-            "name": "liquidityNet",
-            "type": "i128"
-          },
-          {
-            "name": "liquidityGross",
-            "type": "u128"
-          },
-          {
-            "name": "feeGrowthOutsideA",
-            "type": "u128"
-          },
-          {
-            "name": "feeGrowthOutsideB",
-            "type": "u128"
-          },
-          {
-            "name": "rewardGrowthsOutside",
-            "type": {
-              "array": [
-                "u128",
-                3
-              ]
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolBumps",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "whirlpoolBump",
-            "type": "u8"
-          }
-        ]
-      }
-    },
-    {
-      "name": "WhirlpoolRewardInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "mint",
-            "type": "publicKey"
-          },
-          {
-            "name": "vault",
-            "type": "publicKey"
-          },
-          {
-            "name": "authority",
-            "type": "publicKey"
-          },
-          {
-            "name": "emissionsPerSecondX64",
-            "type": "u128"
-          },
-          {
-            "name": "growthGlobalX64",
-            "type": "u128"
-          }
-        ]
-      }
-    },
-    {
-      "name": "AccountsType",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "TransferHookA"
-          },
-          {
-            "name": "TransferHookB"
-          },
-          {
-            "name": "TransferHookReward"
-          },
-          {
-            "name": "TransferHookInput"
-          },
-          {
-            "name": "TransferHookIntermediate"
-          },
-          {
-            "name": "TransferHookOutput"
-          },
-          {
-            "name": "SupplementalTickArrays"
-          },
-          {
-            "name": "SupplementalTickArraysOne"
-          },
-          {
-            "name": "SupplementalTickArraysTwo"
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsInfo",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "slices",
-            "type": {
-              "vec": {
-                "defined": "RemainingAccountsSlice"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "RemainingAccountsSlice",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "accountsType",
-            "type": {
-              "defined": "AccountsType"
-            }
-          },
-          {
-            "name": "length",
-            "type": "u8"
-          }
-        ]
-      }
-    }
-  ],
-  "events": [
-    {
-      "name": "LiquidityDecreased",
-      "fields": [
-        {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_min_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_min_b",
+                    "type": "u64"
+                }
+            ]
         },
         {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
+            "name": "decrease_liquidity_v2",
+            "docs": [
+                "Withdraw liquidity from a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user desires to withdraw.",
+                "- `token_min_a` - The minimum amount of tokenA the user is willing to withdraw.",
+                "- `token_min_b` - The minimum amount of tokenB the user is willing to withdraw.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount."
+            ],
+            "discriminator": [
+                58,
+                127,
+                188,
+                62,
+                79,
+                82,
+                196,
+                96
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_min_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_min_b",
+                    "type": "u64"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         {
-          "name": "tickLowerIndex",
-          "type": "i32",
-          "index": false
+            "name": "delete_position_bundle",
+            "docs": [
+                "Delete a PositionBundle account. Burns the position bundle token in the owner's wallet.",
+                "",
+                "### Authority",
+                "- `position_bundle_owner` - The owner that owns the position bundle token.",
+                "",
+                "### Special Errors",
+                "- `PositionBundleNotDeletable` - The provided position bundle has open positions."
+            ],
+            "discriminator": [
+                100,
+                25,
+                99,
+                2,
+                217,
+                239,
+                124,
+                173
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_owner",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                }
+            ],
+            "args": []
         },
         {
-          "name": "tickUpperIndex",
-          "type": "i32",
-          "index": false
+            "name": "delete_token_badge",
+            "docs": [
+                "Delete a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                53,
+                146,
+                68,
+                8,
+                18,
+                117,
+                17,
+                185
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension",
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint"
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                }
+            ],
+            "args": []
         },
         {
-          "name": "liquidity",
-          "type": "u128",
-          "index": false
+            "name": "idl_include",
+            "discriminator": [
+                223,
+                253,
+                121,
+                121,
+                60,
+                193,
+                129,
+                31
+            ],
+            "accounts": [
+                {
+                    "name": "tick_array"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
         },
         {
-          "name": "tokenAAmount",
-          "type": "u64",
-          "index": false
+            "name": "increase_liquidity",
+            "docs": [
+                "Add liquidity to a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                46,
+                156,
+                243,
+                118,
+                13,
+                205,
+                251,
+                178
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_max_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_max_b",
+                    "type": "u64"
+                }
+            ]
         },
         {
-          "name": "tokenBAmount",
-          "type": "u64",
-          "index": false
+            "name": "increase_liquidity_by_token_amounts_v2",
+            "docs": [
+                "Add liquidity to a position by specifying token maxima, not liquidity.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "NOTE: This instruction is only implemented in Pinocchio, not Anchor.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "- `min_sqrt_price` - The minimum sqrt price allowed.",
+                "- `max_sqrt_price` - The maximum sqrt price allowed.",
+                "",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Computed liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Computed liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                239,
+                251,
+                9,
+                124,
+                210,
+                198,
+                53,
+                43
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "method",
+                    "type": {
+                        "defined": {
+                            "name": "IncreaseLiquidityMethod"
+                        }
+                    }
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         {
-          "name": "tokenATransferFee",
-          "type": "u64",
-          "index": false
+            "name": "increase_liquidity_v2",
+            "docs": [
+                "Add liquidity to a position in the Whirlpool. This call also updates the position's accrued fees and rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `token_max_a` - The maximum amount of tokenA the user is willing to deposit.",
+                "- `token_max_b` - The maximum amount of tokenB the user is willing to deposit.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount."
+            ],
+            "discriminator": [
+                133,
+                29,
+                89,
+                223,
+                69,
+                238,
+                176,
+                10
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_upper",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "liquidity_amount",
+                    "type": "u128"
+                },
+                {
+                    "name": "token_max_a",
+                    "type": "u64"
+                },
+                {
+                    "name": "token_max_b",
+                    "type": "u64"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         {
-          "name": "tokenBTransferFee",
-          "type": "u64",
-          "index": false
+            "name": "initialize_adaptive_fee_tier",
+            "docs": [
+                "Initializes an adaptive_fee_tier account usable by Whirlpools in a WhirlpoolConfig space.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `fee_tier_index` - The index of the fee-tier that this adaptive fee tier will be initialized.",
+                "- `tick_spacing` - The tick-spacing that this fee-tier suggests the default_fee_rate for.",
+                "- `initialize_pool_authority` - The authority that can initialize pools with this adaptive fee-tier.",
+                "- `delegated_fee_authority` - The authority that can set the base fee rate for pools using this adaptive fee-tier.",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickSpacing` - If the provided tick_spacing is 0.",
+                "- `InvalidFeeTierIndex` - If the provided fee_tier_index is same to tick_spacing.",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE.",
+                "- `InvalidAdaptiveFeeConstants` - If the provided adaptive fee constants are invalid."
+            ],
+            "discriminator": [
+                77,
+                99,
+                208,
+                200,
+                141,
+                123,
+                117,
+                48
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config"
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    102,
+                                    101,
+                                    101,
+                                    95,
+                                    116,
+                                    105,
+                                    101,
+                                    114
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "fee_tier_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_tier_index",
+                    "type": "u16"
+                },
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initialize_pool_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "delegated_fee_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "default_base_fee_rate",
+                    "type": "u16"
+                },
+                {
+                    "name": "filter_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "decay_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": "u16"
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": "u32"
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": "u32"
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": "u16"
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_config",
+            "docs": [
+                "Initializes a WhirlpoolsConfig account that hosts info & authorities",
+                "required to govern a set of Whirlpools.",
+                "",
+                "### Authority",
+                "- \"authority\" - Set authority that is one of ADMINS.",
+                "",
+                "### Parameters",
+                "- `fee_authority` - Authority authorized to initialize fee-tiers and set customs fees.",
+                "- `collect_protocol_fees_authority` - Authority authorized to collect protocol fees.",
+                "- `reward_emissions_super_authority` - Authority authorized to set reward authorities in pools."
+            ],
+            "discriminator": [
+                208,
+                127,
+                21,
+                1,
+                194,
+                190,
+                196,
+                70
+            ],
+            "accounts": [
+                {
+                    "name": "config",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "type": "pubkey"
+                },
+                {
+                    "name": "default_protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_config_extension",
+            "docs": [
+                "Initializes a WhirlpoolConfigExtension account that hosts info & authorities.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                55,
+                9,
+                53,
+                9,
+                114,
+                57,
+                209,
+                52
+            ],
+            "accounts": [
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "config_extension",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    99,
+                                    111,
+                                    110,
+                                    102,
+                                    105,
+                                    103,
+                                    95,
+                                    101,
+                                    120,
+                                    116,
+                                    101,
+                                    110,
+                                    115,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "config"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_dynamic_tick_array",
+            "docs": [
+                "Initialize a variable-length tick array for a Whirlpool.",
+                "",
+                "### Parameters",
+                "- `start_tick_index` - The starting tick index for this tick-array.",
+                "Has to be a multiple of TickArray size & the tick spacing of this pool.",
+                "- `idempotent` - If true, the instruction will not fail if the tick array already exists.",
+                "Note: The idempotent option exits successfully if a FixedTickArray is present as well as a DynamicTickArray.",
+                "",
+                "#### Special Errors",
+                "- `InvalidStartTick` - if the provided start tick is out of bounds or is not a multiple of",
+                "TICK_ARRAY_SIZE * tick spacing."
+            ],
+            "discriminator": [
+                41,
+                33,
+                165,
+                200,
+                120,
+                231,
+                142,
+                50
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "tick_array",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    105,
+                                    99,
+                                    107,
+                                    95,
+                                    97,
+                                    114,
+                                    114,
+                                    97,
+                                    121
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "start_tick_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "start_tick_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "idempotent",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "initialize_fee_tier",
+            "docs": [
+                "Initializes a fee_tier account usable by Whirlpools in a WhirlpoolConfig space.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `tick_spacing` - The tick-spacing that this fee-tier suggests the default_fee_rate for.",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickSpacing` - If the provided tick_spacing is 0.",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                183,
+                74,
+                156,
+                160,
+                112,
+                2,
+                42,
+                30
+            ],
+            "accounts": [
+                {
+                    "name": "config"
+                },
+                {
+                    "name": "fee_tier",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    102,
+                                    101,
+                                    101,
+                                    95,
+                                    116,
+                                    105,
+                                    101,
+                                    114
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "config"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "default_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool",
+            "docs": [
+                "Initializes a Whirlpool account.",
+                "Fee rate is set to the default values on the config and supplied fee_tier.",
+                "",
+                "### Parameters",
+                "- `bumps` - The bump value when deriving the PDA of the Whirlpool address.",
+                "- `tick_spacing` - The desired tick spacing for this pool.",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                ""
+            ],
+            "discriminator": [
+                95,
+                180,
+                10,
+                172,
+                84,
+                174,
+                232,
+                40
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_tier"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "WhirlpoolBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool_v2",
+            "docs": [
+                "Initializes a Whirlpool account.",
+                "This instruction works with both Token and Token-2022.",
+                "Fee rate is set to the default values on the config and supplied fee_tier.",
+                "",
+                "### Parameters",
+                "- `bumps` - The bump value when deriving the PDA of the Whirlpool address.",
+                "- `tick_spacing` - The desired tick spacing for this pool.",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                ""
+            ],
+            "discriminator": [
+                207,
+                45,
+                87,
+                242,
+                27,
+                63,
+                204,
+                67
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_badge_a",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_badge_b",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "tick_spacing"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "fee_tier"
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_spacing",
+                    "type": "u16"
+                },
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "initialize_pool_with_adaptive_fee",
+            "docs": [
+                "Initializes a Whirlpool account and Oracle account with adaptive fee.",
+                "",
+                "### Parameters",
+                "- `initial_sqrt_price` - The desired initial sqrt-price for this pool",
+                "- `trade_enable_timestamp` - The timestamp when trading is enabled for this pool (within 72 hours)",
+                "",
+                "#### Special Errors",
+                "`InvalidTokenMintOrder` - The order of mints have to be ordered by",
+                "`SqrtPriceOutOfBounds` - provided initial_sqrt_price is not between 2^-64 to 2^64",
+                "`InvalidTradeEnableTimestamp` - provided trade_enable_timestamp is not within 72 hours or the adaptive fee-tier is permission-less",
+                "`UnsupportedTokenMint` - The provided token mint is not supported by the program (e.g. it has risky token extensions)",
+                ""
+            ],
+            "discriminator": [
+                143,
+                94,
+                96,
+                76,
+                172,
+                124,
+                119,
+                199
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_badge_a",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_badge_b",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "initialize_pool_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    119,
+                                    104,
+                                    105,
+                                    114,
+                                    108,
+                                    112,
+                                    111,
+                                    111,
+                                    108
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_a"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint_b"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "adaptive_fee_tier.fee_tier_index",
+                                "account": "AdaptiveFeeTier"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "adaptive_fee_tier"
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "initial_sqrt_price",
+                    "type": "u128"
+                },
+                {
+                    "name": "trade_enable_timestamp",
+                    "type": {
+                        "option": "u64"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "initialize_position_bundle",
+            "docs": [
+                "Initializes a PositionBundle account that bundles several positions.",
+                "A unique token will be minted to represent the position bundle in the users wallet."
+            ],
+            "discriminator": [
+                117,
+                45,
+                241,
+                149,
+                24,
+                18,
+                194,
+                65
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110,
+                                    95,
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "position_bundle_owner"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_position_bundle_with_metadata",
+            "docs": [
+                "Initializes a PositionBundle account that bundles several positions.",
+                "A unique token will be minted to represent the position bundle in the users wallet.",
+                "Additional Metaplex metadata is appended to identify the token."
+            ],
+            "discriminator": [
+                93,
+                124,
+                16,
+                179,
+                249,
+                131,
+                115,
+                245
+            ],
+            "accounts": [
+                {
+                    "name": "position_bundle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110,
+                                    95,
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_bundle_metadata",
+                    "docs": [
+                        "https://github.com/metaplex-foundation/metaplex-program-library/blob/773a574c4b34e5b9f248a81306ec24db064e255f/token-metadata/program/src/utils/metadata.rs#L100"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "position_bundle_owner"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_program",
+                    "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "initialize_reward",
+            "docs": [
+                "Initialize reward for a Whirlpool. A pool can only support up to a set number of rewards.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index that we'd like to initialize. (0 <= index <= NUM_REWARDS)",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                95,
+                135,
+                192,
+                196,
+                242,
+                129,
+                230,
+                68
+            ],
+            "accounts": [
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "initialize_reward_v2",
+            "docs": [
+                "Initialize reward for a Whirlpool. A pool can only support up to a set number of rewards.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index that we'd like to initialize. (0 <= index <= NUM_REWARDS)",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                91,
+                1,
+                77,
+                50,
+                235,
+                229,
+                133,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_mint"
+                },
+                {
+                    "name": "reward_token_badge",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool.whirlpools_config",
+                                "account": "Whirlpool"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "reward_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "reward_vault",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "reward_token_program"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "initialize_tick_array",
+            "docs": [
+                "Initializes a fixed-length tick_array account to represent a tick-range in a Whirlpool.",
+                "",
+                "### Parameters",
+                "- `start_tick_index` - The starting tick index for this tick-array.",
+                "Has to be a multiple of TickArray size & the tick spacing of this pool.",
+                "",
+                "#### Special Errors",
+                "- `InvalidStartTick` - if the provided start tick is out of bounds or is not a multiple of",
+                "TICK_ARRAY_SIZE * tick spacing."
+            ],
+            "discriminator": [
+                11,
+                188,
+                193,
+                214,
+                141,
+                91,
+                149,
+                184
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "tick_array",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    105,
+                                    99,
+                                    107,
+                                    95,
+                                    97,
+                                    114,
+                                    114,
+                                    97,
+                                    121
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "start_tick_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "start_tick_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "initialize_token_badge",
+            "docs": [
+                "Initialize a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                253,
+                77,
+                205,
+                95,
+                27,
+                224,
+                89,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint"
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    116,
+                                    111,
+                                    107,
+                                    101,
+                                    110,
+                                    95,
+                                    98,
+                                    97,
+                                    100,
+                                    103,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpools_config"
+                            },
+                            {
+                                "kind": "account",
+                                "path": "token_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "lock_position",
+            "docs": [
+                "Lock the position to prevent any liquidity changes.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token.",
+                "",
+                "#### Special Errors",
+                "- `PositionAlreadyLocked` - The provided position is already locked.",
+                "- `PositionNotLockable` - The provided position is not lockable (e.g. An empty position)."
+            ],
+            "discriminator": [
+                227,
+                62,
+                2,
+                252,
+                247,
+                10,
+                171,
+                185
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint"
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "lock_config",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    108,
+                                    111,
+                                    99,
+                                    107,
+                                    95,
+                                    99,
+                                    111,
+                                    110,
+                                    102,
+                                    105,
+                                    103
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "lock_type",
+                    "type": {
+                        "defined": {
+                            "name": "LockType"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "migrate_repurpose_reward_authority_space",
+            "docs": [
+                "Migration instruction to repurpose the reward authority space in the Whirlpool.",
+                "TODO: This instruction should be removed once all pools have been migrated."
+            ],
+            "discriminator": [
+                214,
+                161,
+                248,
+                79,
+                152,
+                98,
+                172,
+                231
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "open_bundled_position",
+            "docs": [
+                "Open a bundled position in a Whirlpool. No new tokens are issued",
+                "because the owner of the position bundle becomes the owner of the position.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Authority",
+                "- `position_bundle_authority` - authority that owns the token corresponding to this desired position bundle.",
+                "",
+                "### Parameters",
+                "- `bundle_index` - The bundle index that we'd like to open.",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidBundleIndex` - If the provided bundle index is out of bounds.",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                169,
+                113,
+                126,
+                171,
+                213,
+                172,
+                212,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "bundled_position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    98,
+                                    117,
+                                    110,
+                                    100,
+                                    108,
+                                    101,
+                                    100,
+                                    95,
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_bundle.position_bundle_mint",
+                                "account": "PositionBundle"
+                            },
+                            {
+                                "kind": "arg",
+                                "path": "bundle_index"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_bundle",
+                    "writable": true
+                },
+                {
+                    "name": "position_bundle_token_account"
+                },
+                {
+                    "name": "position_bundle_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bundle_index",
+                    "type": "u16"
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                135,
+                128,
+                47,
+                77,
+                15,
+                152,
+                240,
+                49
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "OpenPositionBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position_with_metadata",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. Additional Metaplex metadata is appended to identify the token.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                242,
+                29,
+                134,
+                48,
+                58,
+                110,
+                14,
+                60
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_metadata_account",
+                    "docs": [
+                        "https://github.com/metaplex-foundation/mpl-token-metadata/blob/master/programs/token-metadata/program/src/utils/metadata.rs#L78"
+                    ],
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "account",
+                                "path": "owner"
+                            },
+                            {
+                                "kind": "const",
+                                "value": [
+                                    6,
+                                    221,
+                                    246,
+                                    225,
+                                    215,
+                                    101,
+                                    161,
+                                    147,
+                                    217,
+                                    203,
+                                    225,
+                                    70,
+                                    206,
+                                    235,
+                                    121,
+                                    172,
+                                    28,
+                                    180,
+                                    133,
+                                    237,
+                                    95,
+                                    91,
+                                    55,
+                                    145,
+                                    58,
+                                    140,
+                                    245,
+                                    133,
+                                    126,
+                                    255,
+                                    0,
+                                    169
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ],
+                        "program": {
+                            "kind": "const",
+                            "value": [
+                                140,
+                                151,
+                                37,
+                                143,
+                                78,
+                                36,
+                                137,
+                                241,
+                                187,
+                                61,
+                                16,
+                                41,
+                                20,
+                                142,
+                                13,
+                                131,
+                                11,
+                                90,
+                                19,
+                                153,
+                                218,
+                                255,
+                                16,
+                                132,
+                                4,
+                                142,
+                                123,
+                                216,
+                                219,
+                                233,
+                                248,
+                                89
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "rent",
+                    "address": "SysvarRent111111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_program",
+                    "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "bumps",
+                    "type": {
+                        "defined": {
+                            "name": "OpenPositionWithMetadataBumps"
+                        }
+                    }
+                },
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "open_position_with_token_extensions",
+            "docs": [
+                "Open a position in a Whirlpool. A unique token will be minted to represent the position",
+                "in the users wallet. Additional TokenMetadata extension is initialized to identify the token.",
+                "Mint and TokenAccount are based on Token-2022.",
+                "The position will start off with 0 liquidity.",
+                "",
+                "### Parameters",
+                "- `tick_lower_index` - The tick specifying the lower end of the position range.",
+                "- `tick_upper_index` - The tick specifying the upper end of the position range.",
+                "- `with_token_metadata_extension` - If true, the token metadata extension will be initialized.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool."
+            ],
+            "discriminator": [
+                212,
+                47,
+                95,
+                92,
+                114,
+                102,
+                131,
+                250
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "owner"
+                },
+                {
+                    "name": "position",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "position_mint",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool"
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                },
+                {
+                    "name": "associated_token_program",
+                    "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                },
+                {
+                    "name": "metadata_update_auth",
+                    "address": "3axbTs2z5GBy6usVbNVoqEgZMng3vZvMnAoX29BFfwhr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "tick_upper_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "with_token_metadata_extension",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "reposition_liquidity_v2",
+            "docs": [
+                "An atomic instruction that repositions liquidity for a position through the following steps:",
+                "- Withdraws liquidity from the current position range",
+                "- Resets the position to a new tick range",
+                "- Adds liquidity to the new position range",
+                "- Restores fees and rewards",
+                "",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- `position_authority` - authority that owns the token corresponding to this desired position.",
+                "",
+                "### Parameters",
+                "- `new_tick_lower_index` - The new tick index for the lower end of the position range.",
+                "- `new_tick_upper_index` - The new tick index for the upper end of the position range.",
+                "- `new_liquidity_amount` - The total amount of Liquidity the user is willing to deposit.",
+                "- `existing_range_token_min_a` - The minimum amount of tokenA the user is willing to withdraw from the existing range.",
+                "- `existing_range_token_min_b` - The minimum amount of tokenB the user is willing to withdraw from the existing range.",
+                "- `new_range_token_max_a` - The maximum amount of tokenA the user is willing to deposit into the new range.",
+                "- `new_range_token_max_b` - The maximum amount of tokenB the user is willing to deposit into the new range.",
+                "",
+                "#### Special Errors",
+                "- `LiquidityZero` - Provided liquidity amount is zero.",
+                "- `LiquidityTooHigh` - Provided liquidity exceeds u128::max.",
+                "- `TokenMaxExceeded` - The required token to perform this operation exceeds the user defined amount.",
+                "- `TokenMinSubceeded` - The required token to perform this operation subceeds the user defined amount.",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool.",
+                "- `SameTickRangeNotAllowed` - The provided tick range is the same as the current tick range."
+            ],
+            "discriminator": [
+                191,
+                169,
+                224,
+                11,
+                131,
+                19,
+                158,
+                253
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "existing_tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "existing_tick_array_upper",
+                    "writable": true
+                },
+                {
+                    "name": "new_tick_array_lower",
+                    "writable": true
+                },
+                {
+                    "name": "new_tick_array_upper",
+                    "writable": true
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "new_tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "new_tick_upper_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "method",
+                    "type": {
+                        "defined": {
+                            "name": "RepositionLiquidityMethod"
+                        }
+                    }
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "reset_position_range",
+            "docs": [
+                "Reset the position range to a new range.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token.",
+                "",
+                "### Parameters",
+                "- `new_tick_lower_index` - The new tick specifying the lower end of the position range.",
+                "- `new_tick_upper_index` - The new tick specifying the upper end of the position range.",
+                "",
+                "#### Special Errors",
+                "- `InvalidTickIndex` - If a provided tick is out of bounds, out of order or not a multiple of",
+                "the tick-spacing in this pool.",
+                "- `ClosePositionNotEmpty` - The provided position account is not empty.",
+                "- `SameTickRangeNotAllowed` - The provided tick range is the same as the current tick range."
+            ],
+            "discriminator": [
+                164,
+                123,
+                180,
+                141,
+                194,
+                100,
+                160,
+                175
+            ],
+            "accounts": [
+                {
+                    "name": "funder",
+                    "writable": true,
+                    "signer": true
+                },
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "position_token_account"
+                },
+                {
+                    "name": "system_program",
+                    "address": "11111111111111111111111111111111"
+                }
+            ],
+            "args": [
+                {
+                    "name": "new_tick_lower_index",
+                    "type": "i32"
+                },
+                {
+                    "name": "new_tick_upper_index",
+                    "type": "i32"
+                }
+            ]
+        },
+        {
+            "name": "set_adaptive_fee_constants",
+            "docs": [
+                "Sets specific adaptive fee constants for a pool. Only the provided constants will be updated,",
+                "others remain unchanged. Caller should avoid invoking this instruction when a pool's adaptive",
+                "fee is high to prevent LP revenue loss",
+                "",
+                "### Authority",
+                "- `fee_authority` - Set authority in the WhirlpoolsConfig",
+                "",
+                "### Parameters",
+                "All parameters are optional. Only provided values will be updated.",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap.",
+                "",
+                "#### Special Errors",
+                "- `InvalidAdaptiveFeeConstants` - If the resulting constants are invalid for the pool's tick_spacing.",
+                "- `AdaptiveFeeConstantsUnchanged` - If the provided adaptive fee constants are unchanged from the existing constants."
+            ],
+            "discriminator": [
+                133,
+                158,
+                212,
+                189,
+                237,
+                12,
+                73,
+                39
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "relations": [
+                        "oracle"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "oracle",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "filter_period",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "decay_period",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": {
+                        "option": "u32"
+                    }
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": {
+                        "option": "u32"
+                    }
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": {
+                        "option": "u16"
+                    }
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": {
+                        "option": "u16"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_collect_protocol_fees_authority",
+            "docs": [
+                "Sets the fee authority to collect protocol fees for a WhirlpoolConfig.",
+                "Only the current collect protocol fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can collect protocol fees in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                34,
+                150,
+                93,
+                244,
+                139,
+                225,
+                233,
+                67
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "collect_protocol_fees_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_collect_protocol_fees_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_config_extension_authority",
+            "docs": [
+                "Sets the config extension authority for a WhirlpoolsConfigExtension.",
+                "Only the current config extension authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"config_extension_authority\" - Set authority in the WhirlpoolConfigExtension"
+            ],
+            "discriminator": [
+                44,
+                94,
+                241,
+                116,
+                24,
+                188,
+                60,
+                143
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension",
+                    "writable": true
+                },
+                {
+                    "name": "config_extension_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_config_extension_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_config_feature_flag",
+            "docs": [
+                "Sets the feature flag for a WhirlpoolConfig.",
+                "",
+                "### Authority",
+                "- \"authority\" - Set authority that is one of ADMINS.",
+                "",
+                "### Parameters",
+                "- `feature_flag` - The feature flag that the WhirlpoolConfig will use."
+            ],
+            "discriminator": [
+                71,
+                173,
+                228,
+                18,
+                67,
+                247,
+                210,
+                57
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "feature_flag",
+                    "type": {
+                        "defined": {
+                            "name": "ConfigFeatureFlag"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_default_base_fee_rate",
+            "docs": [
+                "Set the default_base_fee_rate for an AdaptiveFeeTier",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_base_fee_rate` - The default base fee rate that a pool will use if the pool uses this",
+                "adaptive fee-tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                229,
+                66,
+                84,
+                251,
+                164,
+                134,
+                183,
+                7
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_base_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_default_fee_rate",
+            "docs": [
+                "Set the default_fee_rate for a FeeTier",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_fee_rate` - The default fee rate that a pool will use if the pool uses this",
+                "fee tier during initialization.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided default_fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                118,
+                215,
+                214,
+                157,
+                182,
+                229,
+                208,
+                228
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "fee_tier"
+                    ]
+                },
+                {
+                    "name": "fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_default_protocol_fee_rate",
+            "docs": [
+                "Sets the default protocol fee rate for a WhirlpoolConfig",
+                "Protocol fee rate is represented as a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `default_protocol_fee_rate` - Rate that is referenced during the initialization of a Whirlpool using this config.",
+                "",
+                "#### Special Errors",
+                "- `ProtocolFeeRateMaxExceeded` - If the provided default_protocol_fee_rate exceeds MAX_PROTOCOL_FEE_RATE."
+            ],
+            "discriminator": [
+                107,
+                205,
+                249,
+                226,
+                151,
+                35,
+                86,
+                0
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "default_protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_delegated_fee_authority",
+            "docs": [
+                "Sets the delegated fee authority for an AdaptiveFeeTier.",
+                "The delegated fee authority can set the fee rate for individual pools initialized with the adaptive fee-tier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                193,
+                234,
+                231,
+                147,
+                138,
+                57,
+                3,
+                122
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_delegated_fee_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_fee_authority",
+            "docs": [
+                "Sets the fee authority for a WhirlpoolConfig.",
+                "The fee authority can set the fee & protocol fee rate for individual pools or",
+                "set the default fee rate for newly minted pools.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                31,
+                1,
+                50,
+                87,
+                237,
+                101,
+                97,
+                132
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_fee_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_fee_rate",
+            "docs": [
+                "Sets the fee rate for a Whirlpool.",
+                "Fee rate is represented as hundredths of a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `fee_rate` - The rate that the pool will use to calculate fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                53,
+                243,
+                137,
+                65,
+                8,
+                140,
+                158,
+                6
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_fee_rate_by_delegated_fee_authority",
+            "docs": [
+                "Sets the fee rate for a Whirlpool by the delegated fee authority in AdaptiveFeeTier.",
+                "Fee rate is represented as hundredths of a basis point.",
+                "",
+                "### Authority",
+                "- \"delegated_fee_authority\" - Set authority that can modify pool fees in the AdaptiveFeeTier",
+                "",
+                "### Parameters",
+                "- `fee_rate` - The rate that the pool will use to calculate fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `FeeRateMaxExceeded` - If the provided fee_rate exceeds MAX_FEE_RATE."
+            ],
+            "discriminator": [
+                121,
+                121,
+                54,
+                114,
+                131,
+                230,
+                162,
+                104
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "adaptive_fee_tier"
+                },
+                {
+                    "name": "delegated_fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_initialize_pool_authority",
+            "docs": [
+                "Sets the initialize pool authority for an AdaptiveFeeTier.",
+                "Only the initialize pool authority can initialize pools with the adaptive fee-tier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig"
+            ],
+            "discriminator": [
+                125,
+                43,
+                127,
+                235,
+                149,
+                26,
+                106,
+                236
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_initialize_pool_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_preset_adaptive_fee_constants",
+            "docs": [
+                "Sets the adaptive fee constants for an AdaptiveFeeTier.",
+                "Only the current fee authority in WhirlpoolsConfig has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `filter_period` - Period determine high frequency trading time window. (seconds)",
+                "- `decay_period` - Period determine when the adaptive fee start decrease. (seconds)",
+                "- `reduction_factor` - Adaptive fee rate decrement rate.",
+                "- `adaptive_fee_control_factor` - Adaptive fee control factor.",
+                "- `max_volatility_accumulator` - Max volatility accumulator.",
+                "- `tick_group_size` - Tick group size to define tick group index.",
+                "- `major_swap_threshold_ticks` - Major swap threshold ticks to define major swap."
+            ],
+            "discriminator": [
+                132,
+                185,
+                66,
+                148,
+                83,
+                88,
+                134,
+                198
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "adaptive_fee_tier"
+                    ]
+                },
+                {
+                    "name": "adaptive_fee_tier",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "filter_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "decay_period",
+                    "type": "u16"
+                },
+                {
+                    "name": "reduction_factor",
+                    "type": "u16"
+                },
+                {
+                    "name": "adaptive_fee_control_factor",
+                    "type": "u32"
+                },
+                {
+                    "name": "max_volatility_accumulator",
+                    "type": "u32"
+                },
+                {
+                    "name": "tick_group_size",
+                    "type": "u16"
+                },
+                {
+                    "name": "major_swap_threshold_ticks",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_protocol_fee_rate",
+            "docs": [
+                "Sets the protocol fee rate for a Whirlpool.",
+                "Protocol fee rate is represented as a basis point.",
+                "Only the current fee authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"fee_authority\" - Set authority that can modify pool fees in the WhirlpoolConfig",
+                "",
+                "### Parameters",
+                "- `protocol_fee_rate` - The rate that the pool will use to calculate protocol fees going onwards.",
+                "",
+                "#### Special Errors",
+                "- `ProtocolFeeRateMaxExceeded` - If the provided default_protocol_fee_rate exceeds MAX_PROTOCOL_FEE_RATE."
+            ],
+            "discriminator": [
+                95,
+                7,
+                4,
+                50,
+                154,
+                79,
+                156,
+                131
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "fee_authority",
+                    "signer": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "protocol_fee_rate",
+                    "type": "u16"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_authority",
+            "docs": [
+                "Set the whirlpool reward authority at the provided `reward_index`.",
+                "Only the current reward authority for this reward index has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - Set authority that can control reward emission for this particular reward.",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                34,
+                39,
+                183,
+                252,
+                83,
+                28,
+                85,
+                127
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_authority"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_authority_by_super_authority",
+            "docs": [
+                "Set the whirlpool reward authority at the provided `reward_index`.",
+                "Only the current reward super authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - Set authority that can control reward emission for this particular reward.",
+                "",
+                "#### Special Errors",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                240,
+                154,
+                201,
+                198,
+                148,
+                93,
+                56,
+                25
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpool"
+                    ]
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_authority"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_emissions",
+            "docs": [
+                "Set the reward emissions for a reward in a Whirlpool.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index (0 <= index <= NUM_REWARDS) that we'd like to modify.",
+                "- `emissions_per_second_x64` - The amount of rewards emitted in this pool.",
+                "",
+                "#### Special Errors",
+                "- `RewardVaultAmountInsufficient` - The amount of rewards in the reward vault cannot emit",
+                "more than a day of desired emissions.",
+                "- `InvalidTimestamp` - Provided timestamp is not in order with the previous timestamp.",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                13,
+                197,
+                86,
+                168,
+                109,
+                176,
+                27,
+                244
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "reward_vault"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "emissions_per_second_x64",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "set_reward_emissions_super_authority",
+            "docs": [
+                "Set the whirlpool reward super authority for a WhirlpoolConfig",
+                "Only the current reward super authority has permission to invoke this instruction.",
+                "This instruction will not change the authority on any `WhirlpoolRewardInfo` whirlpool rewards.",
+                "",
+                "### Authority",
+                "- \"reward_emissions_super_authority\" - Set authority that can control reward authorities for all pools in this config space."
+            ],
+            "discriminator": [
+                207,
+                5,
+                200,
+                209,
+                122,
+                56,
+                82,
+                183
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "writable": true
+                },
+                {
+                    "name": "reward_emissions_super_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_reward_emissions_super_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "set_reward_emissions_v2",
+            "docs": [
+                "Set the reward emissions for a reward in a Whirlpool.",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"reward_authority\" - assigned authority by the reward_super_authority for the specified",
+                "reward-index in this Whirlpool",
+                "",
+                "### Parameters",
+                "- `reward_index` - The reward index (0 <= index <= NUM_REWARDS) that we'd like to modify.",
+                "- `emissions_per_second_x64` - The amount of rewards emitted in this pool.",
+                "",
+                "#### Special Errors",
+                "- `RewardVaultAmountInsufficient` - The amount of rewards in the reward vault cannot emit",
+                "more than a day of desired emissions.",
+                "- `InvalidTimestamp` - Provided timestamp is not in order with the previous timestamp.",
+                "- `InvalidRewardIndex` - If the provided reward index doesn't match the lowest uninitialized",
+                "index in this pool, or exceeds NUM_REWARDS, or",
+                "all reward slots for this pool has been initialized."
+            ],
+            "discriminator": [
+                114,
+                228,
+                72,
+                32,
+                193,
+                48,
+                160,
+                102
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "reward_authority",
+                    "signer": true
+                },
+                {
+                    "name": "reward_vault"
+                }
+            ],
+            "args": [
+                {
+                    "name": "reward_index",
+                    "type": "u8"
+                },
+                {
+                    "name": "emissions_per_second_x64",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "set_token_badge_attribute",
+            "docs": [
+                "Set an attribute on a TokenBadge account.",
+                "",
+                "### Authority",
+                "- \"token_badge_authority\" - Set authority in the WhirlpoolConfigExtension",
+                "",
+                "### Parameters",
+                "- `attribute` - The attribute to set on the TokenBadge account.",
+                "",
+                "#### Special Errors",
+                "- `FeatureIsNotEnabled` - If the feature flag for token badges is not enabled."
+            ],
+            "discriminator": [
+                224,
+                88,
+                65,
+                33,
+                138,
+                147,
+                246,
+                137
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension",
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension"
+                },
+                {
+                    "name": "token_badge_authority",
+                    "signer": true
+                },
+                {
+                    "name": "token_mint",
+                    "relations": [
+                        "token_badge"
+                    ]
+                },
+                {
+                    "name": "token_badge",
+                    "writable": true
+                }
+            ],
+            "args": [
+                {
+                    "name": "attribute",
+                    "type": {
+                        "defined": {
+                            "name": "TokenBadgeAttribute"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "set_token_badge_authority",
+            "docs": [
+                "Sets the token badge authority for a WhirlpoolsConfigExtension.",
+                "Only the config extension authority has permission to invoke this instruction.",
+                "",
+                "### Authority",
+                "- \"config_extension_authority\" - Set authority in the WhirlpoolConfigExtension"
+            ],
+            "discriminator": [
+                207,
+                202,
+                4,
+                32,
+                205,
+                79,
+                13,
+                178
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpools_config",
+                    "relations": [
+                        "whirlpools_config_extension"
+                    ]
+                },
+                {
+                    "name": "whirlpools_config_extension",
+                    "writable": true
+                },
+                {
+                    "name": "config_extension_authority",
+                    "signer": true
+                },
+                {
+                    "name": "new_token_badge_authority"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "swap",
+            "docs": [
+                "Perform a swap in this Whirlpool",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `sqrt_price_limit` - The maximum/minimum price the swap will swap to.",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b` - The direction of the swap. True if swapping from A to B. False if swapping from B to A.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0."
+            ],
+            "discriminator": [
+                248,
+                198,
+                158,
+                145,
+                225,
+                117,
+                135,
+                200
+            ],
+            "accounts": [
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "sqrt_price_limit",
+                    "type": "u128"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b",
+                    "type": "bool"
+                }
+            ]
+        },
+        {
+            "name": "swap_v2",
+            "docs": [
+                "Perform a swap in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `sqrt_price_limit` - The maximum/minimum price the swap will swap to.",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b` - The direction of the swap. True if swapping from A to B. False if swapping from B to A.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0."
+            ],
+            "discriminator": [
+                43,
+                4,
+                237,
+                11,
+                26,
+                201,
+                30,
+                98
+            ],
+            "accounts": [
+                {
+                    "name": "token_program_a"
+                },
+                {
+                    "name": "token_program_b"
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool",
+                    "writable": true
+                },
+                {
+                    "name": "token_mint_a"
+                },
+                {
+                    "name": "token_mint_b"
+                },
+                {
+                    "name": "token_owner_account_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "sqrt_price_limit",
+                    "type": "u128"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b",
+                    "type": "bool"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "transfer_locked_position",
+            "docs": [
+                "Transfer a locked position to a different token account.",
+                "",
+                "### Authority",
+                "- `position_authority` - The authority that owns the position token."
+            ],
+            "discriminator": [
+                179,
+                121,
+                229,
+                46,
+                67,
+                138,
+                194,
+                138
+            ],
+            "accounts": [
+                {
+                    "name": "position_authority",
+                    "signer": true
+                },
+                {
+                    "name": "receiver",
+                    "writable": true
+                },
+                {
+                    "name": "position",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    112,
+                                    111,
+                                    115,
+                                    105,
+                                    116,
+                                    105,
+                                    111,
+                                    110
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "position_mint"
+                            }
+                        ]
+                    },
+                    "relations": [
+                        "lock_config"
+                    ]
+                },
+                {
+                    "name": "position_mint"
+                },
+                {
+                    "name": "position_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "destination_token_account",
+                    "writable": true
+                },
+                {
+                    "name": "lock_config",
+                    "writable": true
+                },
+                {
+                    "name": "token_2022_program",
+                    "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+                }
+            ],
+            "args": []
+        },
+        {
+            "name": "two_hop_swap",
+            "docs": [
+                "Perform a two-hop swap in this Whirlpool",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b_one` - The direction of the swap of hop one. True if swapping from A to B. False if swapping from B to A.",
+                "- `a_to_b_two` - The direction of the swap of hop two. True if swapping from A to B. False if swapping from B to A.",
+                "- `sqrt_price_limit_one` - The maximum/minimum price the swap will swap to in the first hop.",
+                "- `sqrt_price_limit_two` - The maximum/minimum price the swap will swap to in the second hop.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0.",
+                "- `InvalidIntermediaryMint` - Error if the intermediary mint between hop one and two do not equal.",
+                "- `DuplicateTwoHopPool` - Error if whirlpool one & two are the same pool."
+            ],
+            "discriminator": [
+                195,
+                96,
+                237,
+                108,
+                68,
+                162,
+                219,
+                230
+            ],
+            "accounts": [
+                {
+                    "name": "token_program",
+                    "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "whirlpool_one",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool_two",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_one_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_one_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_two_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_a",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_two_b",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_b",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_2",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle_one",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_one"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle_two",
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_two"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_one",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_two",
+                    "type": "bool"
+                },
+                {
+                    "name": "sqrt_price_limit_one",
+                    "type": "u128"
+                },
+                {
+                    "name": "sqrt_price_limit_two",
+                    "type": "u128"
+                }
+            ]
+        },
+        {
+            "name": "two_hop_swap_v2",
+            "docs": [
+                "Perform a two-hop swap in this Whirlpool",
+                "This instruction works with both Token and Token-2022.",
+                "",
+                "### Authority",
+                "- \"token_authority\" - The authority to withdraw tokens from the input token account.",
+                "",
+                "### Parameters",
+                "- `amount` - The amount of input or output token to swap from (depending on amount_specified_is_input).",
+                "- `other_amount_threshold` - The maximum/minimum of input/output token to swap into (depending on amount_specified_is_input).",
+                "- `amount_specified_is_input` - Specifies the token the parameter `amount`represents. If true, the amount represents the input token of the swap.",
+                "- `a_to_b_one` - The direction of the swap of hop one. True if swapping from A to B. False if swapping from B to A.",
+                "- `a_to_b_two` - The direction of the swap of hop two. True if swapping from A to B. False if swapping from B to A.",
+                "- `sqrt_price_limit_one` - The maximum/minimum price the swap will swap to in the first hop.",
+                "- `sqrt_price_limit_two` - The maximum/minimum price the swap will swap to in the second hop.",
+                "",
+                "#### Special Errors",
+                "- `ZeroTradableAmount` - User provided parameter `amount` is 0.",
+                "- `InvalidSqrtPriceLimitDirection` - User provided parameter `sqrt_price_limit` does not match the direction of the trade.",
+                "- `SqrtPriceOutOfBounds` - User provided parameter `sqrt_price_limit` is over Whirlppool's max/min bounds for sqrt-price.",
+                "- `InvalidTickArraySequence` - User provided tick-arrays are not in sequential order required to proceed in this trade direction.",
+                "- `TickArraySequenceInvalidIndex` - The swap loop attempted to access an invalid array index during the query of the next initialized tick.",
+                "- `TickArrayIndexOutofBounds` - The swap loop attempted to access an invalid array index during tick crossing.",
+                "- `LiquidityOverflow` - Liquidity value overflowed 128bits during tick crossing.",
+                "- `InvalidTickSpacing` - The swap pool was initialized with tick-spacing of 0.",
+                "- `InvalidIntermediaryMint` - Error if the intermediary mint between hop one and two do not equal.",
+                "- `DuplicateTwoHopPool` - Error if whirlpool one & two are the same pool."
+            ],
+            "discriminator": [
+                186,
+                143,
+                209,
+                29,
+                254,
+                2,
+                194,
+                117
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool_one",
+                    "writable": true
+                },
+                {
+                    "name": "whirlpool_two",
+                    "writable": true
+                },
+                {
+                    "name": "token_mint_input"
+                },
+                {
+                    "name": "token_mint_intermediate"
+                },
+                {
+                    "name": "token_mint_output"
+                },
+                {
+                    "name": "token_program_input"
+                },
+                {
+                    "name": "token_program_intermediate"
+                },
+                {
+                    "name": "token_program_output"
+                },
+                {
+                    "name": "token_owner_account_input",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_input",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_one_intermediate",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_intermediate",
+                    "writable": true
+                },
+                {
+                    "name": "token_vault_two_output",
+                    "writable": true
+                },
+                {
+                    "name": "token_owner_account_output",
+                    "writable": true
+                },
+                {
+                    "name": "token_authority",
+                    "signer": true
+                },
+                {
+                    "name": "tick_array_one_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_one_2",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_0",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_1",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_two_2",
+                    "writable": true
+                },
+                {
+                    "name": "oracle_one",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_one"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "oracle_two",
+                    "writable": true,
+                    "pda": {
+                        "seeds": [
+                            {
+                                "kind": "const",
+                                "value": [
+                                    111,
+                                    114,
+                                    97,
+                                    99,
+                                    108,
+                                    101
+                                ]
+                            },
+                            {
+                                "kind": "account",
+                                "path": "whirlpool_two"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "name": "memo_program",
+                    "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+                }
+            ],
+            "args": [
+                {
+                    "name": "amount",
+                    "type": "u64"
+                },
+                {
+                    "name": "other_amount_threshold",
+                    "type": "u64"
+                },
+                {
+                    "name": "amount_specified_is_input",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_one",
+                    "type": "bool"
+                },
+                {
+                    "name": "a_to_b_two",
+                    "type": "bool"
+                },
+                {
+                    "name": "sqrt_price_limit_one",
+                    "type": "u128"
+                },
+                {
+                    "name": "sqrt_price_limit_two",
+                    "type": "u128"
+                },
+                {
+                    "name": "remaining_accounts_info",
+                    "type": {
+                        "option": {
+                            "defined": {
+                                "name": "RemainingAccountsInfo"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "update_fees_and_rewards",
+            "docs": [
+                "Update the accrued fees and rewards for a position.",
+                "",
+                "#### Special Errors",
+                "- `TickNotFound` - Provided tick array account does not contain the tick for this position.",
+                "- `LiquidityZero` - Position has zero liquidity and therefore already has the most updated fees and reward values."
+            ],
+            "discriminator": [
+                154,
+                230,
+                250,
+                13,
+                236,
+                209,
+                75,
+                223
+            ],
+            "accounts": [
+                {
+                    "name": "whirlpool",
+                    "writable": true,
+                    "relations": [
+                        "position"
+                    ]
+                },
+                {
+                    "name": "position",
+                    "writable": true
+                },
+                {
+                    "name": "tick_array_lower"
+                },
+                {
+                    "name": "tick_array_upper"
+                }
+            ],
+            "args": []
         }
-      ]
-    },
-    {
-      "name": "LiquidityIncreased",
-      "fields": [
+    ],
+    "accounts": [
         {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+            "name": "AdaptiveFeeTier",
+            "discriminator": [
+                147,
+                16,
+                144,
+                116,
+                47,
+                146,
+                149,
+                46
+            ]
         },
         {
-          "name": "position",
-          "type": "publicKey",
-          "index": false
+            "name": "DynamicTickArray",
+            "discriminator": [
+                17,
+                216,
+                246,
+                142,
+                225,
+                199,
+                218,
+                56
+            ]
         },
         {
-          "name": "tickLowerIndex",
-          "type": "i32",
-          "index": false
+            "name": "FeeTier",
+            "discriminator": [
+                56,
+                75,
+                159,
+                76,
+                142,
+                68,
+                190,
+                105
+            ]
         },
         {
-          "name": "tickUpperIndex",
-          "type": "i32",
-          "index": false
+            "name": "LockConfig",
+            "discriminator": [
+                106,
+                47,
+                238,
+                159,
+                124,
+                12,
+                160,
+                192
+            ]
         },
         {
-          "name": "liquidity",
-          "type": "u128",
-          "index": false
+            "name": "Oracle",
+            "discriminator": [
+                139,
+                194,
+                131,
+                179,
+                140,
+                179,
+                229,
+                244
+            ]
         },
         {
-          "name": "tokenAAmount",
-          "type": "u64",
-          "index": false
+            "name": "Position",
+            "discriminator": [
+                170,
+                188,
+                143,
+                228,
+                122,
+                64,
+                247,
+                208
+            ]
         },
         {
-          "name": "tokenBAmount",
-          "type": "u64",
-          "index": false
+            "name": "PositionBundle",
+            "discriminator": [
+                129,
+                169,
+                175,
+                65,
+                185,
+                95,
+                32,
+                100
+            ]
         },
         {
-          "name": "tokenATransferFee",
-          "type": "u64",
-          "index": false
+            "name": "TickArray",
+            "discriminator": [
+                69,
+                97,
+                189,
+                190,
+                110,
+                7,
+                66,
+                187
+            ]
         },
         {
-          "name": "tokenBTransferFee",
-          "type": "u64",
-          "index": false
+            "name": "TokenBadge",
+            "discriminator": [
+                116,
+                219,
+                204,
+                229,
+                249,
+                116,
+                255,
+                150
+            ]
+        },
+        {
+            "name": "Whirlpool",
+            "discriminator": [
+                63,
+                149,
+                209,
+                12,
+                225,
+                128,
+                99,
+                9
+            ]
+        },
+        {
+            "name": "WhirlpoolsConfig",
+            "discriminator": [
+                157,
+                20,
+                49,
+                224,
+                217,
+                87,
+                193,
+                254
+            ]
+        },
+        {
+            "name": "WhirlpoolsConfigExtension",
+            "discriminator": [
+                2,
+                99,
+                215,
+                163,
+                240,
+                26,
+                153,
+                58
+            ]
         }
-      ]
-    },
-    {
-      "name": "PoolInitialized",
-      "fields": [
+    ],
+    "events": [
         {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+            "name": "LiquidityDecreased",
+            "discriminator": [
+                166,
+                1,
+                36,
+                71,
+                112,
+                202,
+                181,
+                171
+            ]
         },
         {
-          "name": "whirlpoolsConfig",
-          "type": "publicKey",
-          "index": false
+            "name": "LiquidityIncreased",
+            "discriminator": [
+                30,
+                7,
+                144,
+                181,
+                102,
+                254,
+                155,
+                161
+            ]
         },
         {
-          "name": "tokenMintA",
-          "type": "publicKey",
-          "index": false
+            "name": "LiquidityRepositioned",
+            "discriminator": [
+                95,
+                130,
+                181,
+                132,
+                251,
+                50,
+                195,
+                38
+            ]
         },
         {
-          "name": "tokenMintB",
-          "type": "publicKey",
-          "index": false
+            "name": "PoolInitialized",
+            "discriminator": [
+                100,
+                118,
+                173,
+                87,
+                12,
+                198,
+                254,
+                229
+            ]
         },
         {
-          "name": "tickSpacing",
-          "type": "u16",
-          "index": false
+            "name": "PositionOpened",
+            "discriminator": [
+                237,
+                175,
+                243,
+                230,
+                147,
+                117,
+                101,
+                121
+            ]
         },
         {
-          "name": "tokenProgramA",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "tokenProgramB",
-          "type": "publicKey",
-          "index": false
-        },
-        {
-          "name": "decimalsA",
-          "type": "u8",
-          "index": false
-        },
-        {
-          "name": "decimalsB",
-          "type": "u8",
-          "index": false
-        },
-        {
-          "name": "initialSqrtPrice",
-          "type": "u128",
-          "index": false
+            "name": "Traded",
+            "discriminator": [
+                225,
+                202,
+                73,
+                175,
+                147,
+                43,
+                160,
+                150
+            ]
         }
-      ]
-    },
-    {
-      "name": "Traded",
-      "fields": [
+    ],
+    "errors": [
         {
-          "name": "whirlpool",
-          "type": "publicKey",
-          "index": false
+            "code": 6000,
+            "name": "InvalidEnum",
+            "msg": "Enum value could not be converted"
         },
         {
-          "name": "aToB",
-          "type": "bool",
-          "index": false
+            "code": 6001,
+            "name": "InvalidStartTick",
+            "msg": "Invalid start tick index provided."
         },
         {
-          "name": "preSqrtPrice",
-          "type": "u128",
-          "index": false
+            "code": 6002,
+            "name": "TickArrayExistInPool",
+            "msg": "Tick-array already exists in this whirlpool"
         },
         {
-          "name": "postSqrtPrice",
-          "type": "u128",
-          "index": false
+            "code": 6003,
+            "name": "TickArrayIndexOutofBounds",
+            "msg": "Attempt to search for a tick-array failed"
         },
         {
-          "name": "inputAmount",
-          "type": "u64",
-          "index": false
+            "code": 6004,
+            "name": "InvalidTickSpacing",
+            "msg": "Tick-spacing is not supported"
         },
         {
-          "name": "outputAmount",
-          "type": "u64",
-          "index": false
+            "code": 6005,
+            "name": "ClosePositionNotEmpty",
+            "msg": "Position is not empty It cannot be closed"
         },
         {
-          "name": "inputTransferFee",
-          "type": "u64",
-          "index": false
+            "code": 6006,
+            "name": "DivideByZero",
+            "msg": "Unable to divide by zero"
         },
         {
-          "name": "outputTransferFee",
-          "type": "u64",
-          "index": false
+            "code": 6007,
+            "name": "NumberCastError",
+            "msg": "Unable to cast number into BigInt"
         },
         {
-          "name": "lpFee",
-          "type": "u64",
-          "index": false
+            "code": 6008,
+            "name": "NumberDownCastError",
+            "msg": "Unable to down cast number"
         },
         {
-          "name": "protocolFee",
-          "type": "u64",
-          "index": false
+            "code": 6009,
+            "name": "TickNotFound",
+            "msg": "Tick not found within tick array"
+        },
+        {
+            "code": 6010,
+            "name": "InvalidTickIndex",
+            "msg": "Provided tick index is either out of bounds or uninitializable"
+        },
+        {
+            "code": 6011,
+            "name": "SqrtPriceOutOfBounds",
+            "msg": "Provided sqrt price out of bounds"
+        },
+        {
+            "code": 6012,
+            "name": "LiquidityZero",
+            "msg": "Liquidity amount must be greater than zero"
+        },
+        {
+            "code": 6013,
+            "name": "LiquidityTooHigh",
+            "msg": "Liquidity amount must be less than i64::MAX"
+        },
+        {
+            "code": 6014,
+            "name": "LiquidityOverflow",
+            "msg": "Liquidity overflow"
+        },
+        {
+            "code": 6015,
+            "name": "LiquidityUnderflow",
+            "msg": "Liquidity underflow"
+        },
+        {
+            "code": 6016,
+            "name": "LiquidityNetError",
+            "msg": "Tick liquidity net underflowed or overflowed"
+        },
+        {
+            "code": 6017,
+            "name": "TokenMaxExceeded",
+            "msg": "Exceeded token max"
+        },
+        {
+            "code": 6018,
+            "name": "TokenMinSubceeded",
+            "msg": "Did not meet token min"
+        },
+        {
+            "code": 6019,
+            "name": "MissingOrInvalidDelegate",
+            "msg": "Position token account has a missing or invalid delegate"
+        },
+        {
+            "code": 6020,
+            "name": "InvalidPositionTokenAmount",
+            "msg": "Position token amount must be 1"
+        },
+        {
+            "code": 6021,
+            "name": "InvalidTimestampConversion",
+            "msg": "Timestamp should be convertible from i64 to u64"
+        },
+        {
+            "code": 6022,
+            "name": "InvalidTimestamp",
+            "msg": "Timestamp should be greater than the last updated timestamp"
+        },
+        {
+            "code": 6023,
+            "name": "InvalidTickArraySequence",
+            "msg": "Invalid tick array sequence provided for instruction."
+        },
+        {
+            "code": 6024,
+            "name": "InvalidTokenMintOrder",
+            "msg": "Token Mint in wrong order"
+        },
+        {
+            "code": 6025,
+            "name": "RewardNotInitialized",
+            "msg": "Reward not initialized"
+        },
+        {
+            "code": 6026,
+            "name": "InvalidRewardIndex",
+            "msg": "Invalid reward index"
+        },
+        {
+            "code": 6027,
+            "name": "RewardVaultAmountInsufficient",
+            "msg": "Reward vault requires amount to support emissions for at least one day"
+        },
+        {
+            "code": 6028,
+            "name": "FeeRateMaxExceeded",
+            "msg": "Exceeded max fee rate"
+        },
+        {
+            "code": 6029,
+            "name": "ProtocolFeeRateMaxExceeded",
+            "msg": "Exceeded max protocol fee rate"
+        },
+        {
+            "code": 6030,
+            "name": "MultiplicationShiftRightOverflow",
+            "msg": "Multiplication with shift right overflow"
+        },
+        {
+            "code": 6031,
+            "name": "MulDivOverflow",
+            "msg": "Muldiv overflow"
+        },
+        {
+            "code": 6032,
+            "name": "MulDivInvalidInput",
+            "msg": "Invalid div_u256 input"
+        },
+        {
+            "code": 6033,
+            "name": "MultiplicationOverflow",
+            "msg": "Multiplication overflow"
+        },
+        {
+            "code": 6034,
+            "name": "InvalidSqrtPriceLimitDirection",
+            "msg": "Provided SqrtPriceLimit not in the same direction as the swap."
+        },
+        {
+            "code": 6035,
+            "name": "ZeroTradableAmount",
+            "msg": "There are no tradable amount to swap."
+        },
+        {
+            "code": 6036,
+            "name": "AmountOutBelowMinimum",
+            "msg": "Amount out below minimum threshold"
+        },
+        {
+            "code": 6037,
+            "name": "AmountInAboveMaximum",
+            "msg": "Amount in above maximum threshold"
+        },
+        {
+            "code": 6038,
+            "name": "TickArraySequenceInvalidIndex",
+            "msg": "Invalid index for tick array sequence"
+        },
+        {
+            "code": 6039,
+            "name": "AmountCalcOverflow",
+            "msg": "Amount calculated overflows"
+        },
+        {
+            "code": 6040,
+            "name": "AmountRemainingOverflow",
+            "msg": "Amount remaining overflows"
+        },
+        {
+            "code": 6041,
+            "name": "InvalidIntermediaryMint",
+            "msg": "Invalid intermediary mint"
+        },
+        {
+            "code": 6042,
+            "name": "DuplicateTwoHopPool",
+            "msg": "Duplicate two hop pool"
+        },
+        {
+            "code": 6043,
+            "name": "InvalidBundleIndex",
+            "msg": "Bundle index is out of bounds"
+        },
+        {
+            "code": 6044,
+            "name": "BundledPositionAlreadyOpened",
+            "msg": "Position has already been opened"
+        },
+        {
+            "code": 6045,
+            "name": "BundledPositionAlreadyClosed",
+            "msg": "Position has already been closed"
+        },
+        {
+            "code": 6046,
+            "name": "PositionBundleNotDeletable",
+            "msg": "Unable to delete PositionBundle with open positions"
+        },
+        {
+            "code": 6047,
+            "name": "UnsupportedTokenMint",
+            "msg": "Token mint has unsupported attributes"
+        },
+        {
+            "code": 6048,
+            "name": "RemainingAccountsInvalidSlice",
+            "msg": "Invalid remaining accounts"
+        },
+        {
+            "code": 6049,
+            "name": "RemainingAccountsInsufficient",
+            "msg": "Insufficient remaining accounts"
+        },
+        {
+            "code": 6050,
+            "name": "NoExtraAccountsForTransferHook",
+            "msg": "Unable to call transfer hook without extra accounts"
+        },
+        {
+            "code": 6051,
+            "name": "IntermediateTokenAmountMismatch",
+            "msg": "Output and input amount mismatch"
+        },
+        {
+            "code": 6052,
+            "name": "TransferFeeCalculationError",
+            "msg": "Transfer fee calculation failed"
+        },
+        {
+            "code": 6053,
+            "name": "RemainingAccountsDuplicatedAccountsType",
+            "msg": "Same accounts type is provided more than once"
+        },
+        {
+            "code": 6054,
+            "name": "FullRangeOnlyPool",
+            "msg": "This whirlpool only supports full-range positions"
+        },
+        {
+            "code": 6055,
+            "name": "TooManySupplementalTickArrays",
+            "msg": "Too many supplemental tick arrays provided"
+        },
+        {
+            "code": 6056,
+            "name": "DifferentWhirlpoolTickArrayAccount",
+            "msg": "TickArray account for different whirlpool provided"
+        },
+        {
+            "code": 6057,
+            "name": "PartialFillError",
+            "msg": "Trade resulted in partial fill"
+        },
+        {
+            "code": 6058,
+            "name": "PositionNotLockable",
+            "msg": "Position is not lockable"
+        },
+        {
+            "code": 6059,
+            "name": "OperationNotAllowedOnLockedPosition",
+            "msg": "Operation not allowed on locked position"
+        },
+        {
+            "code": 6060,
+            "name": "SameTickRangeNotAllowed",
+            "msg": "Cannot reset position range with same tick range"
+        },
+        {
+            "code": 6061,
+            "name": "InvalidAdaptiveFeeConstants",
+            "msg": "Invalid adaptive fee constants"
+        },
+        {
+            "code": 6062,
+            "name": "InvalidFeeTierIndex",
+            "msg": "Invalid fee tier index"
+        },
+        {
+            "code": 6063,
+            "name": "InvalidTradeEnableTimestamp",
+            "msg": "Invalid trade enable timestamp"
+        },
+        {
+            "code": 6064,
+            "name": "TradeIsNotEnabled",
+            "msg": "Trade is not enabled yet"
+        },
+        {
+            "code": 6065,
+            "name": "RentCalculationError",
+            "msg": "Rent calculation error"
+        },
+        {
+            "code": 6066,
+            "name": "FeatureIsNotEnabled",
+            "msg": "Feature is not enabled"
+        },
+        {
+            "code": 6067,
+            "name": "PositionWithTokenExtensionsRequired",
+            "msg": "This whirlpool only supports open_position_with_token_extensions instruction"
+        },
+        {
+            "code": 6068,
+            "name": "AdaptiveFeeConstantsUnchanged",
+            "msg": "Provided adaptive fee constants are unchanged"
+        },
+        {
+            "code": 6069,
+            "name": "PriceSlippageOutOfBounds",
+            "msg": "Price outside slippage bounds"
         }
-      ]
-    }
-  ],
-  "errors": [
-    {
-      "code": 6000,
-      "name": "InvalidEnum",
-      "msg": "Enum value could not be converted"
-    },
-    {
-      "code": 6001,
-      "name": "InvalidStartTick",
-      "msg": "Invalid start tick index provided."
-    },
-    {
-      "code": 6002,
-      "name": "TickArrayExistInPool",
-      "msg": "Tick-array already exists in this whirlpool"
-    },
-    {
-      "code": 6003,
-      "name": "TickArrayIndexOutofBounds",
-      "msg": "Attempt to search for a tick-array failed"
-    },
-    {
-      "code": 6004,
-      "name": "InvalidTickSpacing",
-      "msg": "Tick-spacing is not supported"
-    },
-    {
-      "code": 6005,
-      "name": "ClosePositionNotEmpty",
-      "msg": "Position is not empty It cannot be closed"
-    },
-    {
-      "code": 6006,
-      "name": "DivideByZero",
-      "msg": "Unable to divide by zero"
-    },
-    {
-      "code": 6007,
-      "name": "NumberCastError",
-      "msg": "Unable to cast number into BigInt"
-    },
-    {
-      "code": 6008,
-      "name": "NumberDownCastError",
-      "msg": "Unable to down cast number"
-    },
-    {
-      "code": 6009,
-      "name": "TickNotFound",
-      "msg": "Tick not found within tick array"
-    },
-    {
-      "code": 6010,
-      "name": "InvalidTickIndex",
-      "msg": "Provided tick index is either out of bounds or uninitializable"
-    },
-    {
-      "code": 6011,
-      "name": "SqrtPriceOutOfBounds",
-      "msg": "Provided sqrt price out of bounds"
-    },
-    {
-      "code": 6012,
-      "name": "LiquidityZero",
-      "msg": "Liquidity amount must be greater than zero"
-    },
-    {
-      "code": 6013,
-      "name": "LiquidityTooHigh",
-      "msg": "Liquidity amount must be less than i64::MAX"
-    },
-    {
-      "code": 6014,
-      "name": "LiquidityOverflow",
-      "msg": "Liquidity overflow"
-    },
-    {
-      "code": 6015,
-      "name": "LiquidityUnderflow",
-      "msg": "Liquidity underflow"
-    },
-    {
-      "code": 6016,
-      "name": "LiquidityNetError",
-      "msg": "Tick liquidity net underflowed or overflowed"
-    },
-    {
-      "code": 6017,
-      "name": "TokenMaxExceeded",
-      "msg": "Exceeded token max"
-    },
-    {
-      "code": 6018,
-      "name": "TokenMinSubceeded",
-      "msg": "Did not meet token min"
-    },
-    {
-      "code": 6019,
-      "name": "MissingOrInvalidDelegate",
-      "msg": "Position token account has a missing or invalid delegate"
-    },
-    {
-      "code": 6020,
-      "name": "InvalidPositionTokenAmount",
-      "msg": "Position token amount must be 1"
-    },
-    {
-      "code": 6021,
-      "name": "InvalidTimestampConversion",
-      "msg": "Timestamp should be convertible from i64 to u64"
-    },
-    {
-      "code": 6022,
-      "name": "InvalidTimestamp",
-      "msg": "Timestamp should be greater than the last updated timestamp"
-    },
-    {
-      "code": 6023,
-      "name": "InvalidTickArraySequence",
-      "msg": "Invalid tick array sequence provided for instruction."
-    },
-    {
-      "code": 6024,
-      "name": "InvalidTokenMintOrder",
-      "msg": "Token Mint in wrong order"
-    },
-    {
-      "code": 6025,
-      "name": "RewardNotInitialized",
-      "msg": "Reward not initialized"
-    },
-    {
-      "code": 6026,
-      "name": "InvalidRewardIndex",
-      "msg": "Invalid reward index"
-    },
-    {
-      "code": 6027,
-      "name": "RewardVaultAmountInsufficient",
-      "msg": "Reward vault requires amount to support emissions for at least one day"
-    },
-    {
-      "code": 6028,
-      "name": "FeeRateMaxExceeded",
-      "msg": "Exceeded max fee rate"
-    },
-    {
-      "code": 6029,
-      "name": "ProtocolFeeRateMaxExceeded",
-      "msg": "Exceeded max protocol fee rate"
-    },
-    {
-      "code": 6030,
-      "name": "MultiplicationShiftRightOverflow",
-      "msg": "Multiplication with shift right overflow"
-    },
-    {
-      "code": 6031,
-      "name": "MulDivOverflow",
-      "msg": "Muldiv overflow"
-    },
-    {
-      "code": 6032,
-      "name": "MulDivInvalidInput",
-      "msg": "Invalid div_u256 input"
-    },
-    {
-      "code": 6033,
-      "name": "MultiplicationOverflow",
-      "msg": "Multiplication overflow"
-    },
-    {
-      "code": 6034,
-      "name": "InvalidSqrtPriceLimitDirection",
-      "msg": "Provided SqrtPriceLimit not in the same direction as the swap."
-    },
-    {
-      "code": 6035,
-      "name": "ZeroTradableAmount",
-      "msg": "There are no tradable amount to swap."
-    },
-    {
-      "code": 6036,
-      "name": "AmountOutBelowMinimum",
-      "msg": "Amount out below minimum threshold"
-    },
-    {
-      "code": 6037,
-      "name": "AmountInAboveMaximum",
-      "msg": "Amount in above maximum threshold"
-    },
-    {
-      "code": 6038,
-      "name": "TickArraySequenceInvalidIndex",
-      "msg": "Invalid index for tick array sequence"
-    },
-    {
-      "code": 6039,
-      "name": "AmountCalcOverflow",
-      "msg": "Amount calculated overflows"
-    },
-    {
-      "code": 6040,
-      "name": "AmountRemainingOverflow",
-      "msg": "Amount remaining overflows"
-    },
-    {
-      "code": 6041,
-      "name": "InvalidIntermediaryMint",
-      "msg": "Invalid intermediary mint"
-    },
-    {
-      "code": 6042,
-      "name": "DuplicateTwoHopPool",
-      "msg": "Duplicate two hop pool"
-    },
-    {
-      "code": 6043,
-      "name": "InvalidBundleIndex",
-      "msg": "Bundle index is out of bounds"
-    },
-    {
-      "code": 6044,
-      "name": "BundledPositionAlreadyOpened",
-      "msg": "Position has already been opened"
-    },
-    {
-      "code": 6045,
-      "name": "BundledPositionAlreadyClosed",
-      "msg": "Position has already been closed"
-    },
-    {
-      "code": 6046,
-      "name": "PositionBundleNotDeletable",
-      "msg": "Unable to delete PositionBundle with open positions"
-    },
-    {
-      "code": 6047,
-      "name": "UnsupportedTokenMint",
-      "msg": "Token mint has unsupported attributes"
-    },
-    {
-      "code": 6048,
-      "name": "RemainingAccountsInvalidSlice",
-      "msg": "Invalid remaining accounts"
-    },
-    {
-      "code": 6049,
-      "name": "RemainingAccountsInsufficient",
-      "msg": "Insufficient remaining accounts"
-    },
-    {
-      "code": 6050,
-      "name": "NoExtraAccountsForTransferHook",
-      "msg": "Unable to call transfer hook without extra accounts"
-    },
-    {
-      "code": 6051,
-      "name": "IntermediateTokenAmountMismatch",
-      "msg": "Output and input amount mismatch"
-    },
-    {
-      "code": 6052,
-      "name": "TransferFeeCalculationError",
-      "msg": "Transfer fee calculation failed"
-    },
-    {
-      "code": 6053,
-      "name": "RemainingAccountsDuplicatedAccountsType",
-      "msg": "Same accounts type is provided more than once"
-    },
-    {
-      "code": 6054,
-      "name": "FullRangeOnlyPool",
-      "msg": "This whirlpool only supports full-range positions"
-    },
-    {
-      "code": 6055,
-      "name": "TooManySupplementalTickArrays",
-      "msg": "Too many supplemental tick arrays provided"
-    },
-    {
-      "code": 6056,
-      "name": "DifferentWhirlpoolTickArrayAccount",
-      "msg": "TickArray account for different whirlpool provided"
-    },
-    {
-      "code": 6057,
-      "name": "PartialFillError",
-      "msg": "Trade resulted in partial fill"
-    },
-    {
-      "code": 6058,
-      "name": "PositionNotLockable",
-      "msg": "Position is not lockable"
-    },
-    {
-      "code": 6059,
-      "name": "OperationNotAllowedOnLockedPosition",
-      "msg": "Operation not allowed on locked position"
-    },
-    {
-      "code": 6060,
-      "name": "SameTickRangeNotAllowed",
-      "msg": "Cannot reset position range with same tick range"
-    },
-    {
-      "code": 6061,
-      "name": "InvalidAdaptiveFeeConstants",
-      "msg": "Invalid adaptive fee constants"
-    },
-    {
-      "code": 6062,
-      "name": "InvalidFeeTierIndex",
-      "msg": "Invalid fee tier index"
-    },
-    {
-      "code": 6063,
-      "name": "InvalidTradeEnableTimestamp",
-      "msg": "Invalid trade enable timestamp"
-    },
-    {
-      "code": 6064,
-      "name": "TradeIsNotEnabled",
-      "msg": "Trade is not enabled yet"
-    }
-  ]
+    ],
+    "types": [
+        {
+            "name": "AccountsType",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "TransferHookA"
+                    },
+                    {
+                        "name": "TransferHookB"
+                    },
+                    {
+                        "name": "TransferHookReward"
+                    },
+                    {
+                        "name": "TransferHookInput"
+                    },
+                    {
+                        "name": "TransferHookIntermediate"
+                    },
+                    {
+                        "name": "TransferHookOutput"
+                    },
+                    {
+                        "name": "SupplementalTickArrays"
+                    },
+                    {
+                        "name": "SupplementalTickArraysOne"
+                    },
+                    {
+                        "name": "SupplementalTickArraysTwo"
+                    },
+                    {
+                        "name": "TransferHookDepositA"
+                    },
+                    {
+                        "name": "TransferHookDepositB"
+                    },
+                    {
+                        "name": "TransferHookWithdrawalA"
+                    },
+                    {
+                        "name": "TransferHookWithdrawalB"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeConstants",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "adaptive_fee_control_factor",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_size",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "major_swap_threshold_ticks",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                16
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeTier",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_tier_index",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "initialize_pool_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "delegated_fee_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "default_base_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "filter_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "decay_period",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "reduction_factor",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "adaptive_fee_control_factor",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "max_volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_size",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "major_swap_threshold_ticks",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "AdaptiveFeeVariables",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "last_reference_update_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "last_major_swap_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "volatility_reference",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "tick_group_index_reference",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "volatility_accumulator",
+                        "type": "u32"
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                16
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "ConfigFeatureFlag",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "TokenBadge",
+                        "fields": [
+                            "bool"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTick",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Uninitialized"
+                    },
+                    {
+                        "name": "Initialized",
+                        "fields": [
+                            {
+                                "defined": {
+                                    "name": "DynamicTickData"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTickArray",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "start_tick_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_bitmap",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "ticks",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "DynamicTick"
+                                    }
+                                },
+                                88
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "DynamicTickData",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "liquidity_net",
+                        "type": "i128"
+                    },
+                    {
+                        "name": "liquidity_gross",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_growths_outside",
+                        "type": {
+                            "array": [
+                                "u128",
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "FeeTier",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "default_fee_rate",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "IncreaseLiquidityMethod",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "ByTokenAmounts",
+                        "fields": [
+                            {
+                                "name": "token_max_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "token_max_b",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "min_sqrt_price",
+                                "type": "u128"
+                            },
+                            {
+                                "name": "max_sqrt_price",
+                                "type": "u128"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityDecreased",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityIncreased",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LiquidityRepositioned",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "existing_range_tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "existing_range_tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "new_range_tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "new_range_tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "existing_range_liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "new_range_liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "existing_range_token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "existing_range_token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "new_range_token_a_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "new_range_token_b_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_a_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "is_token_a_transfer_from_owner",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "token_b_transfer_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_b_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "is_token_b_transfer_from_owner",
+                        "type": "bool"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockConfig",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_owner",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "locked_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "lock_type",
+                        "type": {
+                            "defined": {
+                                "name": "LockTypeLabel"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockType",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Permanent"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "LockTypeLabel",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "Permanent"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "OpenPositionBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "OpenPositionWithMetadataBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bump",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "metadata_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Oracle",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "trade_enable_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "adaptive_fee_constants",
+                        "type": {
+                            "defined": {
+                                "name": "AdaptiveFeeConstants"
+                            }
+                        }
+                    },
+                    {
+                        "name": "adaptive_fee_variables",
+                        "type": {
+                            "defined": {
+                                "name": "AdaptiveFeeVariables"
+                            }
+                        }
+                    },
+                    {
+                        "name": "reserved",
+                        "type": {
+                            "array": [
+                                "u8",
+                                128
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PoolInitialized",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "token_program_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_program_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "decimals_a",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "decimals_b",
+                        "type": "u8"
+                    },
+                    {
+                        "name": "initial_sqrt_price",
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Position",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "fee_growth_checkpoint_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_owed_a",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "fee_growth_checkpoint_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_owed_b",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_infos",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "PositionRewardInfo"
+                                    }
+                                },
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionBundle",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "position_bundle_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position_bitmap",
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionOpened",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "position",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "tick_lower_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "tick_upper_index",
+                        "type": "i32"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "PositionRewardInfo",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "growth_inside_checkpoint",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "amount_owed",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RemainingAccountsInfo",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "slices",
+                        "type": {
+                            "vec": {
+                                "defined": {
+                                    "name": "RemainingAccountsSlice"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RemainingAccountsSlice",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "accounts_type",
+                        "type": {
+                            "defined": {
+                                "name": "AccountsType"
+                            }
+                        }
+                    },
+                    {
+                        "name": "length",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "RepositionLiquidityMethod",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "ByLiquidity",
+                        "fields": [
+                            {
+                                "name": "new_liquidity_amount",
+                                "type": "u128"
+                            },
+                            {
+                                "name": "existing_range_token_min_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "existing_range_token_min_b",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "new_range_token_max_a",
+                                "type": "u64"
+                            },
+                            {
+                                "name": "new_range_token_max_b",
+                                "type": "u64"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Tick",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "initialized",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "liquidity_net",
+                        "type": "i128"
+                    },
+                    {
+                        "name": "liquidity_gross",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "fee_growth_outside_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_growths_outside",
+                        "type": {
+                            "array": [
+                                "u128",
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TickArray",
+            "serialization": "bytemuckunsafe",
+            "repr": {
+                "kind": "c",
+                "packed": true
+            },
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "start_tick_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "ticks",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "Tick"
+                                    }
+                                },
+                                88
+                            ]
+                        }
+                    },
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TokenBadge",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_mint",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "attribute_require_non_transferable_position",
+                        "type": "bool"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "TokenBadgeAttribute",
+            "type": {
+                "kind": "enum",
+                "variants": [
+                    {
+                        "name": "RequireNonTransferablePosition",
+                        "fields": [
+                            "bool"
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Traded",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "a_to_b",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "pre_sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "post_sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "input_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "output_amount",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "input_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "output_transfer_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "lp_fee",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_fee",
+                        "type": "u64"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "Whirlpool",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "whirlpool_bump",
+                        "type": {
+                            "array": [
+                                "u8",
+                                1
+                            ]
+                        }
+                    },
+                    {
+                        "name": "tick_spacing",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "fee_tier_index_seed",
+                        "type": {
+                            "array": [
+                                "u8",
+                                2
+                            ]
+                        }
+                    },
+                    {
+                        "name": "fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "protocol_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "liquidity",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "sqrt_price",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "tick_current_index",
+                        "type": "i32"
+                    },
+                    {
+                        "name": "protocol_fee_owed_a",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "protocol_fee_owed_b",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "token_mint_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_vault_a",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_growth_global_a",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "token_mint_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_vault_b",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "fee_growth_global_b",
+                        "type": "u128"
+                    },
+                    {
+                        "name": "reward_last_updated_timestamp",
+                        "type": "u64"
+                    },
+                    {
+                        "name": "reward_infos",
+                        "type": {
+                            "array": [
+                                {
+                                    "defined": {
+                                        "name": "WhirlpoolRewardInfo"
+                                    }
+                                },
+                                3
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolBumps",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpool_bump",
+                        "type": "u8"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolRewardInfo",
+            "docs": [
+                "Stores the state relevant for tracking liquidity mining rewards at the `Whirlpool` level.",
+                "These values are used in conjunction with `PositionRewardInfo`, `Tick.reward_growths_outside`,",
+                "and `Whirlpool.reward_last_updated_timestamp` to determine how many rewards are earned by open",
+                "positions."
+            ],
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "mint",
+                        "docs": [
+                            "Reward token mint."
+                        ],
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "vault",
+                        "docs": [
+                            "Reward vault token account."
+                        ],
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "extension",
+                        "docs": [
+                            "reward_infos[0]: Authority account that has permission to initialize the reward and set emissions.",
+                            "reward_infos[1]: used for a struct that contains fields for extending the functionality of Whirlpool.",
+                            "reward_infos[2]: reserved for future use.",
+                            "",
+                            "Historical notes:",
+                            "Originally, this was a field named \"authority\", but it was found that there was no opportunity",
+                            "to set different authorities for the three rewards. Therefore, the use of this field was changed for Whirlpool's future extensibility."
+                        ],
+                        "type": {
+                            "array": [
+                                "u8",
+                                32
+                            ]
+                        }
+                    },
+                    {
+                        "name": "emissions_per_second_x64",
+                        "docs": [
+                            "Q64.64 number that indicates how many tokens per second are earned per unit of liquidity."
+                        ],
+                        "type": "u128"
+                    },
+                    {
+                        "name": "growth_global_x64",
+                        "docs": [
+                            "Q64.64 number that tracks the total tokens earned per unit of liquidity since the reward",
+                            "emissions were turned on."
+                        ],
+                        "type": "u128"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolsConfig",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "fee_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "collect_protocol_fees_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "reward_emissions_super_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "default_protocol_fee_rate",
+                        "type": "u16"
+                    },
+                    {
+                        "name": "feature_flags",
+                        "type": "u16"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "WhirlpoolsConfigExtension",
+            "type": {
+                "kind": "struct",
+                "fields": [
+                    {
+                        "name": "whirlpools_config",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "config_extension_authority",
+                        "type": "pubkey"
+                    },
+                    {
+                        "name": "token_badge_authority",
+                        "type": "pubkey"
+                    }
+                ]
+            }
+        }
+    ]
 }

--- a/idl/raydium_clmm.json
+++ b/idl/raydium_clmm.json
@@ -1,0 +1,6927 @@
+{
+  "address": "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK",
+  "metadata": {
+    "name": "raydium_clmm",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Anchor client and source for Raydium concentrated liquidity AMM"
+  },
+  "instructions": [
+    {
+      "name": "close_limit_order",
+      "docs": [
+        "Close a limit order",
+        "Closes the limit order account when unfilled amount is zero",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        ""
+      ],
+      "discriminator": [
+        76,
+        124,
+        128,
+        15,
+        213,
+        87,
+        37,
+        250
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "rent_receiver",
+          "writable": true
+        },
+        {
+          "name": "limit_order",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_position",
+      "docs": [
+        "Close the user's position and NFT account. If the NFT mint belongs to token2022, it will also be closed and the funds returned to the NFT owner.",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        ""
+      ],
+      "discriminator": [
+        123,
+        134,
+        81,
+        0,
+        49,
+        68,
+        98,
+        98
+      ],
+      "accounts": [
+        {
+          "name": "nft_owner",
+          "docs": [
+            "The position nft owner"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "Mint address bound to the personal position."
+          ],
+          "writable": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "User token account where position NFT be minted to"
+          ],
+          "writable": true
+        },
+        {
+          "name": "personal_position",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program to close the position state account"
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token/Token2022 program to close token/mint account"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "close_protocol_position",
+      "docs": [
+        "The CLMM protocol decides to discard the protocol position account, which can reduce users' opening costs.",
+        "After the original protocol position account is closed, the gas fee will be refunded to the user who created it.",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        ""
+      ],
+      "discriminator": [
+        201,
+        117,
+        152,
+        144,
+        85,
+        85,
+        108,
+        178
+      ],
+      "accounts": [
+        {
+          "name": "admin",
+          "writable": true,
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "protocol_position",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "collect_fund_fee",
+      "docs": [
+        "Collect the fund fee accrued to the pool",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1",
+        "* `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0",
+        ""
+      ],
+      "discriminator": [
+        167,
+        138,
+        78,
+        149,
+        223,
+        194,
+        6,
+        126
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Only admin or fund_owner can collect fee now"
+          ],
+          "signer": true
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Pool state stores accumulated protocol fee amount"
+          ],
+          "writable": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Amm config account stores fund_owner"
+          ]
+        },
+        {
+          "name": "token_vault_0",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_1",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token vault 0"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token vault 1"
+          ]
+        },
+        {
+          "name": "recipient_token_account_0",
+          "docs": [
+            "The address that receives the collected token_0 protocol fees"
+          ],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account_1",
+          "docs": [
+            "The address that receives the collected token_1 protocol fees"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "The SPL program to perform token transfers"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "The SPL program 2022 to perform token transfers"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount_0_requested",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_requested",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "collect_protocol_fee",
+      "docs": [
+        "Collect the protocol fee accrued to the pool",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1",
+        "* `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0",
+        ""
+      ],
+      "discriminator": [
+        136,
+        136,
+        252,
+        221,
+        194,
+        66,
+        126,
+        89
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Only admin or config owner can collect fee now"
+          ],
+          "signer": true
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Pool state stores accumulated protocol fee amount"
+          ],
+          "writable": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Amm config account stores owner"
+          ]
+        },
+        {
+          "name": "token_vault_0",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_1",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token vault 0"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token vault 1"
+          ]
+        },
+        {
+          "name": "recipient_token_account_0",
+          "docs": [
+            "The address that receives the collected token_0 protocol fees"
+          ],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account_1",
+          "docs": [
+            "The address that receives the collected token_1 protocol fees"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "The SPL program to perform token transfers"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "The SPL program 2022 to perform token transfers"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount_0_requested",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_requested",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "collect_remaining_rewards",
+      "docs": [
+        "Collect remaining reward token for reward founder",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `reward_index` - the index to reward info",
+        ""
+      ],
+      "discriminator": [
+        18,
+        237,
+        166,
+        197,
+        34,
+        16,
+        213,
+        144
+      ],
+      "accounts": [
+        {
+          "name": "reward_funder",
+          "docs": [
+            "The founder who init reward info previously"
+          ],
+          "signer": true
+        },
+        {
+          "name": "funder_token_account",
+          "docs": [
+            "The funder's reward token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Set reward for this pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "reward_token_vault",
+          "docs": [
+            "Reward vault transfer remaining token to founder token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "reward_vault_mint",
+          "docs": [
+            "The mint of reward token vault"
+          ]
+        },
+        {
+          "name": "token_program",
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Token program 2022"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "memo_program",
+          "docs": [
+            "memo program"
+          ],
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "create_amm_config",
+      "docs": [
+        "# Arguments",
+        "",
+        "* `ctx` - The accounts needed by instruction.",
+        "* `index` - The index of amm config, there may be multiple config.",
+        "* `tick_spacing` - The tickspacing binding with config, cannot be changed.",
+        "* `trade_fee_rate` - Trade fee rate, can be changed.",
+        "* `protocol_fee_rate` - The rate of protocol fee within trade fee.",
+        "* `fund_fee_rate` - The rate of fund fee within trade fee.",
+        "* `limit_fee_rate` - The rate of limit order fee.",
+        ""
+      ],
+      "discriminator": [
+        137,
+        52,
+        237,
+        212,
+        215,
+        117,
+        108,
+        104
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Address to be set as protocol owner."
+          ],
+          "writable": true,
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Initialize config state account to store protocol owner address and fee rates."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  109,
+                  109,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "index",
+          "type": "u16"
+        },
+        {
+          "name": "tick_spacing",
+          "type": "u16"
+        },
+        {
+          "name": "trade_fee_rate",
+          "type": "u32"
+        },
+        {
+          "name": "protocol_fee_rate",
+          "type": "u32"
+        },
+        {
+          "name": "fund_fee_rate",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "create_customizable_pool",
+      "docs": [
+        "Creates a pool for the given token pair with customizable parameters",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `customizable_params` - the customizable parameters",
+        ""
+      ],
+      "discriminator": [
+        43,
+        68,
+        212,
+        167,
+        89,
+        47,
+        164,
+        1
+      ],
+      "accounts": [
+        {
+          "name": "pool_creator",
+          "docs": [
+            "Address paying to create the pool"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "amm_config"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_0"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_1"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint_0",
+          "docs": [
+            "Token_0 mint, the key must be smaller then token_1 mint."
+          ]
+        },
+        {
+          "name": "token_mint_1",
+          "docs": [
+            "Token_1 mint"
+          ]
+        },
+        {
+          "name": "token_vault_0",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_0"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_vault_1",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_1"
+              }
+            ]
+          }
+        },
+        {
+          "name": "observation_state",
+          "docs": [
+            "Initialize an account to store oracle observations"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  98,
+                  115,
+                  101,
+                  114,
+                  118,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "tick_array_bitmap",
+          "docs": [
+            "Initialize an account to store if a tick array is initialized."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121,
+                  95,
+                  98,
+                  105,
+                  116,
+                  109,
+                  97,
+                  112,
+                  95,
+                  101,
+                  120,
+                  116,
+                  101,
+                  110,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program_0",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "token_program_1",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "To create a new program account"
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Sysvar for program account"
+          ],
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "customizable_params",
+          "type": {
+            "defined": {
+              "name": "CreateCustomizableParams"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_dynamic_fee_config",
+      "docs": [
+        "Create dynamic fee config",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `index` - The index of dynamic fee config",
+        "* `filter_period` - The period of filter",
+        "* `decay_period` - The period of decay",
+        "* `reduction_factor` - The reduction factor",
+        "* `adaptive_fee_control_factor` - The adaptive fee control factor",
+        "* `max_volatility_accumulator` - The max volatility accumulator",
+        "* `tick_group_size` - The tick group size"
+      ],
+      "discriminator": [
+        189,
+        14,
+        181,
+        120,
+        85,
+        118,
+        227,
+        62
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "dynamic_fee_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  121,
+                  110,
+                  97,
+                  109,
+                  105,
+                  99,
+                  95,
+                  102,
+                  101,
+                  101,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "index",
+          "type": "u16"
+        },
+        {
+          "name": "filter_period",
+          "type": "u16"
+        },
+        {
+          "name": "decay_period",
+          "type": "u16"
+        },
+        {
+          "name": "reduction_factor",
+          "type": "u16"
+        },
+        {
+          "name": "dynamic_fee_control",
+          "type": "u32"
+        },
+        {
+          "name": "max_volatility_accumulator",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "create_operation_account",
+      "docs": [
+        "Creates an operation account for the program",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        ""
+      ],
+      "discriminator": [
+        63,
+        87,
+        148,
+        33,
+        109,
+        35,
+        8,
+        104
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Address to be set as operation account owner."
+          ],
+          "writable": true,
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "operation_state",
+          "docs": [
+            "Initialize operation state account to store operation owner address and white list mint."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_pool",
+      "docs": [
+        "Creates a pool for the given token pair and the initial price",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `sqrt_price_x64` - the initial sqrt price (amount_token_1 / amount_token_0) of the pool as a Q64.64",
+        "Note: The open_time must be smaller than the current block_timestamp on chain."
+      ],
+      "discriminator": [
+        233,
+        146,
+        209,
+        142,
+        207,
+        104,
+        64,
+        188
+      ],
+      "accounts": [
+        {
+          "name": "pool_creator",
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Initialize an account to store the pool state"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "amm_config"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_0"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_1"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_mint_0",
+          "docs": [
+            "Token_0 mint, the key must be smaller then token_1 mint."
+          ]
+        },
+        {
+          "name": "token_mint_1",
+          "docs": [
+            "Token_1 mint"
+          ]
+        },
+        {
+          "name": "token_vault_0",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_0"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_vault_1",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_mint_1"
+              }
+            ]
+          }
+        },
+        {
+          "name": "observation_state",
+          "docs": [
+            "Initialize an account to store oracle observations"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  98,
+                  115,
+                  101,
+                  114,
+                  118,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "tick_array_bitmap",
+          "docs": [
+            "Initialize an account to store if a tick array is initialized."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121,
+                  95,
+                  98,
+                  105,
+                  116,
+                  109,
+                  97,
+                  112,
+                  95,
+                  101,
+                  120,
+                  116,
+                  101,
+                  110,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program_0",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "token_program_1",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "To create a new program account"
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Sysvar for program account"
+          ],
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "sqrt_price_x64",
+          "type": "u128"
+        },
+        {
+          "name": "open_time",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "create_support_mint_associated",
+      "docs": [
+        "Create support token22 mint account which can create pool and send rewards while ignoring unsupported extensions."
+      ],
+      "discriminator": [
+        17,
+        251,
+        65,
+        92,
+        136,
+        242,
+        14,
+        169
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Address to be set as protocol owner."
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "token_mint",
+          "docs": [
+            "Support token mint"
+          ]
+        },
+        {
+          "name": "support_mint_associated",
+          "docs": [
+            "Initialize support mint state account to store support mint address and bump."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  117,
+                  112,
+                  112,
+                  111,
+                  114,
+                  116,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "token_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "decrease_limit_order",
+      "docs": [
+        "Decrease/Cancel a limit order",
+        "First settle the filled portion of the order; only the remaining unfilled amount can be decreased.",
+        "Even if the specified amount is very large, the decrease will not exceed the remaining unfilled order amount.",
+        "It is recommended to call the `settle_limit_order` instruction before invoking this instruction to settle any filled portions of the order.",
+        "Make sure to check your order's remaining unfilled amount.",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `amount` - The decrease amount of the order,",
+        "* `amount_min` - The minimum amount of the order, which serves as a slippage check",
+        ""
+      ],
+      "discriminator": [
+        117,
+        157,
+        60,
+        103,
+        66,
+        49,
+        163,
+        0
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        },
+        {
+          "name": "tick_array",
+          "writable": true
+        },
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The payer's limit order token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The owner's output token account (opposite direction from input)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault",
+          "docs": [
+            "The address that holds limit order token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_vault",
+          "docs": [
+            "The address that holds output tokens"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault_mint",
+          "docs": [
+            "The mint of token vault"
+          ]
+        },
+        {
+          "name": "output_vault_mint",
+          "docs": [
+            "The mint of output vault"
+          ]
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL program for token transfers"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "SPL program 2022 for token transfers"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "amount_min",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "decrease_liquidity",
+      "docs": [
+        "#[deprecated(note = \"Use `decrease_liquidity_v2` instead.\")]",
+        "Decreases liquidity for an existing position",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` -  The context of accounts",
+        "* `liquidity` - The amount by which liquidity will be decreased",
+        "* `amount_0_min` - The minimum amount of token_0 that should be accounted for the burned liquidity",
+        "* `amount_1_min` - The minimum amount of token_1 that should be accounted for the burned liquidity",
+        ""
+      ],
+      "discriminator": [
+        160,
+        38,
+        208,
+        111,
+        104,
+        91,
+        44,
+        1
+      ],
+      "accounts": [
+        {
+          "name": "nft_owner",
+          "docs": [
+            "The position owner or delegated authority"
+          ],
+          "signer": true
+        },
+        {
+          "name": "nft_account",
+          "docs": [
+            "The token account for the tokenized position"
+          ]
+        },
+        {
+          "name": "personal_position",
+          "docs": [
+            "Decrease liquidity for this position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        },
+        {
+          "name": "protocol_position"
+        },
+        {
+          "name": "token_vault_0",
+          "docs": [
+            "Token_0 vault"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_1",
+          "docs": [
+            "Token_1 vault"
+          ],
+          "writable": true
+        },
+        {
+          "name": "tick_array_lower",
+          "docs": [
+            "Stores init state for the lower tick"
+          ],
+          "writable": true
+        },
+        {
+          "name": "tick_array_upper",
+          "docs": [
+            "Stores init state for the upper tick"
+          ],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account_0",
+          "docs": [
+            "The destination token account for receive amount_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account_1",
+          "docs": [
+            "The destination token account for receive amount_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL program to transfer out tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity",
+          "type": "u128"
+        },
+        {
+          "name": "amount_0_min",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_min",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "decrease_liquidity_v2",
+      "docs": [
+        "Decreases liquidity for an existing position, support Token2022",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` -  The context of accounts",
+        "* `liquidity` - The amount by which liquidity will be decreased",
+        "* `amount_0_min` - The minimum amount of token_0 that should be accounted for the burned liquidity",
+        "* `amount_1_min` - The minimum amount of token_1 that should be accounted for the burned liquidity",
+        ""
+      ],
+      "discriminator": [
+        58,
+        127,
+        188,
+        62,
+        79,
+        82,
+        196,
+        96
+      ],
+      "accounts": [
+        {
+          "name": "nft_owner",
+          "docs": [
+            "The position owner or delegated authority"
+          ],
+          "signer": true
+        },
+        {
+          "name": "nft_account",
+          "docs": [
+            "The token account for the tokenized position"
+          ]
+        },
+        {
+          "name": "personal_position",
+          "docs": [
+            "Decrease liquidity for this position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        },
+        {
+          "name": "protocol_position"
+        },
+        {
+          "name": "token_vault_0",
+          "docs": [
+            "Token_0 vault"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_1",
+          "docs": [
+            "Token_1 vault"
+          ],
+          "writable": true
+        },
+        {
+          "name": "tick_array_lower",
+          "docs": [
+            "Stores init state for the lower tick"
+          ],
+          "writable": true
+        },
+        {
+          "name": "tick_array_upper",
+          "docs": [
+            "Stores init state for the upper tick"
+          ],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account_0",
+          "docs": [
+            "The destination token account for receive amount_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_account_1",
+          "docs": [
+            "The destination token account for receive amount_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL program to transfer out tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Token program 2022"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "memo_program",
+          "docs": [
+            "memo program"
+          ],
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token vault 0"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token vault 1"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity",
+          "type": "u128"
+        },
+        {
+          "name": "amount_0_min",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_min",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "increase_limit_order",
+      "docs": [
+        "Increase a limit order",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `amount` - The increase amount of the order",
+        "* `is_increase` - The direction of the order, true: increase, false: decrease",
+        ""
+      ],
+      "discriminator": [
+        177,
+        144,
+        89,
+        236,
+        250,
+        186,
+        125,
+        99
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "signer": true
+        },
+        {
+          "name": "pool_state"
+        },
+        {
+          "name": "tick_array",
+          "writable": true
+        },
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The payer's limit order token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault",
+          "docs": [
+            "The address that holds limit order token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault_mint",
+          "docs": [
+            "The mint of token vault"
+          ]
+        },
+        {
+          "name": "input_token_program",
+          "docs": [
+            "SPL-TOKEN / SPL-TOKEN2022 program for token transfers"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "increase_liquidity",
+      "docs": [
+        "#[deprecated(note = \"Use `increase_liquidity_v2` instead.\")]",
+        "Increases liquidity for an existing position, with amount paid by `payer`",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `liquidity` - The desired liquidity to be added, can't be zero",
+        "* `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check",
+        "* `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check",
+        ""
+      ],
+      "discriminator": [
+        46,
+        156,
+        243,
+        118,
+        13,
+        205,
+        251,
+        178
+      ],
+      "accounts": [
+        {
+          "name": "nft_owner",
+          "docs": [
+            "Pays to mint the position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        },
+        {
+          "name": "protocol_position"
+        },
+        {
+          "name": "personal_position",
+          "docs": [
+            "Increase liquidity for this position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "tick_array_lower",
+          "docs": [
+            "Stores init state for the lower tick"
+          ],
+          "writable": true
+        },
+        {
+          "name": "tick_array_upper",
+          "docs": [
+            "Stores init state for the upper tick"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_account_0",
+          "docs": [
+            "The payer's token account for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_account_1",
+          "docs": [
+            "The token account spending token_1 to mint the position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_0",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_1",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity",
+          "type": "u128"
+        },
+        {
+          "name": "amount_0_max",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_max",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "increase_liquidity_v2",
+      "docs": [
+        "Increases liquidity for an existing position, with amount paid by `payer`, support Token2022",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `liquidity` - The desired liquidity to be added, if zero, calculate liquidity base amount_0 or amount_1 according base_flag",
+        "* `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check",
+        "* `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check",
+        "* `base_flag` - must be specified if liquidity is zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max",
+        ""
+      ],
+      "discriminator": [
+        133,
+        29,
+        89,
+        223,
+        69,
+        238,
+        176,
+        10
+      ],
+      "accounts": [
+        {
+          "name": "nft_owner",
+          "docs": [
+            "Pays to mint the position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "nft_account",
+          "docs": [
+            "The token account for nft"
+          ]
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        },
+        {
+          "name": "protocol_position"
+        },
+        {
+          "name": "personal_position",
+          "docs": [
+            "Increase liquidity for this position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "tick_array_lower",
+          "docs": [
+            "Stores init state for the lower tick"
+          ],
+          "writable": true
+        },
+        {
+          "name": "tick_array_upper",
+          "docs": [
+            "Stores init state for the upper tick"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_account_0",
+          "docs": [
+            "The payer's token account for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_account_1",
+          "docs": [
+            "The token account spending token_1 to mint the position"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_0",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_1",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Token program 2022"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token vault 0"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token vault 1"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "liquidity",
+          "type": "u128"
+        },
+        {
+          "name": "amount_0_max",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_max",
+          "type": "u64"
+        },
+        {
+          "name": "base_flag",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ]
+    },
+    {
+      "name": "initialize_reward",
+      "docs": [
+        "Initialize a reward info for a given pool and reward index",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `reward_index` - the index to reward info",
+        "* `open_time` - reward open timestamp",
+        "* `end_time` - reward end timestamp",
+        "* `emissions_per_second_x64` - Token reward per second are earned per unit of liquidity.",
+        ""
+      ],
+      "discriminator": [
+        95,
+        135,
+        192,
+        196,
+        242,
+        129,
+        230,
+        68
+      ],
+      "accounts": [
+        {
+          "name": "reward_funder",
+          "docs": [
+            "The founder deposit reward token to vault"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "funder_token_account",
+          "writable": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "For check the reward_funder authority"
+          ]
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Set reward for this pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "operation_state",
+          "docs": [
+            "load info from the account to judge reward permission"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "reward_token_mint",
+          "docs": [
+            "Reward mint"
+          ]
+        },
+        {
+          "name": "reward_token_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  114,
+                  101,
+                  119,
+                  97,
+                  114,
+                  100,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "reward_token_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "reward_token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rent",
+          "address": "SysvarRent111111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "param",
+          "type": {
+            "defined": {
+              "name": "InitializeRewardParam"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "open_limit_order",
+      "docs": [
+        "Place a limit order",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `nonce_index` - The limit order nonce account index, used to create user's order nonce PDA account.",
+        "* `zero_for_one` - The direction of the order, true: zero for one, false: one for zero",
+        "* `tick_index` - The index of the tick",
+        "* `amount` - The amount of the order",
+        "* `with_metadata` - The flag indicating whether to create NFT mint metadata",
+        ""
+      ],
+      "discriminator": [
+        157,
+        32,
+        218,
+        183,
+        71,
+        29,
+        18,
+        147
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "The pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "tick_array",
+          "writable": true
+        },
+        {
+          "name": "limit_order_nonce",
+          "docs": [
+            "The order nonce account PDA"
+          ],
+          "writable": true
+        },
+        {
+          "name": "limit_order",
+          "docs": [
+            "The order account PDA"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "payer"
+              },
+              {
+                "kind": "account",
+                "path": "limit_order_nonce"
+              },
+              {
+                "kind": "account",
+                "path": "limit_order_nonce.order_nonce",
+                "account": "LimitOrderNonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The payer's limit order token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault",
+          "docs": [
+            "The address that holds limit order token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault_mint",
+          "docs": [
+            "The mint of token vault"
+          ]
+        },
+        {
+          "name": "input_token_program",
+          "docs": [
+            "SPL-TOKEN / SPL-TOKEN2022 program for input token transfers"
+          ]
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "SPL program for system operations"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "nonce_index",
+          "type": "u8"
+        },
+        {
+          "name": "zero_for_one",
+          "type": "bool"
+        },
+        {
+          "name": "tick_index",
+          "type": "i32"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "open_position",
+      "docs": [
+        "#[deprecated(note = \"Use `open_position_with_token22_nft` instead.\")]",
+        "Creates a new position wrapped in a NFT",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `tick_lower_index` - The low boundary of market",
+        "* `tick_upper_index` - The upper boundary of market",
+        "* `tick_array_lower_start_index` - The start index of tick array which includes tick low",
+        "* `tick_array_upper_start_index` - The start index of tick array which includes tick upper",
+        "* `liquidity` - The liquidity to be added",
+        "* `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check",
+        "* `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check",
+        ""
+      ],
+      "discriminator": [
+        135,
+        128,
+        47,
+        77,
+        15,
+        152,
+        240,
+        49
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": [
+            "Pays to mint the position"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position_nft_owner"
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "Unique token mint address"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "Token account where position NFT will be minted",
+            "This account created in the contract by cpi to avoid large stack variables"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "position_nft_owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "metadata_account",
+          "docs": [
+            "To store metaplex metadata"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Add liquidity for this pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_position"
+        },
+        {
+          "name": "tick_array_lower",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "arg",
+                "path": "tick_array_lower_start_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "tick_array_upper",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "arg",
+                "path": "tick_array_upper_start_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "personal_position",
+          "docs": [
+            "personal position state"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_account_0",
+          "docs": [
+            "The token_0 account deposit token to the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_account_1",
+          "docs": [
+            "The token_1 account deposit token to the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_0",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_1",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Sysvar for token mint and ATA creation"
+          ],
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "Program to create the position manager state account"
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Program to create an ATA for receiving position NFT"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "metadata_program",
+          "docs": [
+            "Program to create NFT metadata"
+          ],
+          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+        }
+      ],
+      "args": [
+        {
+          "name": "tick_lower_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_upper_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_array_lower_start_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_array_upper_start_index",
+          "type": "i32"
+        },
+        {
+          "name": "liquidity",
+          "type": "u128"
+        },
+        {
+          "name": "amount_0_max",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_max",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "open_position_v2",
+      "docs": [
+        "#[deprecated(note = \"Use `open_position_with_token22_nft` instead.\")]",
+        "Creates a new position wrapped in a NFT, support Token2022",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `tick_lower_index` - The low boundary of market",
+        "* `tick_upper_index` - The upper boundary of market",
+        "* `tick_array_lower_start_index` - The start index of tick array which includes tick low",
+        "* `tick_array_upper_start_index` - The start index of tick array which includes tick upper",
+        "* `liquidity` - The liquidity to be added, if zero, and the base_flag is specified, calculate liquidity base amount_0_max or amount_1_max according base_flag, otherwise open position with zero liquidity",
+        "* `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check",
+        "* `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check",
+        "* `with_metadata` - The flag indicating whether to create NFT mint metadata",
+        "* `base_flag` - if the liquidity specified as zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max",
+        ""
+      ],
+      "discriminator": [
+        77,
+        184,
+        74,
+        214,
+        112,
+        86,
+        241,
+        199
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": [
+            "Pays to mint the position"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position_nft_owner"
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "Unique token mint address"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position_nft_account",
+          "docs": [
+            "Token account where position NFT will be minted"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "position_nft_owner"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "metadata_account",
+          "docs": [
+            "To store metaplex metadata"
+          ],
+          "writable": true
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Add liquidity for this pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_position"
+        },
+        {
+          "name": "tick_array_lower",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "arg",
+                "path": "tick_array_lower_start_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "tick_array_upper",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "arg",
+                "path": "tick_array_upper_start_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "personal_position",
+          "docs": [
+            "personal position state"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_account_0",
+          "docs": [
+            "The token_0 account deposit token to the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_account_1",
+          "docs": [
+            "The token_1 account deposit token to the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_0",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_1",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Sysvar for token mint and ATA creation"
+          ],
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "Program to create the position manager state account"
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Program to create an ATA for receiving position NFT"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "metadata_program",
+          "docs": [
+            "Program to create NFT metadata"
+          ],
+          "address": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token vault 0"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token vault 1"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "tick_lower_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_upper_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_array_lower_start_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_array_upper_start_index",
+          "type": "i32"
+        },
+        {
+          "name": "liquidity",
+          "type": "u128"
+        },
+        {
+          "name": "amount_0_max",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_max",
+          "type": "u64"
+        },
+        {
+          "name": "with_metadata",
+          "type": "bool"
+        },
+        {
+          "name": "base_flag",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ]
+    },
+    {
+      "name": "open_position_with_token22_nft",
+      "docs": [
+        "Creates a new position wrapped in a Token2022 NFT without relying on metadata_program and metadata_account, reduce the cost for user to create a personal position.",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `tick_lower_index` - The low boundary of market",
+        "* `tick_upper_index` - The upper boundary of market",
+        "* `tick_array_lower_start_index` - The start index of tick array which includes tick low",
+        "* `tick_array_upper_start_index` - The start index of tick array which includes tick upper",
+        "* `liquidity` - The liquidity to be added, if zero, and the base_flag is specified, calculate liquidity base amount_0_max or amount_1_max according base_flag, otherwise open position with zero liquidity",
+        "* `amount_0_max` - The max amount of token_0 to spend, which serves as a slippage check",
+        "* `amount_1_max` - The max amount of token_1 to spend, which serves as a slippage check",
+        "* `with_metadata` - The flag indicating whether to create NFT mint metadata",
+        "* `base_flag` - if the liquidity specified as zero, true: calculate liquidity base amount_0_max otherwise base amount_1_max",
+        ""
+      ],
+      "discriminator": [
+        77,
+        255,
+        174,
+        82,
+        125,
+        29,
+        201,
+        46
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": [
+            "Pays to mint the position"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position_nft_owner"
+        },
+        {
+          "name": "position_nft_mint",
+          "docs": [
+            "Unique token mint address, initialize in contract"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "position_nft_account",
+          "writable": true
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Add liquidity for this pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "protocol_position"
+        },
+        {
+          "name": "tick_array_lower",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "arg",
+                "path": "tick_array_lower_start_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "tick_array_upper",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  105,
+                  99,
+                  107,
+                  95,
+                  97,
+                  114,
+                  114,
+                  97,
+                  121
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "arg",
+                "path": "tick_array_upper_start_index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "personal_position",
+          "docs": [
+            "personal position state"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "position_nft_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_account_0",
+          "docs": [
+            "The token_0 account deposit token to the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_account_1",
+          "docs": [
+            "The token_1 account deposit token to the pool"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_0",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_vault_1",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "rent",
+          "docs": [
+            "Sysvar for token mint and ATA creation"
+          ],
+          "address": "SysvarRent111111111111111111111111111111111"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "Program to create the position manager state account"
+          ],
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Program to transfer for token account"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Program to create an ATA for receiving position NFT"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Program to create NFT mint/token account and transfer for token22 account"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token vault 0"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token vault 1"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "tick_lower_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_upper_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_array_lower_start_index",
+          "type": "i32"
+        },
+        {
+          "name": "tick_array_upper_start_index",
+          "type": "i32"
+        },
+        {
+          "name": "liquidity",
+          "type": "u128"
+        },
+        {
+          "name": "amount_0_max",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_max",
+          "type": "u64"
+        },
+        {
+          "name": "with_metadata",
+          "type": "bool"
+        },
+        {
+          "name": "base_flag",
+          "type": {
+            "option": "bool"
+          }
+        }
+      ]
+    },
+    {
+      "name": "set_reward_params",
+      "docs": [
+        "Reset reward param, start a new reward cycle or extend the current cycle.",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `reward_index` - The index of reward token in the pool.",
+        "* `emissions_per_second_x64` - The per second emission reward, when extend the current cycle,",
+        "new value can't be less than old value",
+        "* `open_time` - reward open timestamp, must be set when starting a new cycle",
+        "* `end_time` - reward end timestamp",
+        ""
+      ],
+      "discriminator": [
+        112,
+        52,
+        167,
+        75,
+        32,
+        201,
+        211,
+        137
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "docs": [
+            "Address to be set as protocol owner. It pays to create factory state account."
+          ],
+          "signer": true
+        },
+        {
+          "name": "amm_config"
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        },
+        {
+          "name": "operation_state",
+          "docs": [
+            "load info from the account to judge reward permission"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Token program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Token program 2022"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "reward_index",
+          "type": "u8"
+        },
+        {
+          "name": "emissions_per_second_x64",
+          "type": "u128"
+        },
+        {
+          "name": "open_time",
+          "type": "u64"
+        },
+        {
+          "name": "end_time",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "settle_limit_order",
+      "docs": [
+        "Settle a limit order",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        ""
+      ],
+      "discriminator": [
+        205,
+        78,
+        116,
+        33,
+        92,
+        105,
+        26,
+        96
+      ],
+      "accounts": [
+        {
+          "name": "signer",
+          "signer": true
+        },
+        {
+          "name": "pool_state"
+        },
+        {
+          "name": "tick_array"
+        },
+        {
+          "name": "limit_order",
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The owner's output token account (opposite direction from input)"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_vault",
+          "docs": [
+            "The address that holds output tokens"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_vault_mint",
+          "docs": [
+            "The mint of output vault"
+          ]
+        },
+        {
+          "name": "output_token_program",
+          "docs": [
+            "SPL-TOKEN / SPL-TOKEN2022 program for token transfers"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "swap",
+      "docs": [
+        "#[deprecated(note = \"Use `swap_v2` instead.\")]",
+        "Swaps one token for as much as possible of another token across a single pool",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `amount` - Arranged in pairs with other_amount_threshold. (amount_in, amount_out_minimum) or (amount_out, amount_in_maximum)",
+        "* `other_amount_threshold` - For slippage check",
+        "* `sqrt_price_limit` - The Q64.64 sqrt price √P limit. If zero for one, the price cannot",
+        "* `is_base_input` - swap base input or swap base output",
+        ""
+      ],
+      "discriminator": [
+        248,
+        198,
+        158,
+        145,
+        225,
+        117,
+        135,
+        200
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "The factory state to read protocol fees"
+          ]
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "The program account of the pool in which the swap will be performed"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "observation_state",
+          "docs": [
+            "The program account for the most recent oracle observation"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL program for token transfers"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "tick_array",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "other_amount_threshold",
+          "type": "u64"
+        },
+        {
+          "name": "sqrt_price_limit_x64",
+          "type": "u128"
+        },
+        {
+          "name": "is_base_input",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "swap_router_base_in",
+      "docs": [
+        "Swap token for as much as possible of another token across the path provided, base input",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `amount_in` - Token amount to be swapped in",
+        "* `amount_out_minimum` - Panic if output amount is below minimum amount. For slippage.",
+        ""
+      ],
+      "discriminator": [
+        69,
+        125,
+        115,
+        218,
+        245,
+        186,
+        242,
+        196
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The token account that pays input tokens for the swap"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_token_mint",
+          "docs": [
+            "The mint of input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL program for token transfers"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "SPL program 2022 for token transfers"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "memo_program",
+          "docs": [
+            "Memo program"
+          ],
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount_in",
+          "type": "u64"
+        },
+        {
+          "name": "amount_out_minimum",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "swap_v2",
+      "docs": [
+        "Swaps one token for as much as possible of another token across a single pool, support token program 2022",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `amount` - Arranged in pairs with other_amount_threshold. (amount_in, amount_out_minimum) or (amount_out, amount_in_maximum)",
+        "* `other_amount_threshold` - For slippage check",
+        "* `sqrt_price_limit` - The Q64.64 sqrt price √P limit. If zero for one, the price cannot",
+        "* `is_base_input` - swap base input or swap base output",
+        ""
+      ],
+      "discriminator": [
+        43,
+        4,
+        237,
+        11,
+        26,
+        201,
+        30,
+        98
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "docs": [
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "The factory state to read protocol fees"
+          ]
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "The program account of the pool in which the swap will be performed"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "input_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "output_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
+        },
+        {
+          "name": "observation_state",
+          "docs": [
+            "The program account for the most recent oracle observation"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL program for token transfers"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "SPL program 2022 for token transfers"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "memo_program",
+          "docs": [
+            "Memo program"
+          ],
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        },
+        {
+          "name": "input_vault_mint",
+          "docs": [
+            "The mint of token vault 0"
+          ]
+        },
+        {
+          "name": "output_vault_mint",
+          "docs": [
+            "The mint of token vault 1"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "other_amount_threshold",
+          "type": "u64"
+        },
+        {
+          "name": "sqrt_price_limit_x64",
+          "type": "u128"
+        },
+        {
+          "name": "is_base_input",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "transfer_reward_owner",
+      "docs": [
+        "Transfer reward owner",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `new_owner` - new owner pubkey",
+        ""
+      ],
+      "discriminator": [
+        7,
+        22,
+        12,
+        83,
+        242,
+        43,
+        48,
+        121
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "docs": [
+            "Address to be set as operation account owner."
+          ],
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "new_owner",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "update_amm_config",
+      "docs": [
+        "Updates the owner of the amm config",
+        "Must be called by the current owner or admin",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `trade_fee_rate` - The new trade fee rate of amm config, be set when `param` is 0",
+        "* `protocol_fee_rate` - The new protocol fee rate of amm config, be set when `param` is 1",
+        "* `fund_fee_rate` - The new fund fee rate of amm config, be set when `param` is 2",
+        "* `new_owner` - The config's new owner, be set when `param` is 3",
+        "* `new_fund_owner` - The config's new fund owner, be set when `param` is 4",
+        "* `limit_protocol_fee_rate` - The new limit protocol fee rate of amm config, be set when `param` is 5",
+        "* `limit_fund_fee_rate` - The new limit fund fee rate of amm config, be set when `param` is 6",
+        "* `param` - The value can be 0 | 1 | 2 | 3 | 4 | 5 | 6, otherwise will report an error",
+        ""
+      ],
+      "discriminator": [
+        49,
+        60,
+        174,
+        136,
+        154,
+        28,
+        116,
+        200
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "The amm config owner or admin"
+          ],
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Amm config account to be changed"
+          ],
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "param",
+          "type": "u8"
+        },
+        {
+          "name": "value",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "update_dynamic_fee_config",
+      "docs": [
+        "Updates the dynamic fee configuration constants.",
+        "",
+        "This function allows updating the parameters that control dynamic fee calculation,",
+        "such as filter period, decay period, reduction factor, fee control factor, etc.",
+        "Only the admin or the amm config owner can update these settings.",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `filter_period` - Period that determines the high frequency trading time window (in seconds)",
+        "* `decay_period` - Period that determines when the dynamic fee starts to decrease (in seconds)",
+        "* `reduction_factor` - Dynamic fee rate decrement rate, used for volatility reference decay",
+        "* `dynamic_fee_control` - Factor used to scale the dynamic fee component",
+        "* `max_volatility_accumulator` - Maximum value for the volatility accumulator",
+        "* `create_pool_authority` - The new authority pubkey that can use this dynamic fee config to create pools"
+      ],
+      "discriminator": [
+        7,
+        7,
+        80,
+        8,
+        2,
+        199,
+        132,
+        240
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "The admin has permission to update the config"
+          ],
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "dynamic_fee_config",
+          "docs": [
+            "The dynamic fee config account to be updated"
+          ],
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "filter_period",
+          "type": "u16"
+        },
+        {
+          "name": "decay_period",
+          "type": "u16"
+        },
+        {
+          "name": "reduction_factor",
+          "type": "u16"
+        },
+        {
+          "name": "dynamic_fee_control",
+          "type": "u32"
+        },
+        {
+          "name": "max_volatility_accumulator",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "update_operation_account",
+      "docs": [
+        "Update the operation account",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `param` - The value can be 0 | 1 | 2 | 3, otherwise will report an error",
+        "* `keys`- update operation owner when the `param` is 0",
+        "remove operation owner when the `param` is 1",
+        "update whitelist mint when the `param` is 2",
+        "remove whitelist mint when the `param` is 3",
+        ""
+      ],
+      "discriminator": [
+        127,
+        70,
+        119,
+        40,
+        188,
+        227,
+        61,
+        7
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Address to be set as operation account owner."
+          ],
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "operation_state",
+          "docs": [
+            "Initialize operation state account to store operation owner address and white list mint."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  112,
+                  101,
+                  114,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "param",
+          "type": "u8"
+        },
+        {
+          "name": "keys",
+          "type": {
+            "vec": "pubkey"
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_pool_status",
+      "docs": [
+        "Update pool status for given value",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `status` - The value of status",
+        ""
+      ],
+      "discriminator": [
+        130,
+        87,
+        108,
+        6,
+        46,
+        224,
+        117,
+        123
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true,
+          "address": "2kqJncUWCkk5TyJYamPW5DECfqAz4brYpH6r5j6vg9yx"
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "update_reward_infos",
+      "docs": [
+        "Update rewards info of the given pool, can be called for everyone",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        ""
+      ],
+      "discriminator": [
+        163,
+        172,
+        224,
+        52,
+        11,
+        154,
+        106,
+        223
+      ],
+      "accounts": [
+        {
+          "name": "pool_state",
+          "docs": [
+            "The liquidity pool for which reward info to update"
+          ],
+          "writable": true
+        }
+      ],
+      "args": []
+    }
+  ],
+  "accounts": [
+    {
+      "name": "AmmConfig",
+      "discriminator": [
+        218,
+        244,
+        33,
+        104,
+        203,
+        203,
+        43,
+        111
+      ]
+    },
+    {
+      "name": "DynamicFeeConfig",
+      "discriminator": [
+        244,
+        226,
+        88,
+        82,
+        14,
+        59,
+        246,
+        220
+      ]
+    },
+    {
+      "name": "LimitOrderNonce",
+      "discriminator": [
+        17,
+        153,
+        236,
+        57,
+        25,
+        199,
+        231,
+        248
+      ]
+    },
+    {
+      "name": "LimitOrderState",
+      "discriminator": [
+        1,
+        238,
+        5,
+        142,
+        207,
+        62,
+        44,
+        228
+      ]
+    },
+    {
+      "name": "ObservationState",
+      "discriminator": [
+        122,
+        174,
+        197,
+        53,
+        129,
+        9,
+        165,
+        132
+      ]
+    },
+    {
+      "name": "OperationState",
+      "discriminator": [
+        19,
+        236,
+        58,
+        237,
+        81,
+        222,
+        183,
+        252
+      ]
+    },
+    {
+      "name": "PersonalPositionState",
+      "discriminator": [
+        70,
+        111,
+        150,
+        126,
+        230,
+        15,
+        25,
+        117
+      ]
+    },
+    {
+      "name": "PoolState",
+      "discriminator": [
+        247,
+        237,
+        227,
+        245,
+        215,
+        195,
+        222,
+        70
+      ]
+    },
+    {
+      "name": "ProtocolPositionState",
+      "discriminator": [
+        100,
+        226,
+        145,
+        99,
+        146,
+        218,
+        160,
+        106
+      ]
+    },
+    {
+      "name": "SupportMintAssociated",
+      "discriminator": [
+        134,
+        40,
+        183,
+        79,
+        12,
+        112,
+        162,
+        53
+      ]
+    },
+    {
+      "name": "TickArrayBitmapExtension",
+      "discriminator": [
+        60,
+        150,
+        36,
+        219,
+        97,
+        128,
+        139,
+        153
+      ]
+    },
+    {
+      "name": "TickArrayState",
+      "discriminator": [
+        192,
+        155,
+        85,
+        205,
+        49,
+        249,
+        129,
+        42
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "CollectPersonalFeeEvent",
+      "discriminator": [
+        166,
+        174,
+        105,
+        192,
+        81,
+        161,
+        83,
+        105
+      ]
+    },
+    {
+      "name": "CollectProtocolFeeEvent",
+      "discriminator": [
+        206,
+        87,
+        17,
+        79,
+        45,
+        41,
+        213,
+        61
+      ]
+    },
+    {
+      "name": "ConfigChangeEvent",
+      "discriminator": [
+        247,
+        189,
+        7,
+        119,
+        106,
+        112,
+        95,
+        151
+      ]
+    },
+    {
+      "name": "CreatePersonalPositionEvent",
+      "discriminator": [
+        100,
+        30,
+        87,
+        249,
+        196,
+        223,
+        154,
+        206
+      ]
+    },
+    {
+      "name": "DecreaseLimitOrderEvent",
+      "discriminator": [
+        70,
+        48,
+        40,
+        221,
+        219,
+        237,
+        212,
+        163
+      ]
+    },
+    {
+      "name": "DecreaseLiquidityEvent",
+      "discriminator": [
+        58,
+        222,
+        86,
+        58,
+        68,
+        50,
+        85,
+        56
+      ]
+    },
+    {
+      "name": "IncreaseLimitOrderEvent",
+      "discriminator": [
+        11,
+        120,
+        13,
+        204,
+        199,
+        87,
+        19,
+        200
+      ]
+    },
+    {
+      "name": "IncreaseLiquidityEvent",
+      "discriminator": [
+        49,
+        79,
+        105,
+        212,
+        32,
+        34,
+        30,
+        84
+      ]
+    },
+    {
+      "name": "LiquidityCalculateEvent",
+      "discriminator": [
+        237,
+        112,
+        148,
+        230,
+        57,
+        84,
+        180,
+        162
+      ]
+    },
+    {
+      "name": "LiquidityChangeEvent",
+      "discriminator": [
+        126,
+        240,
+        175,
+        206,
+        158,
+        88,
+        153,
+        107
+      ]
+    },
+    {
+      "name": "OpenLimitOrderEvent",
+      "discriminator": [
+        106,
+        24,
+        71,
+        85,
+        57,
+        169,
+        158,
+        216
+      ]
+    },
+    {
+      "name": "PoolCreatedEvent",
+      "discriminator": [
+        25,
+        94,
+        75,
+        47,
+        112,
+        99,
+        53,
+        63
+      ]
+    },
+    {
+      "name": "SettleLimitOrderEvent",
+      "discriminator": [
+        88,
+        119,
+        77,
+        164,
+        125,
+        124,
+        10,
+        194
+      ]
+    },
+    {
+      "name": "SwapEvent",
+      "discriminator": [
+        64,
+        198,
+        205,
+        232,
+        38,
+        8,
+        113,
+        226
+      ]
+    },
+    {
+      "name": "UpdateRewardInfosEvent",
+      "discriminator": [
+        109,
+        127,
+        186,
+        78,
+        114,
+        65,
+        37,
+        236
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "NotApproved",
+      "msg": "Not approved"
+    },
+    {
+      "code": 6001,
+      "name": "InvalidUpdateConfigFlag",
+      "msg": "invalid update amm config flag"
+    },
+    {
+      "code": 6002,
+      "name": "AccountLack",
+      "msg": "Account lack"
+    },
+    {
+      "code": 6003,
+      "name": "ClosePositionErr",
+      "msg": "Remove liquidity, collect fees owed and reward then you can close position account"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidTickIndex",
+      "msg": "Tick out of range"
+    },
+    {
+      "code": 6005,
+      "name": "TickInvalidOrder",
+      "msg": "The lower tick must be below the upper tick"
+    },
+    {
+      "code": 6006,
+      "name": "TickLowerOverflow",
+      "msg": "The tick must be greater, or equal to the minimum tick(-443636)"
+    },
+    {
+      "code": 6007,
+      "name": "TickUpperOverflow",
+      "msg": "The tick must be lesser than, or equal to the maximum tick(443636)"
+    },
+    {
+      "code": 6008,
+      "name": "TickAndSpacingNotMatch",
+      "msg": "tick % tick_spacing must be zero"
+    },
+    {
+      "code": 6009,
+      "name": "InvalidTickArray",
+      "msg": "Invalid tick array account"
+    },
+    {
+      "code": 6010,
+      "name": "InvalidTickArrayBoundary",
+      "msg": "Invalid tick array boundary"
+    },
+    {
+      "code": 6011,
+      "name": "SqrtPriceLimitOverflow",
+      "msg": "Square root price limit overflow"
+    },
+    {
+      "code": 6012,
+      "name": "SqrtPriceX64",
+      "msg": "sqrt_price_x64 out of range"
+    },
+    {
+      "code": 6013,
+      "name": "LiquiditySubValueErr",
+      "msg": "Liquidity sub delta L must be smaller than before"
+    },
+    {
+      "code": 6014,
+      "name": "LiquidityAddValueErr",
+      "msg": "Liquidity add delta L must be greater, or equal to before"
+    },
+    {
+      "code": 6015,
+      "name": "ForbidBothZeroForSupplyLiquidity",
+      "msg": "Both token amount must not be zero while supply liquidity"
+    },
+    {
+      "code": 6016,
+      "name": "LiquidityInsufficient",
+      "msg": "Liquidity insufficient"
+    },
+    {
+      "code": 6017,
+      "name": "PriceSlippageCheck",
+      "msg": "Price slippage check"
+    },
+    {
+      "code": 6018,
+      "name": "TooLittleOutputReceived",
+      "msg": "Too little output received"
+    },
+    {
+      "code": 6019,
+      "name": "TooMuchInputPaid",
+      "msg": "Too much input paid"
+    },
+    {
+      "code": 6020,
+      "name": "ZeroAmountSpecified",
+      "msg": "Swap special amount can not be zero"
+    },
+    {
+      "code": 6021,
+      "name": "InvalidInputPoolVault",
+      "msg": "Input pool vault is invalid"
+    },
+    {
+      "code": 6022,
+      "name": "TooSmallInputOrOutputAmount",
+      "msg": "Swap input or output amount is too small"
+    },
+    {
+      "code": 6023,
+      "name": "NotEnoughTickArrayAccount",
+      "msg": "Not enough tick array account"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidFirstTickArrayAccount",
+      "msg": "Invalid first tick array account"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidRewardIndex",
+      "msg": "Invalid reward index"
+    },
+    {
+      "code": 6026,
+      "name": "FullRewardInfo",
+      "msg": "The init reward token reach to the max"
+    },
+    {
+      "code": 6027,
+      "name": "RewardTokenAlreadyInUse",
+      "msg": "The init reward token already in use"
+    },
+    {
+      "code": 6028,
+      "name": "ExceptRewardMint",
+      "msg": "The reward tokens must contain one of pool vault mint except the last reward"
+    },
+    {
+      "code": 6029,
+      "name": "InvalidRewardInitParam",
+      "msg": "Invalid reward init param"
+    },
+    {
+      "code": 6030,
+      "name": "InvalidRewardInputAccountNumber",
+      "msg": "Invalid collect reward input account number"
+    },
+    {
+      "code": 6031,
+      "name": "InvalidRewardPeriod",
+      "msg": "Invalid reward period"
+    },
+    {
+      "code": 6032,
+      "name": "NotApproveUpdateRewardEmissions",
+      "msg": "Modification of emissions is allowed within 72 hours from the end of the previous cycle"
+    },
+    {
+      "code": 6033,
+      "name": "UnInitializedRewardInfo",
+      "msg": "uninitialized reward info"
+    },
+    {
+      "code": 6034,
+      "name": "NotSupportMint",
+      "msg": "Not support token_2022 mint extension"
+    },
+    {
+      "code": 6035,
+      "name": "MissingTickArrayBitmapExtensionAccount",
+      "msg": "Missing tickarray bitmap extension account"
+    },
+    {
+      "code": 6036,
+      "name": "InsufficientLiquidityForDirection",
+      "msg": "Insufficient liquidity for this direction"
+    },
+    {
+      "code": 6037,
+      "name": "MaxTokenOverflow",
+      "msg": "Max token overflow"
+    },
+    {
+      "code": 6038,
+      "name": "CalculateOverflow",
+      "msg": "Calculate overflow"
+    },
+    {
+      "code": 6039,
+      "name": "TransferFeeCalculateNotMatch",
+      "msg": "TransferFee calculate not match"
+    },
+    {
+      "code": 6040,
+      "name": "OrderAlreadyFilled",
+      "msg": "Order already fully filled, cannot modify"
+    },
+    {
+      "code": 6041,
+      "name": "InvalidOrderPhase",
+      "msg": "Invalid order phase"
+    },
+    {
+      "code": 6042,
+      "name": "InvalidLimitOrderAmount",
+      "msg": "Invalid limit order amount"
+    },
+    {
+      "code": 6043,
+      "name": "OrderPhaseSaturated",
+      "msg": "Tick order phase saturated"
+    },
+    {
+      "code": 6044,
+      "name": "InvalidDynamicFeeConfigParams",
+      "msg": "Invalid dynamic fee config params"
+    },
+    {
+      "code": 6045,
+      "name": "InvalidFeeOn",
+      "msg": "Invalid fee on which token (must be 0, 1, or 2)"
+    },
+    {
+      "code": 6046,
+      "name": "ZeroSqrtPrice",
+      "msg": "sqrt_price_x64 must be greater than 0"
+    },
+    {
+      "code": 6047,
+      "name": "ZeroLiquidity",
+      "msg": "liquidity must be greater than 0"
+    },
+    {
+      "code": 6048,
+      "name": "MissingBaseFlag",
+      "msg": "base_flag is required when liquidity is zero"
+    },
+    {
+      "code": 6049,
+      "name": "MissingMintAccount",
+      "msg": "Mint account is required but not provided"
+    },
+    {
+      "code": 6050,
+      "name": "MissingTokenProgram2022",
+      "msg": "Token-2022 program is required but not provided"
+    }
+  ],
+  "types": [
+    {
+      "name": "AmmConfig",
+      "docs": [
+        "Holds the current owner of the factory"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump to identify PDA"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Address of the protocol owner"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_fee_rate",
+            "docs": [
+              "The protocol fee"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "trade_fee_rate",
+            "docs": [
+              "The trade fee, denominated in hundredths of a bip (10^-6)"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "tick_spacing",
+            "docs": [
+              "The tick spacing"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "fund_fee_rate",
+            "docs": [
+              "The fund fee, denominated in hundredths of a bip (10^-6)"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "padding_u32",
+            "type": "u32"
+          },
+          {
+            "name": "fund_owner",
+            "docs": [
+              "The fund owner"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                3
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollectFeeOn",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "FromInput"
+          },
+          {
+            "name": "Token0Only"
+          },
+          {
+            "name": "Token1Only"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollectPersonalFeeEvent",
+      "docs": [
+        "Emitted when tokens are collected for a position"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position_nft_mint",
+            "docs": [
+              "The ID of the token for which underlying tokens were collected"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "recipient_token_account_0",
+            "docs": [
+              "The token account that received the collected token_0 tokens"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "recipient_token_account_1",
+            "docs": [
+              "The token account that received the collected token_1 tokens"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount_0",
+            "docs": [
+              "The amount of token_0 owed to the position that was collected"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1",
+            "docs": [
+              "The amount of token_1 owed to the position that was collected"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CollectProtocolFeeEvent",
+      "docs": [
+        "Emitted when the collected protocol fees are withdrawn by the factory owner"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "docs": [
+              "The pool whose protocol fee is collected"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "recipient_token_account_0",
+            "docs": [
+              "The address that receives the collected token_0 protocol fees"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "recipient_token_account_1",
+            "docs": [
+              "The address that receives the collected token_1 protocol fees"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount_0",
+            "docs": [
+              "The amount of token_0 protocol fees that is withdrawn"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1",
+            "docs": [
+              "The amount of token_0 protocol fees that is withdrawn"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ConfigChangeEvent",
+      "docs": [
+        "Emitted when create or update a config"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "protocol_fee_rate",
+            "type": "u32"
+          },
+          {
+            "name": "trade_fee_rate",
+            "type": "u32"
+          },
+          {
+            "name": "tick_spacing",
+            "type": "u16"
+          },
+          {
+            "name": "fund_fee_rate",
+            "type": "u32"
+          },
+          {
+            "name": "fund_owner",
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreateCustomizableParams",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "sqrt_price_x64",
+            "type": "u128"
+          },
+          {
+            "name": "collect_fee_on",
+            "type": {
+              "defined": {
+                "name": "CollectFeeOn"
+              }
+            }
+          },
+          {
+            "name": "enable_dynamic_fee",
+            "type": "bool"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreatePersonalPositionEvent",
+      "docs": [
+        "Emitted when create a new position"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "docs": [
+              "The pool for which liquidity was added"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "minter",
+            "docs": [
+              "The address that create the position"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "nft_owner",
+            "docs": [
+              "The owner of the position and recipient of any minted liquidity"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "tick_lower_index",
+            "docs": [
+              "The lower tick of the position"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "tick_upper_index",
+            "docs": [
+              "The upper tick of the position"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "The amount of liquidity minted to the position range"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "deposit_amount_0",
+            "docs": [
+              "The amount of token_0 was deposit for the liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "deposit_amount_1",
+            "docs": [
+              "The amount of token_1 was deposit for the liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "deposit_amount_0_transfer_fee",
+            "docs": [
+              "The token transfer fee for deposit_amount_0"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "deposit_amount_1_transfer_fee",
+            "docs": [
+              "The token transfer fee for deposit_amount_1"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DecreaseLimitOrderEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "docs": [
+              "The pool whose limit order was decreased"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "docs": [
+              "The limit order account"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "zero_for_one",
+            "docs": [
+              "Direction of the limit order (true if zero_for_one)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "tick_index",
+            "docs": [
+              "Tick index of the limit order"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "total_amount",
+            "docs": [
+              "Total amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "filled_amount",
+            "docs": [
+              "Filled amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "settled_output_amount",
+            "docs": [
+              "Amount of output tokens settled (excluding fees)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "decreased_amount",
+            "docs": [
+              "Amount of input tokens returned to user"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DecreaseLiquidityEvent",
+      "docs": [
+        "Emitted when liquidity is decreased."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position_nft_mint",
+            "docs": [
+              "The ID of the token for which liquidity was decreased"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "The amount by which liquidity for the position was decreased"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "decrease_amount_0",
+            "docs": [
+              "The amount of token_0 that was paid for the decrease in liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "decrease_amount_1",
+            "docs": [
+              "The amount of token_1 that was paid for the decrease in liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fee_amount_0",
+            "type": "u64"
+          },
+          {
+            "name": "fee_amount_1",
+            "docs": [
+              "The amount of token_1 fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "reward_amounts",
+            "docs": [
+              "The amount of rewards"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                3
+              ]
+            }
+          },
+          {
+            "name": "transfer_fee_0",
+            "docs": [
+              "The amount of token_0 transfer fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_1",
+            "docs": [
+              "The amount of token_1 transfer fee"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeConfig",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "type": "u16"
+          },
+          {
+            "name": "filter_period",
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "type": "u16"
+          },
+          {
+            "name": "dynamic_fee_control",
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "type": "u32"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DynamicFeeInfo",
+      "docs": [
+        "Dynamic fee information for pool configuration"
+      ],
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "filter_period",
+            "docs": [
+              "Period that determines the high frequency trading time window (in seconds)."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "decay_period",
+            "docs": [
+              "Period that determines when the dynamic fee starts to decrease (in seconds)."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reduction_factor",
+            "docs": [
+              "Dynamic fee rate decrement rate, used for volatility reference decay."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "dynamic_fee_control",
+            "docs": [
+              "Factor used to scale the dynamic fee component in the fee rate calculation."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "max_volatility_accumulator",
+            "docs": [
+              "Maximum value for the volatility accumulator, used to cap the dynamic fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "tick_spacing_index_reference",
+            "docs": [
+              "Active tick spacing index at the last reference update."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "volatility_reference",
+            "docs": [
+              "Volatility reference value, stores the decayed volatility accumulator."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "volatility_accumulator",
+            "docs": [
+              "Volatility accumulator, used to calculate the dynamic fee rate."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "last_update_timestamp",
+            "docs": [
+              "Last timestamp (block time) when `volatility_reference` and `tick_spacing_index_reference` were updated."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Reserved for future upgrades."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                46
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "IncreaseLimitOrderEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "docs": [
+              "The pool whose limit order was increased"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "docs": [
+              "The limit order account"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "zero_for_one",
+            "docs": [
+              "Direction of the limit order (true if zero_for_one)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "tick_index",
+            "docs": [
+              "Tick index of the limit order"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "total_amount",
+            "docs": [
+              "Total amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "increased_amount",
+            "docs": [
+              "Increased amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee",
+            "docs": [
+              "Transfer fee of the limit order"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "IncreaseLiquidityEvent",
+      "docs": [
+        "Emitted when liquidity is increased."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "position_nft_mint",
+            "docs": [
+              "The ID of the token for which liquidity was increased"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "The amount by which liquidity for the NFT position was increased"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "amount_0",
+            "docs": [
+              "The amount of token_0 that was paid for the increase in liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1",
+            "docs": [
+              "The amount of token_1 that was paid for the increase in liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_0_transfer_fee",
+            "docs": [
+              "The token transfer fee for amount_0"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1_transfer_fee",
+            "docs": [
+              "The token transfer fee for amount_1"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "InitializeRewardParam",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "open_time",
+            "docs": [
+              "Reward open time"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "end_time",
+            "docs": [
+              "Reward end time"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "emissions_per_second_x64",
+            "docs": [
+              "Token reward per second are earned per unit of liquidity"
+            ],
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LimitOrderNonce",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "user_wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "nonce_index",
+            "type": "u8"
+          },
+          {
+            "name": "order_nonce",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LimitOrderState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner of this limit order"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "tick_index",
+            "type": "i32"
+          },
+          {
+            "name": "zero_for_one",
+            "type": "bool"
+          },
+          {
+            "name": "order_phase",
+            "docs": [
+              "Order phase of this limit order, aligned with `TickState.order_phase` for FIFO semantics"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_amount",
+            "docs": [
+              "Total amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "filled_amount",
+            "docs": [
+              "Filled amount of the limit order (informational, for events/display)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "settle_base",
+            "docs": [
+              "The unfilled amount when the current computation segment started.",
+              "Set to total_amount on open, reset on decrease. Never updated during settle —",
+              "this avoids cascading floor-division error across multiple settles."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "settled_output",
+            "docs": [
+              "Cumulative output paid to user in the current segment. Reset on decrease.",
+              "Each settle computes total_output from the segment base and pays the diff",
+              "(total_output - settled_output), limiting dust deduction to once per segment."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "open_time",
+            "docs": [
+              "Order open time"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "unfilled_ratio_x64",
+            "docs": [
+              "Snapshot of `TickState.unfilled_ratio_x64` at the time this segment started (Q64.64).",
+              "Initialized to Q64 on open; reset to tick's current ratio on decrease."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityCalculateEvent",
+      "docs": [
+        "Emitted when liquidity decreased or increase."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_liquidity",
+            "docs": [
+              "The pool liquidity before decrease or increase"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "pool_sqrt_price_x64",
+            "docs": [
+              "The pool price when decrease or increase in liquidity"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "pool_tick",
+            "docs": [
+              "The pool tick when decrease or increase in liquidity"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "calc_amount_0",
+            "docs": [
+              "The amount of token_0 that was calculated for the decrease or increase in liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "calc_amount_1",
+            "docs": [
+              "The amount of token_1 that was calculated for the decrease or increase in liquidity"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_owed_0",
+            "type": "u64"
+          },
+          {
+            "name": "trade_fee_owed_1",
+            "docs": [
+              "The amount of token_1 fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_0",
+            "docs": [
+              "The amount of token_0 transfer fee without trade_fee_amount_0"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_1",
+            "docs": [
+              "The amount of token_1 transfer fee without trade_fee_amount_0"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LiquidityChangeEvent",
+      "docs": [
+        "Emitted pool liquidity change when increase and decrease liquidity"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "docs": [
+              "The pool for swap"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "tick",
+            "docs": [
+              "The tick of the pool"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "tick_lower",
+            "docs": [
+              "The tick lower of position"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "tick_upper",
+            "docs": [
+              "The tick lower of position"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "liquidity_before",
+            "docs": [
+              "The liquidity of the pool before liquidity change"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "liquidity_after",
+            "docs": [
+              "The liquidity of the pool after liquidity change"
+            ],
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Observation",
+      "docs": [
+        "The element of observations in ObservationState"
+      ],
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "block_timestamp",
+            "docs": [
+              "The block timestamp of the observation"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "tick_cumulative",
+            "docs": [
+              "the cumulative of tick during the duration time"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for feature update"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ObservationState",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "initialized",
+            "docs": [
+              "Whether the ObservationState is initialized"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "recent_epoch",
+            "docs": [
+              "recent update epoch"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "observation_index",
+            "docs": [
+              "the most-recently updated index of the observations array"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "pool_id",
+            "docs": [
+              "belongs to which pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "observations",
+            "docs": [
+              "observation array"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "Observation"
+                  }
+                },
+                100
+              ]
+            }
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for feature update"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "OpenLimitOrderEvent",
+      "docs": [
+        "Emitted when a limit order is opened"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "docs": [
+              "The pool whose limit order was opened"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "docs": [
+              "The limit order account"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "zero_for_one",
+            "docs": [
+              "Direction of the limit order (true if zero_for_one)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "tick_index",
+            "docs": [
+              "Tick index of the limit order"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "total_amount",
+            "docs": [
+              "Total amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee",
+            "docs": [
+              "Transfer fee of the limit order"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OperationState",
+      "docs": [
+        "Holds the current owner of the factory"
+      ],
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump to identify PDA"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "operation_owners",
+            "docs": [
+              "Address of the operation owner"
+            ],
+            "type": {
+              "array": [
+                "pubkey",
+                10
+              ]
+            }
+          },
+          {
+            "name": "whitelist_mints",
+            "docs": [
+              "The mint address of whitelist to emit reward"
+            ],
+            "type": {
+              "array": [
+                "pubkey",
+                100
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PersonalPositionState",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump to identify PDA"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                1
+              ]
+            }
+          },
+          {
+            "name": "nft_mint",
+            "docs": [
+              "Mint address of the tokenized position"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_id",
+            "docs": [
+              "The ID of the pool with which this token is connected"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "tick_lower_index",
+            "docs": [
+              "The lower bound tick of the position"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "tick_upper_index",
+            "docs": [
+              "The upper bound tick of the position"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "The amount of liquidity owned by this position"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "fee_growth_inside_0_last_x64",
+            "docs": [
+              "The token_0 fee growth of the aggregate position as of the last action on the individual position"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "fee_growth_inside_1_last_x64",
+            "docs": [
+              "The token_1 fee growth of the aggregate position as of the last action on the individual position"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "token_fees_owed_0",
+            "docs": [
+              "The fees owed to the position owner in token_0, as of the last computation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_fees_owed_1",
+            "docs": [
+              "The fees owed to the position owner in token_1, as of the last computation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "reward_infos",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "PositionRewardInfo"
+                  }
+                },
+                3
+              ]
+            }
+          },
+          {
+            "name": "recent_epoch",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                7
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolCreatedEvent",
+      "docs": [
+        "Emitted when a pool is created and initialized with a starting price",
+        ""
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "token_mint_0",
+            "docs": [
+              "The first token of the pool by address sort order"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint_1",
+            "docs": [
+              "The second token of the pool by address sort order"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "tick_spacing",
+            "docs": [
+              "The minimum number of ticks between initialized ticks"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "pool_state",
+            "docs": [
+              "The address of the created pool"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "sqrt_price_x64",
+            "docs": [
+              "The initial sqrt price of the pool, as a Q64.64"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "tick",
+            "docs": [
+              "The initial tick of the pool, i.e. log base 1.0001 of the starting price of the pool"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "token_vault_0",
+            "docs": [
+              "Vault of token_0"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_vault_1",
+            "docs": [
+              "Vault of token_1"
+            ],
+            "type": "pubkey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolState",
+      "docs": [
+        "The pool state",
+        "",
+        "PDA of `[POOL_SEED, config, token_mint_0, token_mint_1]`",
+        ""
+      ],
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump to identify PDA"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                1
+              ]
+            }
+          },
+          {
+            "name": "amm_config",
+            "type": "pubkey"
+          },
+          {
+            "name": "owner",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint_0",
+            "docs": [
+              "Token pair of the pool, where token_mint_0 address < token_mint_1 address"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_mint_1",
+            "type": "pubkey"
+          },
+          {
+            "name": "token_vault_0",
+            "docs": [
+              "Token pair vault"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_vault_1",
+            "type": "pubkey"
+          },
+          {
+            "name": "observation_key",
+            "docs": [
+              "observation account key"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "mint_decimals_0",
+            "docs": [
+              "mint0 and mint1 decimals"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "mint_decimals_1",
+            "type": "u8"
+          },
+          {
+            "name": "tick_spacing",
+            "docs": [
+              "The minimum number of ticks between initialized ticks"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "The currently in range liquidity available to the pool."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "sqrt_price_x64",
+            "docs": [
+              "The current price of the pool as a sqrt(token_1/token_0) Q64.64 value"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "tick_current",
+            "docs": [
+              "The current tick of the pool, i.e. according to the last tick transition that was run."
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "padding3",
+            "type": "u16"
+          },
+          {
+            "name": "padding4",
+            "type": "u16"
+          },
+          {
+            "name": "fee_growth_global_0_x64",
+            "docs": [
+              "The fee growth as a Q64.64 number, i.e. fees of token_0 and token_1 collected per",
+              "unit of liquidity for the entire life of the pool."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "fee_growth_global_1_x64",
+            "type": "u128"
+          },
+          {
+            "name": "protocol_fees_token_0",
+            "docs": [
+              "The amounts of token_0 and token_1 that are owed to the protocol."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fees_token_1",
+            "type": "u64"
+          },
+          {
+            "name": "padding5",
+            "type": {
+              "array": [
+                "u128",
+                4
+              ]
+            }
+          },
+          {
+            "name": "status",
+            "docs": [
+              "Bitwise representation of the state of the pool",
+              "bit0, 1: disable open position and increase liquidity, 0: normal",
+              "bit1, 1: disable decrease liquidity, 0: normal",
+              "bit2, 1: disable collect fee, 0: normal",
+              "bit3, 1: disable collect reward, 0: normal",
+              "bit4, 1: disable swap, 0: normal",
+              "bit5, 1: disable limit order, 0: normal"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "fee_on",
+            "docs": [
+              "Fee on which token (0 = FromInput, 1 = Token0Only, 2 = Token1Only)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "Leave blank for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "reward_infos",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "RewardInfo"
+                  }
+                },
+                3
+              ]
+            }
+          },
+          {
+            "name": "tick_array_bitmap",
+            "docs": [
+              "Packed initialized tick array state"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                16
+              ]
+            }
+          },
+          {
+            "name": "padding6",
+            "type": {
+              "array": [
+                "u64",
+                4
+              ]
+            }
+          },
+          {
+            "name": "fund_fees_token_0",
+            "type": "u64"
+          },
+          {
+            "name": "fund_fees_token_1",
+            "type": "u64"
+          },
+          {
+            "name": "open_time",
+            "type": "u64"
+          },
+          {
+            "name": "recent_epoch",
+            "type": "u64"
+          },
+          {
+            "name": "dynamic_fee_info",
+            "docs": [
+              "Dynamic fee info"
+            ],
+            "type": {
+              "defined": {
+                "name": "DynamicFeeInfo"
+              }
+            }
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u64",
+                14
+              ]
+            }
+          },
+          {
+            "name": "padding2",
+            "type": {
+              "array": [
+                "u64",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PositionRewardInfo",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "growth_inside_last_x64",
+            "type": "u128"
+          },
+          {
+            "name": "reward_amount_owed",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtocolPositionState",
+      "docs": [
+        "Info stored for each user's position"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump to identify PDA"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "pool_id",
+            "docs": [
+              "The ID of the pool with which this token is connected"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "tick_lower_index",
+            "docs": [
+              "The lower bound tick of the position"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "tick_upper_index",
+            "docs": [
+              "The upper bound tick of the position"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "The amount of liquidity owned by this position"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "fee_growth_inside_0_last_x64",
+            "docs": [
+              "The token_0 fee growth per unit of liquidity as of the last update to liquidity or fees owed"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "fee_growth_inside_1_last_x64",
+            "docs": [
+              "The token_1 fee growth per unit of liquidity as of the last update to liquidity or fees owed"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "token_fees_owed_0",
+            "docs": [
+              "The fees owed to the position owner in token_0"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_fees_owed_1",
+            "docs": [
+              "The fees owed to the position owner in token_1"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "reward_growth_inside",
+            "docs": [
+              "The reward growth per unit of liquidity as of the last update to liquidity"
+            ],
+            "type": {
+              "array": [
+                "u128",
+                3
+              ]
+            }
+          },
+          {
+            "name": "recent_epoch",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                7
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RewardInfo",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "reward_state",
+            "docs": [
+              "Reward state"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "open_time",
+            "docs": [
+              "Reward open time"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "end_time",
+            "docs": [
+              "Reward end time"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "last_update_time",
+            "docs": [
+              "Reward last update time"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "emissions_per_second_x64",
+            "docs": [
+              "Q64.64 number indicates how many tokens per second are earned per unit of liquidity."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "reward_total_emitted",
+            "docs": [
+              "The total amount of reward emitted"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "reward_claimed",
+            "docs": [
+              "The total amount of claimed reward"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_mint",
+            "docs": [
+              "Reward token mint."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_vault",
+            "docs": [
+              "Reward vault token account."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "authority",
+            "docs": [
+              "The owner that has permission to set reward param"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "reward_growth_global_x64",
+            "docs": [
+              "Q64.64 number that tracks the total tokens earned per unit of liquidity since the reward",
+              "emissions were turned on."
+            ],
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SettleLimitOrderEvent",
+      "docs": [
+        "Emitted when a limit order is settled and proceeds are transferred"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "docs": [
+              "The pool whose limit order was settled"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "limit_order",
+            "docs": [
+              "The limit order account"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "zero_for_one",
+            "docs": [
+              "Direction of the limit order (true if zero_for_one)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "tick_index",
+            "docs": [
+              "Tick index of the limit order"
+            ],
+            "type": "i32"
+          },
+          {
+            "name": "total_amount",
+            "docs": [
+              "Total amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "filled_amount",
+            "docs": [
+              "Filled amount of the limit order"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "settled_amount_out",
+            "docs": [
+              "Amount of output tokens transferred (excluding fees)"
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SupportMintAssociated",
+      "docs": [
+        "Holds the current owner of the factory"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump to identify PDA"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "mint",
+            "docs": [
+              "Address of the supported token22 mint"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u64",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapEvent",
+      "docs": [
+        "Emitted by when a swap is performed for a pool"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_state",
+            "docs": [
+              "The pool for which token_0 and token_1 were swapped"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "sender",
+            "docs": [
+              "The address that initiated the swap call, and that received the callback"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_account_0",
+            "docs": [
+              "The payer token account in zero for one swaps, or the recipient token account",
+              "in one for zero swaps"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_account_1",
+            "docs": [
+              "The payer token account in one for zero swaps, or the recipient token account",
+              "in zero for one swaps"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount_0",
+            "docs": [
+              "The real delta amount of the token_0 of the pool or user"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_0",
+            "docs": [
+              "The transfer fee charged by the withheld_amount of the token_0"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "amount_1",
+            "docs": [
+              "The real delta of the token_1 of the pool or user"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "transfer_fee_1",
+            "docs": [
+              "The transfer fee charged by the withheld_amount of the token_1"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "zero_for_one",
+            "docs": [
+              "if true, amount_0 is negtive and amount_1 is positive"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "sqrt_price_x64",
+            "docs": [
+              "The sqrt(price) of the pool after the swap, as a Q64.64"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "liquidity",
+            "docs": [
+              "The liquidity of the pool after the swap"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "tick",
+            "docs": [
+              "The log base 1.0001 of price of the pool after the swap"
+            ],
+            "type": "i32"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TickArrayBitmapExtension",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "positive_tick_array_bitmap",
+            "docs": [
+              "Packed initialized tick array state for start_tick_index is positive"
+            ],
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    "u64",
+                    8
+                  ]
+                },
+                14
+              ]
+            }
+          },
+          {
+            "name": "negative_tick_array_bitmap",
+            "docs": [
+              "Packed initialized tick array state for start_tick_index is negitive"
+            ],
+            "type": {
+              "array": [
+                {
+                  "array": [
+                    "u64",
+                    8
+                  ]
+                },
+                14
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TickArrayState",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "start_tick_index",
+            "type": "i32"
+          },
+          {
+            "name": "ticks",
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "TickState"
+                  }
+                },
+                60
+              ]
+            }
+          },
+          {
+            "name": "initialized_tick_count",
+            "type": "u8"
+          },
+          {
+            "name": "recent_epoch",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u8",
+                107
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "TickState",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "tick",
+            "type": "i32"
+          },
+          {
+            "name": "liquidity_net",
+            "docs": [
+              "Amount of net liquidity added (subtracted) when tick is crossed from left to right (right to left)"
+            ],
+            "type": "i128"
+          },
+          {
+            "name": "liquidity_gross",
+            "docs": [
+              "The total position liquidity that references this tick"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "fee_growth_outside_0_x64",
+            "docs": [
+              "Fee growth per unit of liquidity on the _other_ side of this tick (relative to the current tick)",
+              "only has relative meaning, not absolute — the value depends on when the tick is initialized"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "fee_growth_outside_1_x64",
+            "type": "u128"
+          },
+          {
+            "name": "reward_growths_outside_x64",
+            "docs": [
+              "Reward growth per unit of liquidity like fee, array of Q64.64"
+            ],
+            "type": {
+              "array": [
+                "u128",
+                3
+              ]
+            }
+          },
+          {
+            "name": "order_phase",
+            "docs": [
+              "Order phase of the tick, used as a FIFO cohort index for limit orders"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "orders_amount",
+            "docs": [
+              "The amount of limit orders that have never been matched,",
+              "only counts newly opened orders, not partially filled ones"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "part_filled_orders_remaining",
+            "docs": [
+              "Remaining part filled orders amount"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "unfilled_ratio_x64",
+            "docs": [
+              "Cumulative unfilled ratio for the current part-filled cohort (Q64.64 format).",
+              "Starts at Q64(1) when a new cohort forms, multiplied down as fills occur."
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "padding",
+            "type": {
+              "array": [
+                "u32",
+                3
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "UpdateRewardInfosEvent",
+      "docs": [
+        "Emitted when Reward are updated for a pool"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "reward_growth_global_x64",
+            "docs": [
+              "Reward info"
+            ],
+            "type": {
+              "array": [
+                "u128",
+                3
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/idl/raydium_cpmm.json
+++ b/idl/raydium_cpmm.json
@@ -1,192 +1,337 @@
 {
-  "version": "0.1.0",
-  "name": "raydium_cp_swap",
+  "address": "CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C",
   "metadata": {
-    "address": "CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C"
+    "name": "raydium_cp_swap",
+    "version": "0.2.0",
+    "spec": "0.1.0",
+    "description": "Raydium constant product AMM, supports Token2022 and without Openbook"
   },
   "instructions": [
     {
-      "name": "createAmmConfig",
+      "name": "close_permission_pda",
       "docs": [
+        "Close a permission account",
+        "",
         "# Arguments",
         "",
-        "* `ctx`- The accounts needed by instruction.",
-        "* `index` - The index of amm config, there may be multiple config.",
-        "* `trade_fee_rate` - Trade fee rate, can be changed.",
-        "* `protocol_fee_rate` - The rate of protocol fee within tarde fee.",
-        "* `fund_fee_rate` - The rate of fund fee within tarde fee.",
+        "* `ctx`- The context of accounts",
         ""
+      ],
+      "discriminator": [
+        156,
+        84,
+        32,
+        118,
+        69,
+        135,
+        70,
+        123
       ],
       "accounts": [
         {
           "name": "owner",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Address to be set as protocol owner."]
+          "writable": true,
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
         },
         {
-          "name": "ammConfig",
-          "isMut": true,
-          "isSigner": false,
+          "name": "permission_authority"
+        },
+        {
+          "name": "permission",
           "docs": [
             "Initialize config state account to store protocol owner address and fee rates."
-          ]
-        },
-        { "name": "systemProgram", "isMut": false, "isSigner": false }
-      ],
-      "args": [
-        { "name": "index", "type": "u16" },
-        { "name": "tradeFeeRate", "type": "u64" },
-        { "name": "protocolFeeRate", "type": "u64" },
-        { "name": "fundFeeRate", "type": "u64" },
-        { "name": "createPoolFee", "type": "u64" }
-      ]
-    },
-    {
-      "name": "updateAmmConfig",
-      "docs": [
-        "Updates the owner of the amm config",
-        "Must be called by the current owner or admin",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx`- The context of accounts",
-        "* `trade_fee_rate`- The new trade fee rate of amm config, be set when `param` is 0",
-        "* `protocol_fee_rate`- The new protocol fee rate of amm config, be set when `param` is 1",
-        "* `fund_fee_rate`- The new fund fee rate of amm config, be set when `param` is 2",
-        "* `new_owner`- The config's new owner, be set when `param` is 3",
-        "* `new_fund_owner`- The config's new fund owner, be set when `param` is 4",
-        "* `param`- The vaule can be 0 | 1 | 2 | 3 | 4, otherwise will report a error",
-        ""
-      ],
-      "accounts": [
-        {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["The amm config owner or admin"]
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "permission_authority"
+              }
+            ]
+          }
         },
         {
-          "name": "ammConfig",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Amm config account to be changed"]
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
-      "args": [
-        { "name": "param", "type": "u8" },
-        { "name": "value", "type": "u64" }
-      ]
+      "args": []
     },
     {
-      "name": "updatePoolStatus",
+      "name": "collect_creator_fee",
       "docs": [
-        "Update pool status for given vaule",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx`- The context of accounts",
-        "* `status` - The vaule of status",
-        ""
-      ],
-      "accounts": [
-        { "name": "authority", "isMut": false, "isSigner": true },
-        { "name": "poolState", "isMut": true, "isSigner": false }
-      ],
-      "args": [{ "name": "status", "type": "u8" }]
-    },
-    {
-      "name": "collectProtocolFee",
-      "docs": [
-        "Collect the protocol fee accrued to the pool",
+        "Collect the creator fee",
         "",
         "# Arguments",
         "",
         "* `ctx` - The context of accounts",
-        "* `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1",
-        "* `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0",
         ""
+      ],
+      "discriminator": [
+        20,
+        22,
+        86,
+        123,
+        198,
+        28,
+        219,
+        132
       ],
       "accounts": [
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Only admin or owner can collect fee now"]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool state stores accumulated protocol fee amount"]
-        },
-        {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Amm config account stores owner"]
-        },
-        {
-          "name": "token0Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_0"]
-        },
-        {
-          "name": "token1Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_1"]
-        },
-        {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_0 vault"]
-        },
-        {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_1 vault"]
-        },
-        {
-          "name": "recipientToken0Account",
-          "isMut": true,
-          "isSigner": false,
+          "name": "creator",
           "docs": [
-            "The address that receives the collected token_0 protocol fees"
+            "Only pool creator can collect fee"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Pool state stores accumulated protocol fee amount"
+          ],
+          "writable": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Amm config account stores fund_owner"
           ]
         },
         {
-          "name": "recipientToken1Account",
-          "isMut": true,
-          "isSigner": false,
+          "name": "token_0_vault",
           "docs": [
-            "The address that receives the collected token_1 protocol fees"
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_1_vault",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token_0 vault"
           ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The SPL program to perform token transfers"]
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token_1 vault"
+          ]
         },
         {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The SPL program 2022 to perform token transfers"]
+          "name": "creator_token_0",
+          "docs": [
+            "The address that receives the collected token_0 fund fees"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "creator"
+              },
+              {
+                "kind": "account",
+                "path": "token_0_program"
+              },
+              {
+                "kind": "account",
+                "path": "vault_0_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "creator_token_1",
+          "docs": [
+            "The address that receives the collected token_1 fund fees"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "creator"
+              },
+              {
+                "kind": "account",
+                "path": "token_1_program"
+              },
+              {
+                "kind": "account",
+                "path": "vault_1_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_0_program",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "token_1_program",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Program to create an ATA for receiving position NFT"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "To create a new program account"
+          ],
+          "address": "11111111111111111111111111111111"
         }
       ],
-      "args": [
-        { "name": "amount0Requested", "type": "u64" },
-        { "name": "amount1Requested", "type": "u64" }
-      ]
+      "args": []
     },
     {
-      "name": "collectFundFee",
+      "name": "collect_fund_fee",
       "docs": [
         "Collect the fund fee accrued to the pool",
         "",
@@ -197,78 +342,607 @@
         "* `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0",
         ""
       ],
+      "discriminator": [
+        167,
+        138,
+        78,
+        149,
+        223,
+        194,
+        6,
+        126
+      ],
       "accounts": [
         {
           "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Only admin or fund_owner can collect fee now"]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool state stores accumulated protocol fee amount"]
+          "docs": [
+            "Only admin or fund_owner can collect fee now"
+          ],
+          "signer": true
         },
         {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Amm config account stores fund_owner"]
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "token0Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_0"]
+          "name": "pool_state",
+          "docs": [
+            "Pool state stores accumulated protocol fee amount"
+          ],
+          "writable": true
         },
         {
-          "name": "token1Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_1"]
+          "name": "amm_config",
+          "docs": [
+            "Amm config account stores fund_owner"
+          ]
         },
         {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_0 vault"]
+          "name": "token_0_vault",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
         },
         {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_1 vault"]
+          "name": "token_1_vault",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
         },
         {
-          "name": "recipientToken0Account",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that receives the collected token_0 fund fees"]
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token_0 vault"
+          ]
         },
         {
-          "name": "recipientToken1Account",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that receives the collected token_1 fund fees"]
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token_1 vault"
+          ]
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The SPL program to perform token transfers"]
+          "name": "recipient_token_0_account",
+          "docs": [
+            "The address that receives the collected token_0 fund fees"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The SPL program 2022 to perform token transfers"]
+          "name": "recipient_token_1_account",
+          "docs": [
+            "The address that receives the collected token_1 fund fees"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "The SPL program to perform token transfers"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "The SPL program 2022 to perform token transfers"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
         }
       ],
       "args": [
-        { "name": "amount0Requested", "type": "u64" },
-        { "name": "amount1Requested", "type": "u64" }
+        {
+          "name": "amount_0_requested",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_requested",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "collect_protocol_fee",
+      "docs": [
+        "Collect the protocol fee accrued to the pool",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `amount_0_requested` - The maximum amount of token_0 to send, can be 0 to collect fees in only token_1",
+        "* `amount_1_requested` - The maximum amount of token_1 to send, can be 0 to collect fees in only token_0",
+        ""
+      ],
+      "discriminator": [
+        136,
+        136,
+        252,
+        221,
+        194,
+        66,
+        126,
+        89
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Only admin or owner can collect fee now"
+          ],
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Pool state stores accumulated protocol fee amount"
+          ],
+          "writable": true
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Amm config account stores owner"
+          ]
+        },
+        {
+          "name": "token_0_vault",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_1_vault",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token_0 vault"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token_1 vault"
+          ]
+        },
+        {
+          "name": "recipient_token_0_account",
+          "docs": [
+            "The address that receives the collected token_0 protocol fees"
+          ],
+          "writable": true
+        },
+        {
+          "name": "recipient_token_1_account",
+          "docs": [
+            "The address that receives the collected token_1 protocol fees"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "The SPL program to perform token transfers"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "The SPL program 2022 to perform token transfers"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount_0_requested",
+          "type": "u64"
+        },
+        {
+          "name": "amount_1_requested",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "create_amm_config",
+      "docs": [
+        "# Arguments",
+        "",
+        "* `ctx`- The accounts needed by instruction.",
+        "* `index` - The index of amm config, there may be multiple config.",
+        "* `trade_fee_rate` - Trade fee rate, can be changed.",
+        "* `protocol_fee_rate` - The rate of protocol fee within trade fee.",
+        "* `fund_fee_rate` - The rate of fund fee within trade fee.",
+        ""
+      ],
+      "discriminator": [
+        137,
+        52,
+        237,
+        212,
+        215,
+        117,
+        108,
+        104
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Address to be set as protocol owner."
+          ],
+          "writable": true,
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Initialize config state account to store protocol owner address and fee rates."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  109,
+                  109,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "index"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "index",
+          "type": "u16"
+        },
+        {
+          "name": "trade_fee_rate",
+          "type": "u64"
+        },
+        {
+          "name": "protocol_fee_rate",
+          "type": "u64"
+        },
+        {
+          "name": "fund_fee_rate",
+          "type": "u64"
+        },
+        {
+          "name": "create_pool_fee",
+          "type": "u64"
+        },
+        {
+          "name": "creator_fee_rate",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "create_permission_pda",
+      "docs": [
+        "Create a permission account",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx`- The context of accounts",
+        ""
+      ],
+      "discriminator": [
+        135,
+        136,
+        2,
+        216,
+        137,
+        169,
+        181,
+        202
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "permission_authority"
+        },
+        {
+          "name": "permission",
+          "docs": [
+            "Initialize config state account to store protocol owner address and fee rates."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "permission_authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "deposit",
+      "docs": [
+        "Deposit lp token to the pool",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx`- The context of accounts",
+        "* `lp_token_amount` - Increased number of LPs",
+        "* `maximum_token_0_amount` -  Maximum token 0 amount to deposit, prevents excessive slippage",
+        "* `maximum_token_1_amount` - Maximum token 1 amount to deposit, prevents excessive slippage",
+        ""
+      ],
+      "discriminator": [
+        242,
+        35,
+        198,
+        137,
+        82,
+        225,
+        242,
+        182
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Pays to mint the position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        },
+        {
+          "name": "owner_lp_token",
+          "docs": [
+            "Owner lp token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_0_account",
+          "docs": [
+            "The payer's token account for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_1_account",
+          "docs": [
+            "The payer's token account for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_0_vault",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_1_vault",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token Program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Token program 2022"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token_0 vault"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token_1 vault"
+          ]
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "Lp token mint"
+          ],
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "lp_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "maximum_token_0_amount",
+          "type": "u64"
+        },
+        {
+          "name": "maximum_token_1_amount",
+          "type": "u64"
+        }
       ]
     },
     {
@@ -284,310 +958,832 @@
         "* `open_time` - the timestamp allowed for swap",
         ""
       ],
+      "discriminator": [
+        175,
+        175,
+        109,
+        31,
+        13,
+        152,
+        155,
+        237
+      ],
       "accounts": [
         {
           "name": "creator",
-          "isMut": true,
-          "isSigner": true,
-          "docs": ["Address paying to create the pool. Can be anyone"]
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Which config the pool belongs to."]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Initialize an account to store the pool state"]
+          "name": "amm_config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
         },
         {
-          "name": "token0Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token_0 mint, the key must smaller then token_1 mint."]
+          "name": "authority",
+          "docs": [
+            "pool vault and lp mint authority"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "token1Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token_1 mint, the key must grater then token_0 mint."]
+          "name": "pool_state",
+          "docs": [
+            "PDA account:",
+            "seeds = [",
+            "POOL_SEED.as_bytes(),",
+            "amm_config.key().as_ref(),",
+            "token_0_mint.key().as_ref(),",
+            "token_1_mint.key().as_ref(),",
+            "],",
+            "",
+            "Or random account: must be signed by cli"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["pool lp mint"]
+          "name": "token_0_mint",
+          "docs": [
+            "Token_0 mint, the key must smaller than token_1 mint."
+          ]
         },
         {
-          "name": "creatorToken0",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["payer token0 account"]
+          "name": "token_1_mint",
+          "docs": [
+            "Token_1 mint, the key must grater then token_0 mint."
+          ]
         },
         {
-          "name": "creatorToken1",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["creator token1 account"]
+          "name": "lp_mint",
+          "docs": [
+            "pool lp mint"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
         },
         {
-          "name": "creatorLpToken",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["creator lp token account"]
-        },
-        { "name": "token0Vault", "isMut": true, "isSigner": false },
-        { "name": "token1Vault", "isMut": true, "isSigner": false },
-        {
-          "name": "createPoolFee",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["create pool fee account"]
+          "name": "creator_token_0",
+          "docs": [
+            "payer token0 account"
+          ],
+          "writable": true
         },
         {
-          "name": "observationState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["an account to store oracle observations"]
+          "name": "creator_token_1",
+          "docs": [
+            "creator token1 account"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Program to create mint account and mint tokens"]
+          "name": "creator_lp_token",
+          "docs": [
+            "creator lp token account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "creator"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "lp_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
         },
         {
-          "name": "token0Program",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Spl token program or token program 2022"]
+          "name": "token_0_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_0_mint"
+              }
+            ]
+          }
         },
         {
-          "name": "token1Program",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Spl token program or token program 2022"]
+          "name": "token_1_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_1_mint"
+              }
+            ]
+          }
         },
         {
-          "name": "associatedTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Program to create an ATA for receiving position NFT"]
+          "name": "create_pool_fee",
+          "docs": [
+            "create pool fee account"
+          ],
+          "writable": true,
+          "address": "DNXgeM9EiiaAbaWvwjHj9fQQLAX5ZsfHyvmYUNRAdNC8"
         },
         {
-          "name": "systemProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["To create a new program account"]
+          "name": "observation_state",
+          "docs": [
+            "an account to store oracle observations"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  98,
+                  115,
+                  101,
+                  114,
+                  118,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_0_program",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "token_1_program",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Program to create an ATA for receiving position NFT"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "To create a new program account"
+          ],
+          "address": "11111111111111111111111111111111"
         },
         {
           "name": "rent",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Sysvar for program account"]
+          "docs": [
+            "Sysvar for program account"
+          ],
+          "address": "SysvarRent111111111111111111111111111111111"
         }
       ],
       "args": [
-        { "name": "initAmount0", "type": "u64" },
-        { "name": "initAmount1", "type": "u64" },
-        { "name": "openTime", "type": "u64" }
+        {
+          "name": "init_amount_0",
+          "type": "u64"
+        },
+        {
+          "name": "init_amount_1",
+          "type": "u64"
+        },
+        {
+          "name": "open_time",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "deposit",
+      "name": "initialize_with_permission",
       "docs": [
-        "Creates a pool for the given token pair and the initial price",
+        "Create a pool with permission",
         "",
         "# Arguments",
         "",
         "* `ctx`- The context of accounts",
-        "* `lp_token_amount` - Pool token amount to transfer. token_a and token_b amount are set by the current exchange rate and size of the pool",
-        "* `maximum_token_0_amount` -  Maximum token 0 amount to deposit, prevents excessive slippage",
-        "* `maximum_token_1_amount` - Maximum token 1 amount to deposit, prevents excessive slippage",
+        "* `init_amount_0` - the initial amount_0 to deposit",
+        "* `init_amount_1` - the initial amount_1 to deposit",
+        "* `open_time` - the timestamp allowed for swap",
+        "* `creator_fee_on` - creator fee model, 0：both token0 and token1 (depends on the input), 1: only token0, 2: only token1",
         ""
+      ],
+      "discriminator": [
+        63,
+        55,
+        254,
+        65,
+        49,
+        178,
+        89,
+        121
       ],
       "accounts": [
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Pays to mint the position"]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        { "name": "poolState", "isMut": true, "isSigner": false },
-        {
-          "name": "ownerLpToken",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Owner lp tokan account"]
+          "name": "payer",
+          "docs": [
+            "Address paying to create the pool. Can be anyone"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "name": "token0Account",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The payer's token account for token_0"]
+          "name": "creator"
         },
         {
-          "name": "token1Account",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The payer's token account for token_1"]
+          "name": "amm_config",
+          "docs": [
+            "Which config the pool belongs to."
+          ]
         },
         {
-          "name": "token0Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_0"]
+          "name": "authority",
+          "docs": [
+            "pool vault and lp mint authority"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
         },
         {
-          "name": "token1Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_1"]
+          "name": "pool_state",
+          "docs": [
+            "PDA account:",
+            "seeds = [",
+            "POOL_SEED.as_bytes(),",
+            "amm_config.key().as_ref(),",
+            "token_0_mint.key().as_ref(),",
+            "token_1_mint.key().as_ref(),",
+            "],",
+            "",
+            "Or random account: must be signed by cli"
+          ],
+          "writable": true
         },
         {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["token Program"]
+          "name": "token_0_mint",
+          "docs": [
+            "Token_0 mint, the key must smaller than token_1 mint."
+          ]
         },
         {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program 2022"]
+          "name": "token_1_mint",
+          "docs": [
+            "Token_1 mint, the key must grater then token_0 mint."
+          ]
         },
         {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_0 vault"]
+          "name": "lp_mint",
+          "docs": [
+            "pool lp mint"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
         },
         {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_1 vault"]
+          "name": "payer_token_0",
+          "docs": [
+            "payer token0 account"
+          ],
+          "writable": true
         },
         {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Lp token mint"]
+          "name": "payer_token_1",
+          "docs": [
+            "payer token1 account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "payer_lp_token",
+          "docs": [
+            "payer lp token account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "account",
+                "path": "payer"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  6,
+                  221,
+                  246,
+                  225,
+                  215,
+                  101,
+                  161,
+                  147,
+                  217,
+                  203,
+                  225,
+                  70,
+                  206,
+                  235,
+                  121,
+                  172,
+                  28,
+                  180,
+                  133,
+                  237,
+                  95,
+                  91,
+                  55,
+                  145,
+                  58,
+                  140,
+                  245,
+                  133,
+                  126,
+                  255,
+                  0,
+                  169
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "lp_mint"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                140,
+                151,
+                37,
+                143,
+                78,
+                36,
+                137,
+                241,
+                187,
+                61,
+                16,
+                41,
+                20,
+                142,
+                13,
+                131,
+                11,
+                90,
+                19,
+                153,
+                218,
+                255,
+                16,
+                132,
+                4,
+                142,
+                123,
+                216,
+                219,
+                233,
+                248,
+                89
+              ]
+            }
+          }
+        },
+        {
+          "name": "token_0_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_0_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_1_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  97,
+                  117,
+                  108,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "token_1_mint"
+              }
+            ]
+          }
+        },
+        {
+          "name": "create_pool_fee",
+          "docs": [
+            "create pool fee account"
+          ],
+          "writable": true,
+          "address": "DNXgeM9EiiaAbaWvwjHj9fQQLAX5ZsfHyvmYUNRAdNC8"
+        },
+        {
+          "name": "observation_state",
+          "docs": [
+            "an account to store oracle observations"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  111,
+                  98,
+                  115,
+                  101,
+                  114,
+                  118,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              }
+            ]
+          }
+        },
+        {
+          "name": "permission",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  101,
+                  114,
+                  109,
+                  105,
+                  115,
+                  115,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "payer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "Program to create mint account and mint tokens"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_0_program",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "token_1_program",
+          "docs": [
+            "Spl token program or token program 2022"
+          ]
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Program to create an ATA for receiving position NFT"
+          ],
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "To create a new program account"
+          ],
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
-        { "name": "lpTokenAmount", "type": "u64" },
-        { "name": "maximumToken0Amount", "type": "u64" },
-        { "name": "maximumToken1Amount", "type": "u64" }
-      ]
-    },
-    {
-      "name": "withdraw",
-      "docs": [
-        "Withdraw lp for token0 ande token1",
-        "",
-        "# Arguments",
-        "",
-        "* `ctx`- The context of accounts",
-        "* `lp_token_amount` - Amount of pool tokens to burn. User receives an output of token a and b based on the percentage of the pool tokens that are returned.",
-        "* `minimum_token_0_amount` -  Minimum amount of token 0 to receive, prevents excessive slippage",
-        "* `minimum_token_1_amount` -  Minimum amount of token 1 to receive, prevents excessive slippage",
-        ""
-      ],
-      "accounts": [
         {
-          "name": "owner",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["Pays to mint the position"]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool state account"]
+          "name": "init_amount_0",
+          "type": "u64"
         },
         {
-          "name": "ownerLpToken",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Owner lp token account"]
+          "name": "init_amount_1",
+          "type": "u64"
         },
         {
-          "name": "token0Account",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The owner's token account for receive token_0"]
+          "name": "open_time",
+          "type": "u64"
         },
         {
-          "name": "token1Account",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The owner's token account for receive token_1"]
-        },
-        {
-          "name": "token0Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_0"]
-        },
-        {
-          "name": "token1Vault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The address that holds pool tokens for token_1"]
-        },
-        {
-          "name": "tokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["token Program"]
-        },
-        {
-          "name": "tokenProgram2022",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["Token program 2022"]
-        },
-        {
-          "name": "vault0Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_0 vault"]
-        },
-        {
-          "name": "vault1Mint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of token_1 vault"]
-        },
-        {
-          "name": "lpMint",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["Pool lp token mint"]
-        },
-        {
-          "name": "memoProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["memo program"]
+          "name": "creator_fee_on",
+          "type": {
+            "defined": {
+              "name": "CreatorFeeOn"
+            }
+          }
         }
-      ],
-      "args": [
-        { "name": "lpTokenAmount", "type": "u64" },
-        { "name": "minimumToken0Amount", "type": "u64" },
-        { "name": "minimumToken1Amount", "type": "u64" }
       ]
     },
     {
-      "name": "swapBaseInput",
+      "name": "swap_base_input",
       "docs": [
         "Swap the tokens in the pool base input amount",
         "",
@@ -598,90 +1794,149 @@
         "* `minimum_amount_out` -  Minimum amount of output token, prevents excessive slippage",
         ""
       ],
+      "discriminator": [
+        143,
+        190,
+        90,
+        218,
+        196,
+        30,
+        51,
+        222
+      ],
       "accounts": [
         {
           "name": "payer",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["The user performing the swap"]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The factory state to read protocol fees"]
-        },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
-            "The program account of the pool in which the swap will be performed"
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "The factory state to read protocol fees"
           ]
         },
         {
-          "name": "inputTokenAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The user token account for input token"]
+          "name": "pool_state",
+          "docs": [
+            "The program account of the pool in which the swap will be performed"
+          ],
+          "writable": true
         },
         {
-          "name": "outputTokenAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The user token account for output token"]
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
         },
         {
-          "name": "inputVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The vault token account for input token"]
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
         },
         {
-          "name": "outputVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The vault token account for output token"]
+          "name": "input_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
         },
         {
-          "name": "inputTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["SPL program for input token transfers"]
+          "name": "output_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
         },
         {
-          "name": "outputTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["SPL program for output token transfers"]
+          "name": "input_token_program",
+          "docs": [
+            "SPL program for input token transfers"
+          ]
         },
         {
-          "name": "inputTokenMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of input token"]
+          "name": "output_token_program",
+          "docs": [
+            "SPL program for output token transfers"
+          ]
         },
         {
-          "name": "outputTokenMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of output token"]
+          "name": "input_token_mint",
+          "docs": [
+            "The mint of input token"
+          ]
         },
         {
-          "name": "observationState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The program account for the most recent oracle observation"]
+          "name": "output_token_mint",
+          "docs": [
+            "The mint of output token"
+          ]
+        },
+        {
+          "name": "observation_state",
+          "docs": [
+            "The program account for the most recent oracle observation"
+          ],
+          "writable": true
         }
       ],
       "args": [
-        { "name": "amountIn", "type": "u64" },
-        { "name": "minimumAmountOut", "type": "u64" }
+        {
+          "name": "amount_in",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_amount_out",
+          "type": "u64"
+        }
       ]
     },
     {
-      "name": "swapBaseOutput",
+      "name": "swap_base_output",
       "docs": [
         "Swap the tokens in the pool base output amount",
         "",
@@ -692,377 +1947,513 @@
         "* `amount_out` -  amount of output token",
         ""
       ],
+      "discriminator": [
+        55,
+        217,
+        98,
+        86,
+        163,
+        74,
+        180,
+        173
+      ],
       "accounts": [
         {
           "name": "payer",
-          "isMut": false,
-          "isSigner": true,
-          "docs": ["The user performing the swap"]
-        },
-        { "name": "authority", "isMut": false, "isSigner": false },
-        {
-          "name": "ammConfig",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The factory state to read protocol fees"]
-        },
-        {
-          "name": "poolState",
-          "isMut": true,
-          "isSigner": false,
           "docs": [
-            "The program account of the pool in which the swap will be performed"
+            "The user performing the swap"
+          ],
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "The factory state to read protocol fees"
           ]
         },
         {
-          "name": "inputTokenAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The user token account for input token"]
+          "name": "pool_state",
+          "docs": [
+            "The program account of the pool in which the swap will be performed"
+          ],
+          "writable": true
         },
         {
-          "name": "outputTokenAccount",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The user token account for output token"]
+          "name": "input_token_account",
+          "docs": [
+            "The user token account for input token"
+          ],
+          "writable": true
         },
         {
-          "name": "inputVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The vault token account for input token"]
+          "name": "output_token_account",
+          "docs": [
+            "The user token account for output token"
+          ],
+          "writable": true
         },
         {
-          "name": "outputVault",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The vault token account for output token"]
+          "name": "input_vault",
+          "docs": [
+            "The vault token account for input token"
+          ],
+          "writable": true
         },
         {
-          "name": "inputTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["SPL program for input token transfers"]
+          "name": "output_vault",
+          "docs": [
+            "The vault token account for output token"
+          ],
+          "writable": true
         },
         {
-          "name": "outputTokenProgram",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["SPL program for output token transfers"]
+          "name": "input_token_program",
+          "docs": [
+            "SPL program for input token transfers"
+          ]
         },
         {
-          "name": "inputTokenMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of input token"]
+          "name": "output_token_program",
+          "docs": [
+            "SPL program for output token transfers"
+          ]
         },
         {
-          "name": "outputTokenMint",
-          "isMut": false,
-          "isSigner": false,
-          "docs": ["The mint of output token"]
+          "name": "input_token_mint",
+          "docs": [
+            "The mint of input token"
+          ]
         },
         {
-          "name": "observationState",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["The program account for the most recent oracle observation"]
+          "name": "output_token_mint",
+          "docs": [
+            "The mint of output token"
+          ]
+        },
+        {
+          "name": "observation_state",
+          "docs": [
+            "The program account for the most recent oracle observation"
+          ],
+          "writable": true
         }
       ],
       "args": [
-        { "name": "maxAmountIn", "type": "u64" },
-        { "name": "amountOut", "type": "u64" }
+        {
+          "name": "max_amount_in",
+          "type": "u64"
+        },
+        {
+          "name": "amount_out",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_amm_config",
+      "docs": [
+        "Updates the owner of the amm config",
+        "Must be called by the current owner or admin",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx`- The context of accounts",
+        "* `trade_fee_rate`- The new trade fee rate of amm config, be set when `param` is 0",
+        "* `protocol_fee_rate`- The new protocol fee rate of amm config, be set when `param` is 1",
+        "* `fund_fee_rate`- The new fund fee rate of amm config, be set when `param` is 2",
+        "* `new_owner`- The config's new owner, be set when `param` is 3",
+        "* `new_fund_owner`- The config's new fund owner, be set when `param` is 4",
+        "* `param`- The value can be 0 | 1 | 2 | 3 | 4, otherwise will report a error",
+        ""
+      ],
+      "discriminator": [
+        49,
+        60,
+        174,
+        136,
+        154,
+        28,
+        116,
+        200
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "The amm config owner or admin"
+          ],
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "amm_config",
+          "docs": [
+            "Amm config account to be changed"
+          ],
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "param",
+          "type": "u8"
+        },
+        {
+          "name": "value",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_pool_status",
+      "docs": [
+        "Update pool status for given value",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx`- The context of accounts",
+        "* `status` - The value of status",
+        ""
+      ],
+      "discriminator": [
+        130,
+        87,
+        108,
+        6,
+        46,
+        224,
+        117,
+        123
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "pool_state",
+          "writable": true
+        }
+      ],
+      "args": [
+        {
+          "name": "status",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "withdraw",
+      "docs": [
+        "Withdraw lp for token0 and token1",
+        "",
+        "# Arguments",
+        "",
+        "* `ctx`- The context of accounts",
+        "* `lp_token_amount` - Amount of pool tokens to burn. User receives an output of token a and b based on the percentage of the pool tokens that are returned.",
+        "* `minimum_token_0_amount` -  Minimum amount of token 0 to receive, prevents excessive slippage",
+        "* `minimum_token_1_amount` -  Minimum amount of token 1 to receive, prevents excessive slippage",
+        ""
+      ],
+      "discriminator": [
+        183,
+        18,
+        70,
+        156,
+        148,
+        109,
+        161,
+        34
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "docs": [
+            "Pays to mint the position"
+          ],
+          "signer": true
+        },
+        {
+          "name": "authority",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  97,
+                  110,
+                  100,
+                  95,
+                  108,
+                  112,
+                  95,
+                  109,
+                  105,
+                  110,
+                  116,
+                  95,
+                  97,
+                  117,
+                  116,
+                  104,
+                  95,
+                  115,
+                  101,
+                  101,
+                  100
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "Pool state account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "owner_lp_token",
+          "docs": [
+            "Owner lp token account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_0_account",
+          "docs": [
+            "The token account for receive token_0,"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_1_account",
+          "docs": [
+            "The token account for receive token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_0_vault",
+          "docs": [
+            "The address that holds pool tokens for token_0"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_1_vault",
+          "docs": [
+            "The address that holds pool tokens for token_1"
+          ],
+          "writable": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "token Program"
+          ],
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "token_program_2022",
+          "docs": [
+            "Token program 2022"
+          ],
+          "address": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        },
+        {
+          "name": "vault_0_mint",
+          "docs": [
+            "The mint of token_0 vault"
+          ]
+        },
+        {
+          "name": "vault_1_mint",
+          "docs": [
+            "The mint of token_1 vault"
+          ]
+        },
+        {
+          "name": "lp_mint",
+          "docs": [
+            "Pool lp token mint"
+          ],
+          "writable": true
+        },
+        {
+          "name": "memo_program",
+          "docs": [
+            "memo program"
+          ],
+          "address": "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+        }
+      ],
+      "args": [
+        {
+          "name": "lp_token_amount",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_token_0_amount",
+          "type": "u64"
+        },
+        {
+          "name": "minimum_token_1_amount",
+          "type": "u64"
+        }
       ]
     }
   ],
   "accounts": [
     {
       "name": "AmmConfig",
-      "docs": ["Holds the current owner of the factory"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          { "name": "bump", "docs": ["Bump to identify PDA"], "type": "u8" },
-          {
-            "name": "disableCreatePool",
-            "docs": ["Status to control if new pool can be create"],
-            "type": "bool"
-          },
-          { "name": "index", "docs": ["Config index"], "type": "u16" },
-          {
-            "name": "tradeFeeRate",
-            "docs": [
-              "The trade fee, denominated in hundredths of a bip (10^-6)"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "protocolFeeRate",
-            "docs": ["The protocol fee"],
-            "type": "u64"
-          },
-          {
-            "name": "fundFeeRate",
-            "docs": [
-              "The fund fee, denominated in hundredths of a bip (10^-6)"
-            ],
-            "type": "u64"
-          },
-          {
-            "name": "createPoolFee",
-            "docs": ["Fee for create a new pool"],
-            "type": "u64"
-          },
-          {
-            "name": "protocolOwner",
-            "docs": ["Address of the protocol fee owner"],
-            "type": "publicKey"
-          },
-          {
-            "name": "fundOwner",
-            "docs": ["Address of the fund fee owner"],
-            "type": "publicKey"
-          },
-          {
-            "name": "padding",
-            "docs": ["padding"],
-            "type": { "array": ["u64", 16] }
-          }
-        ]
-      }
+      "discriminator": [
+        218,
+        244,
+        33,
+        104,
+        203,
+        203,
+        43,
+        111
+      ]
     },
     {
       "name": "ObservationState",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "initialized",
-            "docs": ["Whether the ObservationState is initialized"],
-            "type": "bool"
-          },
-          {
-            "name": "observationIndex",
-            "docs": [
-              "the most-recently updated index of the observations array"
-            ],
-            "type": "u16"
-          },
-          { "name": "poolId", "type": "publicKey" },
-          {
-            "name": "observations",
-            "docs": ["observation array"],
-            "type": { "array": [{ "defined": "Observation" }, 100] }
-          },
-          {
-            "name": "padding",
-            "docs": ["padding for feature update"],
-            "type": { "array": ["u64", 4] }
-          }
-        ]
-      }
+      "discriminator": [
+        122,
+        174,
+        197,
+        53,
+        129,
+        9,
+        165,
+        132
+      ]
+    },
+    {
+      "name": "Permission",
+      "discriminator": [
+        224,
+        83,
+        28,
+        79,
+        10,
+        253,
+        161,
+        28
+      ]
     },
     {
       "name": "PoolState",
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "ammConfig",
-            "docs": ["Which config the pool belongs"],
-            "type": "publicKey"
-          },
-          {
-            "name": "poolCreator",
-            "docs": ["pool creator"],
-            "type": "publicKey"
-          },
-          { "name": "token0Vault", "docs": ["Token A"], "type": "publicKey" },
-          { "name": "token1Vault", "docs": ["Token B"], "type": "publicKey" },
-          {
-            "name": "lpMint",
-            "docs": [
-              "Pool tokens are issued when A or B tokens are deposited.",
-              "Pool tokens can be withdrawn back to the original A or B token."
-            ],
-            "type": "publicKey"
-          },
-          {
-            "name": "token0Mint",
-            "docs": ["Mint information for token A"],
-            "type": "publicKey"
-          },
-          {
-            "name": "token1Mint",
-            "docs": ["Mint information for token B"],
-            "type": "publicKey"
-          },
-          {
-            "name": "token0Program",
-            "docs": ["token_0 program"],
-            "type": "publicKey"
-          },
-          {
-            "name": "token1Program",
-            "docs": ["token_1 program"],
-            "type": "publicKey"
-          },
-          {
-            "name": "observationKey",
-            "docs": ["observation account to store oracle data"],
-            "type": "publicKey"
-          },
-          { "name": "authBump", "type": "u8" },
-          {
-            "name": "status",
-            "docs": [
-              "Bitwise representation of the state of the pool",
-              "bit0, 1: disable deposit(vaule is 1), 0: normal",
-              "bit1, 1: disable withdraw(vaule is 2), 0: normal",
-              "bit2, 1: disable swap(vaule is 4), 0: normal"
-            ],
-            "type": "u8"
-          },
-          { "name": "lpMintDecimals", "type": "u8" },
-          {
-            "name": "mint0Decimals",
-            "docs": ["mint0 and mint1 decimals"],
-            "type": "u8"
-          },
-          { "name": "mint1Decimals", "type": "u8" },
-          { "name": "lpSupply", "docs": ["lp mint supply"], "type": "u64" },
-          {
-            "name": "protocolFeesToken0",
-            "docs": [
-              "The amounts of token_0 and token_1 that are owed to the liquidity provider."
-            ],
-            "type": "u64"
-          },
-          { "name": "protocolFeesToken1", "type": "u64" },
-          { "name": "fundFeesToken0", "type": "u64" },
-          { "name": "fundFeesToken1", "type": "u64" },
-          {
-            "name": "openTime",
-            "docs": ["The timestamp allowed for swap in the pool."],
-            "type": "u64"
-          },
-          {
-            "name": "padding",
-            "docs": ["padding for future updates"],
-            "type": { "array": ["u64", 32] }
-          }
-        ]
-      }
-    }
-  ],
-  "types": [
-    {
-      "name": "Observation",
-      "docs": ["The element of observations in ObservationState"],
-      "type": {
-        "kind": "struct",
-        "fields": [
-          {
-            "name": "blockTimestamp",
-            "docs": ["The block timestamp of the observation"],
-            "type": "u64"
-          },
-          {
-            "name": "cumulativeToken0PriceX32",
-            "docs": [
-              "the cumulative of token0 price during the duration time, Q32.32, the remaining 64 bit for overflow"
-            ],
-            "type": "u128"
-          },
-          {
-            "name": "cumulativeToken1PriceX32",
-            "docs": [
-              "the cumulative of token1 price during the duration time, Q32.32, the remaining 64 bit for overflow"
-            ],
-            "type": "u128"
-          }
-        ]
-      }
-    },
-    {
-      "name": "TradeDirection",
-      "docs": [
-        "The direction of a trade, since curves can be specialized to treat each",
-        "token differently (by adding offsets or weights)"
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "ZeroForOne" }, { "name": "OneForZero" }]
-      }
-    },
-    {
-      "name": "RoundDirection",
-      "docs": [
-        "The direction to round.  Used for pool token to trading token conversions to",
-        "avoid losing value on any deposit or withdrawal."
-      ],
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "Floor" }, { "name": "Ceiling" }]
-      }
-    },
-    {
-      "name": "PoolStatusBitIndex",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          { "name": "Deposit" },
-          { "name": "Withdraw" },
-          { "name": "Swap" }
-        ]
-      }
-    },
-    {
-      "name": "PoolStatusBitFlag",
-      "type": {
-        "kind": "enum",
-        "variants": [{ "name": "Enable" }, { "name": "Disable" }]
-      }
+      "discriminator": [
+        247,
+        237,
+        227,
+        245,
+        215,
+        195,
+        222,
+        70
+      ]
     }
   ],
   "events": [
     {
       "name": "LpChangeEvent",
-      "fields": [
-        { "name": "poolId", "type": "publicKey", "index": true },
-        { "name": "lpAmountBefore", "type": "u64", "index": false },
-        { "name": "token0VaultBefore", "type": "u64", "index": false },
-        { "name": "token1VaultBefore", "type": "u64", "index": false },
-        { "name": "token0Amount", "type": "u64", "index": false },
-        { "name": "token1Amount", "type": "u64", "index": false },
-        { "name": "token0TransferFee", "type": "u64", "index": false },
-        { "name": "token1TransferFee", "type": "u64", "index": false },
-        { "name": "changeType", "type": "u8", "index": false }
+      "discriminator": [
+        121,
+        163,
+        205,
+        201,
+        57,
+        218,
+        117,
+        60
       ]
     },
     {
       "name": "SwapEvent",
-      "fields": [
-        { "name": "poolId", "type": "publicKey", "index": true },
-        { "name": "inputVaultBefore", "type": "u64", "index": false },
-        { "name": "outputVaultBefore", "type": "u64", "index": false },
-        { "name": "inputAmount", "type": "u64", "index": false },
-        { "name": "outputAmount", "type": "u64", "index": false },
-        { "name": "inputTransferFee", "type": "u64", "index": false },
-        { "name": "outputTransferFee", "type": "u64", "index": false },
-        { "name": "baseInput", "type": "bool", "index": false }
+      "discriminator": [
+        64,
+        198,
+        205,
+        232,
+        38,
+        8,
+        113,
+        226
       ]
     }
   ],
   "errors": [
-    { "code": 6000, "name": "NotApproved", "msg": "Not approved" },
+    {
+      "code": 6000,
+      "name": "NotApproved",
+      "msg": "Not approved"
+    },
     {
       "code": 6001,
       "name": "InvalidOwner",
       "msg": "Input account owner is not the program address"
     },
-    { "code": 6002, "name": "EmptySupply", "msg": "Input token account empty" },
-    { "code": 6003, "name": "InvalidInput", "msg": "InvalidInput" },
+    {
+      "code": 6002,
+      "name": "EmptySupply",
+      "msg": "Input token account empty"
+    },
+    {
+      "code": 6003,
+      "name": "InvalidInput",
+      "msg": "InvalidInput"
+    },
     {
       "code": 6004,
       "name": "IncorrectLpMint",
@@ -1083,11 +2474,618 @@
       "name": "NotSupportMint",
       "msg": "Not support token_2022 mint extension"
     },
-    { "code": 6008, "name": "InvalidVault", "msg": "invaild vault" },
+    {
+      "code": 6008,
+      "name": "InvalidVault",
+      "msg": "invaild vault"
+    },
     {
       "code": 6009,
       "name": "InitLpAmountTooLess",
       "msg": "Init lp amount is too less(Because 100 amount lp will be locked)"
+    },
+    {
+      "code": 6010,
+      "name": "TransferFeeCalculateNotMatch",
+      "msg": "TransferFee calculate not match"
+    },
+    {
+      "code": 6011,
+      "name": "MathOverflow",
+      "msg": "Math overflow"
+    },
+    {
+      "code": 6012,
+      "name": "InsufficientVault",
+      "msg": "Insufficient vault"
+    },
+    {
+      "code": 6013,
+      "name": "InvalidFeeModel",
+      "msg": "Invalid fee model"
+    },
+    {
+      "code": 6014,
+      "name": "NoFeeCollect",
+      "msg": "Fee is zero"
+    }
+  ],
+  "types": [
+    {
+      "name": "AmmConfig",
+      "docs": [
+        "Holds the current owner of the factory"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "docs": [
+              "Bump to identify PDA"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "disable_create_pool",
+            "docs": [
+              "Status to control if new pool can be create"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "index",
+            "docs": [
+              "Config index"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "trade_fee_rate",
+            "docs": [
+              "The trade fee, denominated in hundredths of a bip (10^-6)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee_rate",
+            "docs": [
+              "The protocol fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "fund_fee_rate",
+            "docs": [
+              "The fund fee, denominated in hundredths of a bip (10^-6)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "create_pool_fee",
+            "docs": [
+              "Fee for create a new pool"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_owner",
+            "docs": [
+              "Address of the protocol fee owner"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "fund_owner",
+            "docs": [
+              "Address of the fund fee owner"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "creator_fee_rate",
+            "docs": [
+              "The pool creator fee, denominated in hundredths of a bip (10^-6)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                15
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CreatorFeeOn",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "BothToken"
+          },
+          {
+            "name": "OnlyToken0"
+          },
+          {
+            "name": "OnlyToken1"
+          }
+        ]
+      }
+    },
+    {
+      "name": "LpChangeEvent",
+      "docs": [
+        "Emitted when deposit and withdraw"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "lp_amount_before",
+            "type": "u64"
+          },
+          {
+            "name": "token_0_vault_before",
+            "docs": [
+              "pool vault sub trade fees"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_1_vault_before",
+            "docs": [
+              "pool vault sub trade fees"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_0_amount",
+            "docs": [
+              "calculate result without transfer fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_1_amount",
+            "docs": [
+              "calculate result without transfer fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "token_0_transfer_fee",
+            "type": "u64"
+          },
+          {
+            "name": "token_1_transfer_fee",
+            "type": "u64"
+          },
+          {
+            "name": "change_type",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Observation",
+      "docs": [
+        "The element of observations in ObservationState"
+      ],
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "block_timestamp",
+            "docs": [
+              "The block timestamp of the observation"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "cumulative_token_0_price_x32",
+            "docs": [
+              "the cumulative of token0 price during the duration time, Q32.32, the remaining 64 bit for overflow"
+            ],
+            "type": "u128"
+          },
+          {
+            "name": "cumulative_token_1_price_x32",
+            "docs": [
+              "the cumulative of token1 price during the duration time, Q32.32, the remaining 64 bit for overflow"
+            ],
+            "type": "u128"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ObservationState",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "initialized",
+            "docs": [
+              "Whether the ObservationState is initialized"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "observation_index",
+            "docs": [
+              "the most-recently updated index of the observations array"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "pool_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "observations",
+            "docs": [
+              "observation array"
+            ],
+            "type": {
+              "array": [
+                {
+                  "defined": {
+                    "name": "Observation"
+                  }
+                },
+                100
+              ]
+            }
+          },
+          {
+            "name": "last_update_timestamp",
+            "docs": [
+              "the last update timestamp"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for feature update"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                3
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Permission",
+      "docs": [
+        "Holds the current owner of the factory"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "authority"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                30
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "PoolState",
+      "serialization": "bytemuckunsafe",
+      "repr": {
+        "kind": "c",
+        "packed": true
+      },
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "amm_config",
+            "docs": [
+              "Which config the pool belongs"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pool_creator",
+            "docs": [
+              "pool creator"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_0_vault",
+            "docs": [
+              "Token A"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_1_vault",
+            "docs": [
+              "Token B"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "lp_mint",
+            "docs": [
+              "Pool tokens are issued when A or B tokens are deposited.",
+              "Pool tokens can be withdrawn back to the original A or B token."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_0_mint",
+            "docs": [
+              "Mint information for token A"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_1_mint",
+            "docs": [
+              "Mint information for token B"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_0_program",
+            "docs": [
+              "token_0 program"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "token_1_program",
+            "docs": [
+              "token_1 program"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "observation_key",
+            "docs": [
+              "observation account to store oracle data"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "auth_bump",
+            "type": "u8"
+          },
+          {
+            "name": "status",
+            "docs": [
+              "Bitwise representation of the state of the pool",
+              "bit0, 1: disable deposit(value is 1), 0: normal",
+              "bit1, 1: disable withdraw(value is 2), 0: normal",
+              "bit2, 1: disable swap(value is 4), 0: normal"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "lp_mint_decimals",
+            "type": "u8"
+          },
+          {
+            "name": "mint_0_decimals",
+            "docs": [
+              "mint0 and mint1 decimals"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "mint_1_decimals",
+            "type": "u8"
+          },
+          {
+            "name": "lp_supply",
+            "docs": [
+              "True circulating supply without burns and lock ups"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fees_token_0",
+            "docs": [
+              "The amounts of token_0 and token_1 that are owed to the liquidity provider."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fees_token_1",
+            "type": "u64"
+          },
+          {
+            "name": "fund_fees_token_0",
+            "type": "u64"
+          },
+          {
+            "name": "fund_fees_token_1",
+            "type": "u64"
+          },
+          {
+            "name": "open_time",
+            "docs": [
+              "The timestamp allowed for swap in the pool."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "recent_epoch",
+            "docs": [
+              "recent epoch"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_fee_on",
+            "docs": [
+              "Creator fee collect mode",
+              "0: both token_0 and token_1 can be used as trade fees. It depends on what the input token is when swapping",
+              "1: only token_0 as trade fee",
+              "2: only token_1 as trade fee"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "enable_creator_fee",
+            "type": "bool"
+          },
+          {
+            "name": "padding1",
+            "type": {
+              "array": [
+                "u8",
+                6
+              ]
+            }
+          },
+          {
+            "name": "creator_fees_token_0",
+            "type": "u64"
+          },
+          {
+            "name": "creator_fees_token_1",
+            "type": "u64"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future updates"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                28
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SwapEvent",
+      "docs": [
+        "Emitted when swap"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "pool_id",
+            "type": "pubkey"
+          },
+          {
+            "name": "input_vault_before",
+            "docs": [
+              "pool vault sub trade fees"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "output_vault_before",
+            "docs": [
+              "pool vault sub trade fees"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "input_amount",
+            "docs": [
+              "calculate result without transfer fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "output_amount",
+            "docs": [
+              "calculate result without transfer fee"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "input_transfer_fee",
+            "type": "u64"
+          },
+          {
+            "name": "output_transfer_fee",
+            "type": "u64"
+          },
+          {
+            "name": "base_input",
+            "type": "bool"
+          },
+          {
+            "name": "input_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "output_mint",
+            "type": "pubkey"
+          },
+          {
+            "name": "trade_fee",
+            "type": "u64"
+          },
+          {
+            "name": "creator_fee",
+            "docs": [
+              "Amount of fee tokens going to creator"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "creator_fee_on_input",
+            "type": "bool"
+          }
+        ]
+      }
     }
   ]
 }

--- a/idl/raydium_launchpad.json
+++ b/idl/raydium_launchpad.json
@@ -36,6 +36,7 @@
             "The user performing the swap operation",
             "Must sign the transaction and pay for fees"
           ],
+          "writable": true,
           "signer": true
         },
         {
@@ -225,6 +226,7 @@
             "The user performing the swap operation",
             "Must sign the transaction and pay for fees"
           ],
+          "writable": true,
           "signer": true
         },
         {
@@ -1107,6 +1109,79 @@
       "args": []
     },
     {
+      "name": "close_platform_global_access",
+      "docs": [
+        "Close a platform's permission to use a global config."
+      ],
+      "discriminator": [
+        123,
+        180,
+        184,
+        129,
+        111,
+        185,
+        187,
+        59
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "global_config"
+        },
+        {
+          "name": "platform_config"
+        },
+        {
+          "name": "platform_global_access",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  108,
+                  97,
+                  116,
+                  102,
+                  111,
+                  114,
+                  109,
+                  95,
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  97,
+                  99,
+                  99,
+                  101,
+                  115,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "platform_config"
+              },
+              {
+                "kind": "account",
+                "path": "global_config"
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "collect_fee",
       "docs": [
         "Collects accumulated fees from the pool",
@@ -1521,6 +1596,9 @@
         },
         {
           "name": "transfer_fee_extension_authority"
+        },
+        {
+          "name": "platform_vesting_wallet"
         }
       ],
       "args": [
@@ -1533,6 +1611,182 @@
           }
         }
       ]
+    },
+    {
+      "name": "create_platform_global_access",
+      "docs": [
+        "Create a platform permission to use a global config when authorization is enabled."
+      ],
+      "discriminator": [
+        162,
+        91,
+        146,
+        199,
+        93,
+        133,
+        234,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "writable": true,
+          "signer": true,
+          "address": "GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ"
+        },
+        {
+          "name": "global_config"
+        },
+        {
+          "name": "platform_config"
+        },
+        {
+          "name": "platform_global_access",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  108,
+                  97,
+                  116,
+                  102,
+                  111,
+                  114,
+                  109,
+                  95,
+                  103,
+                  108,
+                  111,
+                  98,
+                  97,
+                  108,
+                  95,
+                  97,
+                  99,
+                  99,
+                  101,
+                  115,
+                  115
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "platform_config"
+              },
+              {
+                "kind": "account",
+                "path": "global_config"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_platform_vesting_account",
+      "docs": [
+        "Create vesting account",
+        "# Arguments",
+        "",
+        "* `ctx` - The context of accounts",
+        "* `share` - The share amount of base token to be vested",
+        ""
+      ],
+      "discriminator": [
+        146,
+        71,
+        173,
+        69,
+        98,
+        19,
+        15,
+        106
+      ],
+      "accounts": [
+        {
+          "name": "platform_vesting_wallet",
+          "docs": [
+            "The account paying for the initialization costs",
+            "This can be any account with sufficient SOL to cover the transaction"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "beneficiary",
+          "docs": [
+            "The beneficiary is used to receive the allocated linear release of tokens.",
+            "Once this account is set, it cannot be modified, so please ensure the validity of this account,",
+            "otherwise, the unlocked tokens will not be claimable."
+          ],
+          "writable": true
+        },
+        {
+          "name": "platform_config",
+          "docs": [
+            "Platform config account to be changed"
+          ]
+        },
+        {
+          "name": "pool_state",
+          "docs": [
+            "The pool state account"
+          ],
+          "writable": true
+        },
+        {
+          "name": "platform_vesting_record",
+          "docs": [
+            "The vesting record account"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  111,
+                  108,
+                  95,
+                  118,
+                  101,
+                  115,
+                  116,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "pool_state"
+              },
+              {
+                "kind": "account",
+                "path": "beneficiary"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "Required for account creation"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
     },
     {
       "name": "create_vesting_account",
@@ -3650,6 +3904,7 @@
             "The user performing the swap operation",
             "Must sign the transaction and pay for fees"
           ],
+          "writable": true,
           "signer": true
         },
         {
@@ -3840,6 +4095,7 @@
             "The user performing the swap operation",
             "Must sign the transaction and pay for fees"
           ],
+          "writable": true,
           "signer": true
         },
         {
@@ -4011,6 +4267,7 @@
         "* `param` - Parameter to update:",
         "- 0: Update trade_fee_rate",
         "- 1: Update fee owner",
+        "- 12: Toggle whether explicit platform authorization is required",
         "* `value` - New value for the selected parameter",
         ""
       ],
@@ -4250,6 +4507,19 @@
       ]
     },
     {
+      "name": "PlatformGlobalAccess",
+      "discriminator": [
+        174,
+        147,
+        132,
+        240,
+        137,
+        219,
+        243,
+        16
+      ]
+    },
+    {
       "name": "PoolState",
       "discriminator": [
         247,
@@ -4435,6 +4705,21 @@
       "code": 6020,
       "name": "CurveParamIsNotExist",
       "msg": "Curve param is not exist"
+    },
+    {
+      "code": 6021,
+      "name": "InvalidTotalLockedAmount",
+      "msg": "Total locked amount must great or equal to the platform vesting share amount"
+    },
+    {
+      "code": 6022,
+      "name": "PlatformGlobalAccessDenied",
+      "msg": "Platform is not authorized to use this global config"
+    },
+    {
+      "code": 6023,
+      "name": "InvalidPlatformGlobalAccess",
+      "msg": "Invalid platform-global access account"
     }
   ],
   "types": [
@@ -4787,6 +5072,25 @@
             "type": "pubkey"
           },
           {
+            "name": "requires_platform_auth",
+            "docs": [
+              "Whether a platform must be explicitly authorized before using this global config"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "padding_alignment",
+            "docs": [
+              "padding alignment"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                7
+              ]
+            }
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for future updates"
@@ -4794,7 +5098,7 @@
             "type": {
               "array": [
                 "u64",
-                16
+                15
               ]
             }
           }
@@ -4996,6 +5300,22 @@
             "type": "pubkey"
           },
           {
+            "name": "platform_vesting_wallet",
+            "type": "pubkey"
+          },
+          {
+            "name": "platform_vesting_scale",
+            "type": "u64"
+          },
+          {
+            "name": "platform_cp_creator",
+            "docs": [
+              "If a valid platform_cp_creator is configured for the platform,",
+              "it will be used as the creator for the AMM pool during migration to cpswap pool."
+            ],
+            "type": "pubkey"
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for future updates"
@@ -5003,7 +5323,7 @@
             "type": {
               "array": [
                 "u8",
-                180
+                108
               ]
             }
           },
@@ -5067,6 +5387,14 @@
           {
             "name": "creator_fee_rate",
             "type": "u64"
+          },
+          {
+            "name": "platform_vesting_scale",
+            "type": "u64"
+          },
+          {
+            "name": "vesting_wallet",
+            "type": "pubkey"
           }
         ]
       }
@@ -5134,6 +5462,24 @@
                 }
               }
             ]
+          },
+          {
+            "name": "VestingWallet",
+            "fields": [
+              "pubkey"
+            ]
+          },
+          {
+            "name": "PlatformVestingScale",
+            "fields": [
+              "u64"
+            ]
+          },
+          {
+            "name": "PlatformCPCreator",
+            "fields": [
+              "pubkey"
+            ]
           }
         ]
       }
@@ -5191,6 +5537,38 @@
       }
     },
     {
+      "name": "PlatformGlobalAccess",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "global_config",
+            "type": "pubkey"
+          },
+          {
+            "name": "platform_config",
+            "type": "pubkey"
+          },
+          {
+            "name": "padding",
+            "docs": [
+              "padding for future updates"
+            ],
+            "type": {
+              "array": [
+                "u64",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "PlatformParams",
       "docs": [
         "Represents the parameters for initializing a platform config account",
@@ -5231,6 +5609,10 @@
           },
           {
             "name": "creator_fee_rate",
+            "type": "u64"
+          },
+          {
+            "name": "platform_vesting_scale",
             "type": "u64"
           }
         ]
@@ -5509,6 +5891,13 @@
             }
           },
           {
+            "name": "platform_vesting_share",
+            "docs": [
+              "platform vesting token amount"
+            ],
+            "type": "u64"
+          },
+          {
             "name": "padding",
             "docs": [
               "padding for future updates"
@@ -5516,7 +5905,7 @@
             "type": {
               "array": [
                 "u8",
-                62
+                54
               ]
             }
           }


### PR DESCRIPTION
## Summary
- sync current official Pump, Raydium, Meteora, and Orca IDLs used by the trading SDK
- add the current Raydium CLMM IDL
- retain explicitly versioned historical IDLs as compatibility snapshots
- document official upstream sources and canonical SHA-256 hashes
- keep Raydium AMM V4 compatibility references because the program has no maintained Anchor IDL

## Validation
- canonical JSON hashes match the official protocol repositories or package artifacts
- all IDL JSON files parse with jq
- cargo test: 191 passed, 2 ignored
- git diff --check