### PR TITLE
release: prepare sol-trade-sdk 5.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sol-trade-sdk"
-version = "5.0.0"
+version = "5.0.1"
 edition = "2021"
 authors = [
     "William <byteblock6@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ This SDK is available in multiple languages:
 
 ## 🔖 Current Release
 
-**Rust crate:** `sol-trade-sdk = "4.0.23"`
+**Rust crate:** `sol-trade-sdk = "5.0.1"`
 
-This release updates PumpSwap for the July 2026 virtual quote reserve rollout. Pool and event schemas include `virtual_quote_reserves`, and all PumpSwap buy, sell, pricing, and dynamic-fee calculations use `quote_vault_balance + virtual_quote_reserves`.
+This release synchronizes the current official Meteora, Raydium, and Orca program IDLs used by the trading SDK. Explicitly versioned historical IDLs remain available as compatibility snapshots, and Raydium AMM V4 continues to use its source-defined instruction layout because it is not an Anchor program.
 
 ## ✨ Features
 
@@ -134,14 +134,14 @@ Add the dependency to your `Cargo.toml`:
 
 ```toml
 # Add to your Cargo.toml
-sol-trade-sdk = { path = "./sol-trade-sdk", version = "4.0.23" }
+sol-trade-sdk = { path = "./sol-trade-sdk", version = "5.0.1" }
 ```
 
 ### Use crates.io
 
 ```toml
 # Add to your Cargo.toml
-sol-trade-sdk = "4.0.23"
+sol-trade-sdk = "5.0.1"
 ```
 
 ## 🛠️ Usage Examples

--- a/README_CN.md
+++ b/README_CN.md
@@ -88,9 +88,9 @@
 
 ## 🔖 当前版本
 
-**Rust crate:** `sol-trade-sdk = "4.0.23"`
+**Rust crate:** `sol-trade-sdk = "5.0.1"`
 
-本版本适配 PumpSwap 2026 年 7 月的虚拟 quote 储备升级。Pool 与事件 schema 新增 `virtual_quote_reserves`，PumpSwap 买入、卖出、报价和动态费率计算统一使用 `quote_vault_balance + virtual_quote_reserves`。
+本版本同步交易 SDK 使用的最新 Meteora、Raydium 和 Orca 官方程序 IDL。带明确版本号的历史 IDL 继续作为兼容快照保留；Raydium AMM V4 不是 Anchor 程序，因此继续以官方源码定义的指令布局为准。
 
 ## ✨ 项目特性
 
@@ -134,14 +134,14 @@ git clone https://github.com/0xfnzero/sol-trade-sdk
 
 ```toml
 # 添加到您的 Cargo.toml
-sol-trade-sdk = { path = "./sol-trade-sdk", version = "4.0.23" }
+sol-trade-sdk = { path = "./sol-trade-sdk", version = "5.0.1" }
 ```
 
 ### 使用 crates.io
 
 ```toml
 # 添加到您的 Cargo.toml
-sol-trade-sdk = "4.0.23"
+sol-trade-sdk = "5.0.1"
 ```
 
 ## 🛠️ 使用示例


### PR DESCRIPTION
## Summary
- bump the crate version to 5.0.1
- update the English and Chinese installation examples from the stale 4.0.23 reference
- document the current official Meteora, Raydium, and Orca IDL synchronization
- clarify that explicitly versioned IDLs remain compatibility snapshots and Raydium AMM V4 follows its source-defined non-Anchor layout

## Included IDL updates
The official IDL synchronization was merged in #115. This release packages those current program definitions for crates.io consumers under a neutral release branch name.

## Validation
- cargo test --locked: 191 passed, 2 ignored
- doctests: 2 ignored by the existing test configuration
- cargo publish --dry-run --allow-dirty: package verification passed
- git diff --check